### PR TITLE
Fix ambiguous Go shortcuts by removing duplicate QAction bindings

### DIFF
--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -599,13 +599,9 @@ class TitleBar(Widget):
         self.goToolBtn = TitleBarToolBtn(self)
         self.goToolBtn.setText(self.tr('Go'))
         prevPageAction = QAction(self.tr('Previous Page'), self)
-        prevPageAction.setShortcut(QKeySequence.fromString(get_shortcut("go.prev_page", getattr(pcfg, "shortcuts", None))))
         nextPageAction = QAction(self.tr('Next Page'), self)
-        nextPageAction.setShortcut(QKeySequence.fromString(get_shortcut("go.next_page", getattr(pcfg, "shortcuts", None))))
         prevPageAltAction = QAction(self.tr('Previous Page (alternate)'), self)
-        prevPageAltAction.setShortcut(QKeySequence.fromString(get_shortcut("go.prev_page_alt", getattr(pcfg, "shortcuts", None))))
         nextPageAltAction = QAction(self.tr('Next Page (alternate)'), self)
-        nextPageAltAction.setShortcut(QKeySequence.fromString(get_shortcut("go.next_page_alt", getattr(pcfg, "shortcuts", None))))
         goMenu = QMenu(self.goToolBtn)
         goMenu.addActions([prevPageAction, nextPageAction])
         goMenu.addSeparator()
@@ -616,12 +612,6 @@ class TitleBar(Widget):
         self.nextpage_trigger = nextPageAction.triggered
         prevPageAltAction.triggered.connect(self.prevpage_trigger)
         nextPageAltAction.triggered.connect(self.nextpage_trigger)
-        self._shortcut_actions_title.extend([
-            ("go.prev_page", "PageUp", prevPageAction),
-            ("go.next_page", "PageDown", nextPageAction),
-            ("go.prev_page_alt", "A", prevPageAltAction),
-            ("go.next_page_alt", "D", nextPageAltAction),
-        ])
 
         # Tools menu
         self.toolsToolBtn = TitleBarToolBtn(self)


### PR DESCRIPTION
### Motivation
- Qt emitted `QAction::event: Ambiguous shortcut overload` warnings (e.g. `PgDown`, `PgUp`, `A`, `D`) due to duplicate keyboard bindings for page navigation being registered in both `TitleBar` and `MainWindow`.
- The change centralizes keyboard handling to avoid duplicate registrations while preserving existing menu-trigger behavior.

### Description
- Removed direct `QAction.setShortcut(...)` assignments for Go menu actions in `ui/mainwindowbars.py` so those menu actions no longer register their own shortcuts.
- Removed the Go actions from the `TitleBar` `_shortcut_actions_title` list so `TitleBar.apply_shortcuts()` no longer re-applies those bindings.
- Left the menu `triggered` signals (`prevpage_trigger` / `nextpage_trigger`) and their connections intact so menu clicks still navigate pages and keyboard navigation remains handled by `MainWindow` `QShortcut` bindings.

### Testing
- Ran `python -m compileall -f -q ui/mainwindowbars.py ui/mainwindow.py` and compilation succeeded.
- Verified shortcut identifiers with `rg -n "go\.prev_page|go\.next_page|go\.prev_page_alt|go\.next_page_alt"` and confirmed only the `MainWindow` shortcut registrations remain alongside the `utils/shortcuts.py` defaults.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f12d5149b8832c9947b764763a2c36)