### PR TITLE
Respect setup-selected Python mode in Windows launcher

### DIFF
--- a/Launch BallonsTranslator.bat
+++ b/Launch BallonsTranslator.bat
@@ -122,26 +122,8 @@ call "%~dp0launch_win_amd_nightly.bat"
 goto :end
 
 :direct_launch
-if exist "venv\Scripts\python.exe" (
-    "venv\Scripts\python.exe" launch.py %*
-    set "ERR=%ERRORLEVEL%"
-    if not "%ERR%"=="0" (
-        echo.
-        echo launch.py exited with code %ERR%
-        pause
-    )
-    goto :finish
-)
-
-echo.
-echo [BallonsTranslator] No venv found at: %~dp0venv
-echo Create it, then install deps:
-echo   py -3.10 -m venv venv
-echo   venv\Scripts\python.exe -m pip install -r requirements.txt
-echo   Optional: GPU PyTorch ^(see README or run launch.py --reinstall-torch^)
-echo.
-pause
-set "ERR=1"
+call "%~dp0launch_win.bat" %*
+set "ERR=%ERRORLEVEL%"
 goto :finish
 
 :finish

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ On first launch, base requirements are installed automatically if needed.
 ## Option B: Windows helper scripts
 
 - `setup.bat`: one-time setup
-- `Launch BallonsTranslator.bat`: run with local repo virtual environment
+- `Launch BallonsTranslator.bat`: run with the Python mode selected in `setup.bat` (system Python or local `venv`, with automatic fallback)
 - `launch_win.bat` / `launch_win_with_autoupdate.bat` / `launch_win_amd_nightly.bat`: for portable bundle layouts
 
 If you are unsure, start with **`python launch.py`**.

--- a/launch_win.bat
+++ b/launch_win.bat
@@ -9,7 +9,24 @@ if exist "%PADDLE_PATH%" set "PATH=%PADDLE_PATH%;%PATH%"
 
 :: Prefer existing project venv, then bundled portable python, then system Python launcher/python.
 set "PYTHON="
-if exist "venv\Scripts\python.exe" set "PYTHON=venv\Scripts\python.exe"
+set "PY_MODE_FILE=.bt_python_mode"
+set "PY_MODE="
+if exist "%PY_MODE_FILE%" (
+    set /p PY_MODE=<"%PY_MODE_FILE%"
+)
+if /I "%PY_MODE%"=="venv" (
+    if exist "venv\Scripts\python.exe" set "PYTHON=venv\Scripts\python.exe"
+)
+if /I "%PY_MODE%"=="system" (
+    py -3 -c "" >NUL 2>NUL
+    if %ERRORLEVEL% == 0 set "PYTHON=py -3"
+    if not defined PYTHON (
+        python -c "" >NUL 2>NUL
+        if %ERRORLEVEL% == 0 set "PYTHON=python"
+    )
+)
+
+if not defined PYTHON if exist "venv\Scripts\python.exe" set "PYTHON=venv\Scripts\python.exe"
 if not defined PYTHON if exist "ballontrans_pylibs_win\python.exe" set "PYTHON=ballontrans_pylibs_win\python.exe"
 if not defined PYTHON (
     py -3 -c "" >NUL 2>NUL

--- a/setup.bat
+++ b/setup.bat
@@ -4,6 +4,7 @@ REM Installs dependencies. PyTorch is auto-installed on first "python launch.py"
 
 setlocal
 cd /d "%~dp0"
+set "PY_MODE_FILE=.bt_python_mode"
 
 echo BallonsTranslator setup (Windows)
 echo.
@@ -39,6 +40,7 @@ if not defined PYTHON (
     exit /b 1
 )
 echo Using system interpreter: %PYTHON%
+> "%PY_MODE_FILE%" echo system
 goto :install
 
 :setup_venv
@@ -56,6 +58,7 @@ if not exist "venv\Scripts\python.exe" (
 )
 set "PYTHON=venv\Scripts\python.exe"
 echo Using venv interpreter: %PYTHON%
+> "%PY_MODE_FILE%" echo venv
 goto :install
 
 :install


### PR DESCRIPTION
### Motivation
- Allow the Windows launcher to use the Python interpreter mode the user chose during `setup.bat` (system Python or project `venv`) instead of forcing the repo `venv` on direct launch.

### Description
- Persist the chosen mode from `setup.bat` into a small marker file `.bt_python_mode` (`system` or `venv`).
- Update `launch_win.bat` to read `.bt_python_mode` and prioritize the selected interpreter mode before falling back to the previous auto-detection logic.
- Make `Launch BallonsTranslator.bat` delegate direct launches to `launch_win.bat` so argument-based launches respect the setup-selected mode.
- Update `README.md` text to document that `Launch BallonsTranslator.bat` uses the Python mode selected in `setup.bat` with automatic fallback.

### Testing
- Ran `python -m compileall -f -q launch.py` and it completed successfully.
- Attempted a shell syntax check for `setup.bat` in this Linux environment, but Windows `.bat` validation is not meaningful here (Windows runtime smoke checks should be run on Windows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2b4a07dbc832ca2c636f3d021f308)