### PR TITLE
Add LLM review mode to Chain translator and update README for Pro fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # BallonsTranslator-Pro
 
-BallonsTranslator-Pro is a desktop app that helps you translate manga/comic pages with an assisted workflow:
+BallonsTranslator-Pro is an advanced fork of [dmMaze/BallonsTranslator](https://github.com/dmMaze/BallonsTranslator), keeping the same assisted manga/comic translation pipeline while adding production-focused module options and quality-of-life workflow improvements for power users.
+
+<img src="https://raw.githubusercontent.com/dmMaze/BallonsTranslator/master/doc/src/ui0.jpg" align="center">
+
+BallonsTranslator-Pro helps you translate manga/comic pages with an assisted workflow:
 
 1. Detect speech balloons/text areas
 2. Read text (OCR)
@@ -14,6 +18,15 @@ This fork focuses on practical, real-world comic workflows and gives you multipl
 - Full change history: [docs/CHANGELOG.md](docs/CHANGELOG.md)
 
 ---
+
+## What this fork keeps from base (and what it extends)
+
+From the base project, Pro preserves the core five-stage pipeline (detect → OCR → translate → inpaint → edit/export) and WYSIWYG editing workflow.
+
+The Pro fork focuses on:
+- broader translator/model choices (including chainable and LLM-based translators),
+- practical configuration for real chapter workflows,
+- documentation for tuning quality/speed tradeoffs.
 
 ## Who this is for
 
@@ -76,6 +89,19 @@ Default baseline after successful setup:
 5. **Export results**: Tools → Export all pages
 
 That’s enough to complete most projects.
+
+### New: 2-step translation validation (Feature #55)
+
+You can now run a two-step translation flow with online MT + LLM review/correction:
+
+1. Set **Translator** to `Chain`
+2. In Chain settings:
+   - `chain_translators`: `google,LLM_API_Translator` (or `DeepL,LLM_API_Translator`)
+   - `chain_intermediate_langs`: `English`
+   - leave `chain_llm_review_mode` enabled
+3. Configure your `LLM_API_Translator` provider/model normally
+
+When enabled, the final LLM step receives both original source text and the first-pass draft so it can validate and refine wording, tone, and consistency before final output.
 
 ---
 

--- a/modules/translators/trans_chain.py
+++ b/modules/translators/trans_chain.py
@@ -23,6 +23,16 @@ class TransChain(BaseTranslator):
             'value': 'English',
             'description': 'Comma-separated intermediate language(s). Must be n-1 for n translators (e.g. one for 2-step chain).',
         },
+        'chain_llm_review_mode': {
+            'type': 'checkbox',
+            'value': True,
+            'description': 'When the final step is LLM_API_Translator, pass both original text and first-step draft so the LLM can review/correct it (2-step translation validation).',
+        },
+        'chain_llm_review_instruction': {
+            'type': 'editor',
+            'value': 'Improve the draft translation using the source text. Keep meaning accurate, natural, and concise; preserve names and terms consistently.',
+            'description': 'Instruction prepended when chain_llm_review_mode is enabled.',
+        },
         'description': 'Run multiple translators in sequence. Set chain_translators (e.g. google,trans_llm_api) and chain_intermediate_langs (e.g. English).',
     }
 
@@ -45,6 +55,25 @@ class TransChain(BaseTranslator):
         intermediate = [l.strip() for l in raw_langs.split(',') if l.strip()]
         return names, intermediate
 
+
+    def _as_bool(self, value) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return bool(value)
+        return str(value).strip().lower() in {'1', 'true', 'yes', 'on'}
+
+    def _build_llm_review_inputs(self, sources: List[str], drafts: List[str], review_instruction: str) -> List[str]:
+        payloads: List[str] = []
+        for src, draft in zip(sources, drafts):
+            payloads.append(
+                f"{review_instruction}\n\n"
+                f"[Source Text]\n{src}\n\n"
+                f"[Draft Translation]\n{draft}\n\n"
+                "Return only the improved final translation text."
+            )
+        return payloads
+
     def _translate(self, src_list: List[str]) -> List[str]:
         names, intermediate_langs = self._get_chain_config()
         if not names:
@@ -61,6 +90,7 @@ class TransChain(BaseTranslator):
 
         exclude = {'Chain', 'None', 'Copy Source', 'Ensemble (3+1)', 'Chimera (multi-source)'}
         current = list(src_list)
+        original_sources = list(src_list)
         for i, tname in enumerate(names):
             if tname in exclude:
                 continue
@@ -104,8 +134,18 @@ class TransChain(BaseTranslator):
                         setattr(trans, attr, getattr(self, attr))
                     except Exception:
                         pass
+            step_inputs = current
+            if (
+                i == len(names) - 1
+                and tname == 'LLM_API_Translator'
+                and self._as_bool(self.get_param_value('chain_llm_review_mode'))
+                and len(original_sources) == len(current)
+            ):
+                review_instruction = (self.get_param_value('chain_llm_review_instruction') or '').strip()
+                if review_instruction:
+                    step_inputs = self._build_llm_review_inputs(original_sources, current, review_instruction)
             try:
-                current = trans.translate(current)
+                current = trans.translate(step_inputs)
             except Exception as e:
                 self.logger.error(f"Chain: step '{tname}' failed: {e}")
                 break


### PR DESCRIPTION
### Motivation

- Introduce a production-focused Pro fork README and documentation for power-user workflows and model choices.
- Enable a two-step translation validation flow where an LLM can review and refine a first-pass machine translation to improve wording and consistency.

### Description

- Expanded `README.md` to describe the Pro fork, include an inline screenshot, and add a new section explaining the 2-step translation validation feature.
- Added `chain_llm_review_mode` and `chain_llm_review_instruction` params to the `Chain` translator in `modules/translators/trans_chain.py` to let the final `LLM_API_Translator` receive both source text and the first-pass draft for review.
- Implemented helper methods `_as_bool` and `_build_llm_review_inputs` and updated `_translate` to construct and pass combined review payloads to the final LLM step when enabled while preserving existing context and parameter flattening logic.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f297bafaec832cae802c6c7d87da9a)