### PR TITLE
Fix startup health overlay crash when APP_VERSION is missing

### DIFF
--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -1847,7 +1847,7 @@ class MainWindow(mainwindow_cls):
         from qtpy import API, QT_VERSION
         from utils.logger import NoisyThirdPartyFilter
         lines = [
-            f"Version: {shared.APP_VERSION}",
+            f"Version: {(QApplication.instance().applicationVersion() or 'unknown') if QApplication.instance() else 'unknown'}",
             f"Qt API: {API}",
             f"Qt Version: {QT_VERSION}",
             f"Python: {sys.version.splitlines()[0]}",


### PR DESCRIPTION
### Motivation
- Prevent an `AttributeError` during startup diagnostics when `utils.shared.APP_VERSION` is not defined, which caused the health overlay to crash.

### Description
- Replace `shared.APP_VERSION` with a safe lookup of the Qt application version via `QApplication.instance().applicationVersion()` with a fallback to `'unknown'` in `ui/mainwindow.py` to avoid the missing-attribute crash.

### Testing
- Ran `python -m compileall -f -q ui/mainwindow.py` which succeeded; the file compiles. 
- Attempted a Qt runtime smoke check snippet but it could not run in this environment due to a missing system library (`libGL.so.1`), so runtime verification is environment-blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2ce7e47d0832c91922683a13e3c84)