### PR TITLE
Add LLM top-k sampling control and track 20 upstream feature requests

### DIFF
--- a/docs/upstream_feature_backlog.md
+++ b/docs/upstream_feature_backlog.md
@@ -1,0 +1,28 @@
+# Upstream Feature Backlog Supplement Plan (BallonsTranslator-Pro)
+
+Generated: 2026-04-30
+
+This document tracks **20 open upstream feature requests** and a proposed Pro-side supplement path.
+
+| Upstream Issue | Request | Pro status | Supplement implementation path |
+|---|---|---|---|
+| [#1171](https://github.com/dmMaze/BallonsTranslator/issues/1171) | Feature Request: Add support for FLUX.2-klein-4B inpainting | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1169](https://github.com/dmMaze/BallonsTranslator/issues/1169) | Feature Request: Font size based on block size | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1168](https://github.com/dmMaze/BallonsTranslator/issues/1168) | 添加了字体集功能并尝试修复了“仅识别fonts内字体” | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1166](https://github.com/dmMaze/BallonsTranslator/issues/1166) | PaddleOCR无论如何都安装不上，即使我安装CPU版本，也会显示不出来 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1164](https://github.com/dmMaze/BallonsTranslator/issues/1164) | Feature Request: add parameter top k on ChatGpt/llm_api translator | Partially implemented (this patch adds top-k in LLM_API_Translator) | Implemented sampling control: configurable `top k` in LLM_API_Translator. |
+| [#1162](https://github.com/dmMaze/BallonsTranslator/issues/1162) | Feature Request:可否改进Intel GPU launch脚本 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1151](https://github.com/dmMaze/BallonsTranslator/issues/1151) | Feature Request: Propose BallonsTranslator-Pro as experimental branch | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1150](https://github.com/dmMaze/BallonsTranslator/issues/1150) | Feature Request: Add community fork (BallonsTranslator-Pro) to README | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1142](https://github.com/dmMaze/BallonsTranslator/issues/1142) | Feature Request:Local VLM and more context for better translation | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1141](https://github.com/dmMaze/BallonsTranslator/issues/1141) | Feature Request:Support of the acbf format, the cbz multilangual | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1138](https://github.com/dmMaze/BallonsTranslator/issues/1138) | Feature Request: adding “Text on Path" | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1131](https://github.com/dmMaze/BallonsTranslator/issues/1131) | 用vl视觉模型代替文字识别和OCR | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1123](https://github.com/dmMaze/BallonsTranslator/issues/1123) | DeepL - Vietnamese Translation | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1121](https://github.com/dmMaze/BallonsTranslator/issues/1121) | Feature Request: Open Import Translation From.... default change | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1118](https://github.com/dmMaze/BallonsTranslator/issues/1118) | Feature Request: 仅运行本页 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1117](https://github.com/dmMaze/BallonsTranslator/issues/1117) | 关于智能修图的问题 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1114](https://github.com/dmMaze/BallonsTranslator/issues/1114) | 能否添加特殊字体艺术字之类的 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1111](https://github.com/dmMaze/BallonsTranslator/issues/1111) | Feature Request:是否可以增加同時一次性處理多個圖片的功能 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1107](https://github.com/dmMaze/BallonsTranslator/issues/1107) | Feature Request:尊敬的dmMaze你好，和各位ballonstranslator的贡献者 | Not implemented | Backlog: design + staged implementation in Pro |
+| [#1106](https://github.com/dmMaze/BallonsTranslator/issues/1106) | 怎么claude翻译没了 | Not implemented | Backlog: design + staged implementation in Pro |

--- a/modules/translators/trans_llm_api.py
+++ b/modules/translators/trans_llm_api.py
@@ -281,6 +281,10 @@ class LLM_API_Translator(BaseTranslator):
             "value": 1.0,
             "description": "Top P for sampling.",
         },
+        "top k": {
+            "value": 0,
+            "description": "Top K for sampling. 0 disables/lets provider default. Supported by OpenRouter, Ollama, and many local OpenAI-compatible servers.",
+        },
         "retry attempts": {
             "value": 3,
             "description": "Number of retry attempts on API connection or parsing failures.",
@@ -1000,6 +1004,12 @@ class LLM_API_Translator(BaseTranslator):
         if provider == "OpenAI":
             cfg["frequency_penalty"] = self.frequency_penalty
             cfg["presence_penalty"] = self.presence_penalty
+        if int(self.top_k or 0) > 0 and provider in {"OpenRouter", "Ollama", "LLM Studio", "Grok"}:
+            extra = cfg.get("extra_body")
+            if not isinstance(extra, dict):
+                extra = {}
+            extra["top_k"] = int(self.top_k)
+            cfg["extra_body"] = extra
         # Do not set max_tokens here.
         # _request_translation() already computes a tighter per-request cap via
         # _translation_completion_max_tokens(provider, expected_count). Overriding it
@@ -1101,6 +1111,10 @@ class LLM_API_Translator(BaseTranslator):
     @property
     def top_p(self) -> float:
         return float(self.get_param_value("top p"))
+
+    @property
+    def top_k(self) -> int:
+        return int(self.get_param_value("top k") or 0)
 
     @property
     def max_tokens(self) -> int:


### PR DESCRIPTION
### Motivation
- Add a user-configurable sampling control requested by upstream issue #1164 so LLM-style translators can limit sampling to top-k candidates when supported by the provider. 
- Create a concise backlog of high-impact upstream feature requests to guide BallonsTranslator‑Pro incremental work and prioritization.

### Description
- Add a new `"top k"` parameter to `LLM_API_Translator` params with default `0` and a short description indicating `0` disables/lets provider default. 
- Expose a `top_k` property and wire it into `_build_generation_config` so that when `top_k > 0` and the provider is one of `{"OpenRouter", "Ollama", "LLM Studio", "Grok"}`, the translator adds `extra_body.top_k` to the provider API args. 
- Keep existing defaults and provider behavior unchanged when `top_k == 0`. 
- Add `docs/upstream_feature_backlog.md` that lists 20 open upstream feature requests and a proposed Pro-side supplement/implementation path to serve as an implementation queue.

### Testing
- Ran compilation and static checks with `python -m compileall -f -q modules/translators/trans_llm_api.py docs/upstream_feature_backlog.md` which completed for the modified files. 
- Verified the new symbols via grep: `rg -n '"top k"|def top_k|extra\["top_k"\]' modules/translators/trans_llm_api.py` which shows the new param, accessor, and injection into `extra_body`. 
- Attempted a runtime import/test that reads `LLM_API_Translator.params`, but it was blocked by an environment dependency when importing OpenCV (`cv2`), producing `ImportError: libGL.so.1: cannot open shared object file`, so a full runtime smoke test was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2a14537d4832cbca5785b31d51910)