### PR TITLE
Fix translation line-count mismatches, Omni search index handling, and noisy error tracebacks

### DIFF
--- a/modules/translators/trans_google.py
+++ b/modules/translators/trans_google.py
@@ -130,7 +130,7 @@ class GoogleTranslateProviderPython:
 @register_translator("google")
 class TransGoogle(BaseTranslator):
 
-    concate_text = True
+    concate_text = False
     params: Dict = {
         "api_key": {
             "value": "",

--- a/tests/translators/test_base_translator_batch_modes.py
+++ b/tests/translators/test_base_translator_batch_modes.py
@@ -86,9 +86,9 @@ def test_translate_list_uses_per_item_path_when_translate_by_textblock_is_true()
     assert translator.calls[0] == src
 
 
-def test_google_translator_keeps_batch_concatenation_capability_by_default():
-    # Class-level defaults should continue enabling concatenation for Google provider path.
-    assert TransGoogle.concate_text is True
+def test_google_translator_uses_per_item_translation_by_default():
+    # Google responses can rewrite delimiter markers, so default to per-item translation for stable block counts.
+    assert TransGoogle.concate_text is False
     assert TransGoogle.translate_by_textblock is False
 
 

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -1164,7 +1164,13 @@ class TitleBar(Widget):
         try:
             if not proxy_index or not proxy_index.isValid():
                 return
-            src_index = self._omni_proxy.mapToSource(proxy_index)
+            # Depending on completer internals, activation can provide either proxy or source indexes.
+            if proxy_index.model() is self._omni_proxy:
+                src_index = self._omni_proxy.mapToSource(proxy_index)
+            elif proxy_index.model() is self._omni_model:
+                src_index = proxy_index
+            else:
+                return
             item = self._omni_model.itemFromIndex(src_index) if src_index.isValid() else None
             payload = item.data(Qt.ItemDataRole.UserRole) if item is not None else None
             if not isinstance(payload, dict):

--- a/utils/message.py
+++ b/utils/message.py
@@ -13,7 +13,11 @@ def create_error_dialog(exception: Exception, error_msg: str = None, exception_t
         exception_type: Specify it to avoid errors dialog of the same type popup repeatedly 
     '''
 
-    detail_traceback = traceback.format_exc()
+    # format_exc() outside an active exception block yields noisy "NoneType: None".
+    if exception is not None and getattr(exception, "__traceback__", None) is not None:
+        detail_traceback = ''.join(traceback.format_exception(type(exception), exception, exception.__traceback__))
+    else:
+        detail_traceback = ''
     
     if exception_type is None:
         exception_type = ''
@@ -27,7 +31,8 @@ def create_error_dialog(exception: Exception, error_msg: str = None, exception_t
         else:
             error_msg = str(exception) + '\n' + error_msg
         LOGGER.error(error_msg + '\n')
-        LOGGER.error(detail_traceback)
+        if detail_traceback:
+            LOGGER.error(detail_traceback)
 
         if not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
             shared.create_errdialog_in_mainthread(error_msg, detail_traceback, exception_type)


### PR DESCRIPTION
### Motivation
- Prevent repeated soft translation failures caused by provider-altered delimiters that produce inconsistent translated line counts observed in logs (`base:translate:241`).
- Stop the Qt warning `QSortFilterProxyModel: index from wrong model passed to mapToSource` when selecting Omni search completions.
- Avoid logging misleading `NoneType: None` tracebacks for merge/update errors when no active exception traceback exists.

### Description
- Change Google translator class default to per-item translation by setting `concate_text = False` to avoid delimiter corruption and broken output counts (`modules/translators/trans_google.py`).
- Harden Omni search activation to accept either a proxy index or a source index and only call `mapToSource` when appropriate to prevent wrong-model index mapping (`ui/mainwindowbars.py`).
- Make `create_error_dialog` only format and log a traceback when an exception object contains a real `__traceback__`, avoiding noisy `traceback.format_exc()` output when called outside an exception context (`utils/message.py`).
- Update unit test expectation to reflect the Google translator default change (`tests/translators/test_base_translator_batch_modes.py`).

### Testing
- Ran compilation check: `python -m compileall -f -q modules/translators/trans_google.py ui/mainwindowbars.py utils/message.py tests/translators/test_base_translator_batch_modes.py` which completed successfully.
- Ran unit tests: `pytest -q tests/translators/test_base_translator_batch_modes.py` and all tests passed (`5 passed, 1 warning`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f2d3fd5e0c832c9603dd61e175fd2d)