### PR TITLE
Default first-launch UI to dark mode and add launcher alias

### DIFF
--- a/ballonstranslator.bat
+++ b/ballonstranslator.bat
@@ -1,0 +1,3 @@
+@echo off
+REM Compatibility launcher alias for users typing ballonstranslator.bat.
+call "%~dp0Launch BallonsTranslator.bat" %*

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -212,7 +212,7 @@
   "gsearch_whole_word": false,
   "gsearch_regex": false,
   "gsearch_range": 0,
-  "darkmode": false,
+  "darkmode": true,
   "bubbly_ui": true,
   "accent_color_hex": "",
   "app_font_family": "",

--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -29,6 +29,24 @@ PACKAGE_TIERS = getattr(_model_packages, "PACKAGE_TIERS", {})
 DEFAULT_MODEL_PACKAGE_PRESET_ID = getattr(_model_packages, "DEFAULT_MODEL_PACKAGE_PRESET_ID", next(iter(MODEL_PACKAGE_PRESETS)))
 get_package_ids_for_preset = getattr(_model_packages, "get_package_ids_for_preset", lambda pid: ["core"] if pid == "core" else [])
 
+def _dark_first_launch_stylesheet() -> str:
+    """Keep first-launch model selection readable even before global theme is applied."""
+    return """
+QDialog { background-color: #21252b; color: #e6e6e6; }
+QLabel { color: #e6e6e6; }
+QGroupBox { border: 1px solid #3b3f4c; border-radius: 8px; margin-top: 12px; padding-top: 8px; color: #f0f0f0; }
+QGroupBox::title { subcontrol-origin: margin; left: 10px; padding: 0 4px; }
+QCheckBox, QRadioButton { color: #e6e6e6; }
+QPushButton {
+    background-color: #2f3440;
+    color: #f2f2f2;
+    border: 1px solid #4a5060;
+    border-radius: 6px;
+    padding: 6px 12px;
+}
+QPushButton:hover { background-color: #3a404d; }
+QPushButton:pressed { background-color: #2a2f39; }
+"""
 
 class ModelPackageSelectorDialog(QDialog):
     """Let the user choose which model packages to download at first launch."""
@@ -46,6 +64,7 @@ class ModelPackageSelectorDialog(QDialog):
         self._result = ["core"]
         self._result_preset_ids = []
         self._build_ui()
+        self.setStyleSheet(_dark_first_launch_stylesheet())
 
     def _build_ui(self):
         layout = QVBoxLayout(self)
@@ -83,7 +102,7 @@ class ModelPackageSelectorDialog(QDialog):
             details_label = QLabel(details)
             details_label.setWordWrap(True)
             if hasattr(details_label, "setStyleSheet"):
-                details_label.setStyleSheet("color: #666; margin-left: 22px;")
+                details_label.setStyleSheet("color: #b8becd; margin-left: 22px;")
             presets_layout.addWidget(details_label)
 
         default_rb = self._preset_radios.get(DEFAULT_MODEL_PACKAGE_PRESET_ID)

--- a/utils/config.py
+++ b/utils/config.py
@@ -444,7 +444,7 @@ class ProgramConfig(Config):
     gsearch_whole_word: bool = False
     gsearch_regex: bool = False
     gsearch_range: int = 0
-    darkmode: bool = False
+    darkmode: bool = True
     bubbly_ui: bool = True
     accent_color_hex: str = ''  # Theme customizer: e.g. #1E93E5 (blue) or #9B59B6 (purple). Empty = use theme default.
     app_font_family: str = ''   # Theme customizer: app-wide font. Empty = system default.


### PR DESCRIPTION
### Motivation
- Ensure the first-launch "Choose models to download" dialog uses a dark appearance even before global theming is applied to avoid an overly bright experience.
- Make new installations default to dark mode so the initial UI matches the dark stylesheet and reduce surprising theme flips on first run.
- Provide a small compatibility launcher alias so calling `ballonstranslator.bat` forwards to the existing `Launch BallonsTranslator.bat` file.

### Description
- Set the runtime default `darkmode` to `True` in `ProgramConfig` (`utils/config.py`) and updated `config/config.example.json` to match this default.
- Added `_dark_first_launch_stylesheet()` and applied it to the first-launch model package selector dialog in `ui/model_package_selector_dialog.py` to force a cohesive dark look before global theme initialization, and adjusted preset detail text color for readability.
- Added `ballonstranslator.bat` which forwards to `Launch BallonsTranslator.bat` as a compatibility alias for users invoking the simpler filename.

### Testing
- Ran `python -m compileall -f -q ui/model_package_selector_dialog.py utils/config.py` and the modified Python files compiled successfully with no syntax errors.
- Performed local repository checks to ensure only the intended files were modified (changes include `ui/model_package_selector_dialog.py`, `utils/config.py`, `config/config.example.json`, and new `ballonstranslator.bat`).
- Windows batch runtime behavior for `Launch BallonsTranslator.bat` / `ballonstranslator.bat` could not be executed in this Linux-based environment, so batch execution should be validated on Windows during QA.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2b6752318832c8df6a4cbe06cc8cf)