### PR TITLE
Compile missing .qm at startup and improve translation compiler script

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -97,6 +97,59 @@ def is_installed(package):
     return spec is not None
 
 
+def _lrelease_candidates(ts_path: str, qm_path: str):
+    return [
+        ["pyside6-lrelease", ts_path, "-qm", qm_path],
+        ["lrelease", ts_path, "-qm", qm_path],
+        ["lrelease-qt6", ts_path, "-qm", qm_path],
+        [sys.executable, "-m", "pylrelease6", ts_path, "-qm", qm_path],
+        [sys.executable, "-m", "PySide6.scripts.pyside_tool", "lrelease", ts_path, "-qm", qm_path],
+    ]
+
+
+def ensure_qm_for_display_language(lang: str, translate_dir: str, logger=None) -> bool:
+    """
+    Ensure `<translate_dir>/<lang>.qm` exists.
+    If missing and `<translate_dir>/<lang>.ts` exists, try compiling it with available lrelease tooling.
+    Returns True when qm exists (already existed or compiled), otherwise False.
+    """
+    if not lang or lang in ('en_US', 'English'):
+        return True
+
+    qm_path = osp.join(translate_dir, f"{lang}.qm")
+    if osp.exists(qm_path):
+        return True
+
+    ts_path = osp.join(translate_dir, f"{lang}.ts")
+    if not osp.exists(ts_path):
+        return False
+
+    candidates = _lrelease_candidates(ts_path, qm_path)
+
+    log = logger.info if logger is not None else print
+    log(f"Display language qm missing for {lang}; attempting to compile {ts_path}.")
+
+    for cmd in candidates:
+        try:
+            result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        except FileNotFoundError:
+            continue
+        except Exception as exc:
+            if logger is not None:
+                logger.debug("lrelease command failed: %s | err=%s", cmd, exc, exc_info=True)
+            continue
+
+        if result.returncode == 0 and osp.exists(qm_path):
+            log(f"Compiled display language qm successfully: {qm_path}")
+            return True
+        if logger is not None:
+            logger.debug(
+                "lrelease attempt failed: cmd=%s rc=%s stdout=%s stderr=%s",
+                cmd, result.returncode, (result.stdout or "").strip(), (result.stderr or "").strip()
+            )
+    return osp.exists(qm_path)
+
+
 def run(command, desc=None, errdesc=None, custom_env=None, live=False):
     if desc is not None:
         print(desc)
@@ -375,6 +428,7 @@ def main():
         shared.SCREEN_H = ps.geometry().height()
 
     lang = config.display_lang
+    ensure_qm_for_display_language(lang, shared.TRANSLATE_DIR, LOGGER)
     langp = osp.join(shared.TRANSLATE_DIR, lang + '.qm')
     if not osp.exists(langp) and lang.startswith('zh_'):
         for code in ('zh_CN', 'zh_TW'):

--- a/scripts/compile_translation.py
+++ b/scripts/compile_translation.py
@@ -7,75 +7,90 @@ Run from project root. Tries, in order:
 
 If none is found, prints where to get lrelease and exits with 1.
 """
-import os
 import os.path as osp
 import subprocess
 import sys
+from glob import glob
+
+
+def _lrelease_candidates(ts_path: str, qm_path: str):
+    return [
+        ['pyside6-lrelease', ts_path, '-qm', qm_path],
+        ['lrelease', ts_path, '-qm', qm_path],
+        ['lrelease-qt6', ts_path, '-qm', qm_path],
+        [sys.executable, '-m', 'pylrelease6', ts_path, '-qm', qm_path],
+        [sys.executable, '-m', 'PySide6.scripts.pyside_tool', 'lrelease', ts_path, '-qm', qm_path],
+    ]
+
+
+def _compile_one(root: str, ts_path: str, qm_path: str) -> bool:
+    for cmd in _lrelease_candidates(ts_path, qm_path):
+        try:
+            r = subprocess.run(
+                cmd,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+        except FileNotFoundError:
+            continue
+        except Exception as e:
+            print(f'[WARN] Compiler launch failed for {cmd}: {e}', file=sys.stderr)
+            continue
+
+        if r.returncode == 0 and osp.isfile(qm_path):
+            print(f'Compiled: {qm_path}')
+            return True
+
+        stderr = (r.stderr or '').strip()
+        if stderr:
+            print(f'[DEBUG] failed cmd: {" ".join(cmd)}', file=sys.stderr)
+            print(stderr, file=sys.stderr)
+    return False
 
 def main():
     root = osp.dirname(osp.dirname(osp.abspath(__file__)))
     trans_dir = osp.join(root, 'translate')
-    ts_path = osp.join(trans_dir, 'zh_CN.ts')
-    qm_path = osp.join(trans_dir, 'zh_CN.qm')
+    if len(sys.argv) > 1:
+        targets = []
+        for arg in sys.argv[1:]:
+            ts_path = arg if osp.isabs(arg) else osp.join(root, arg)
+            if ts_path.endswith('.qm'):
+                ts_path = ts_path[:-3] + '.ts'
+            if not ts_path.endswith('.ts'):
+                ts_path = ts_path + '.ts'
+            if osp.isfile(ts_path):
+                targets.append(ts_path)
+            else:
+                print(f'Not found: {ts_path}', file=sys.stderr)
+    else:
+        targets = sorted(glob(osp.join(trans_dir, '*.ts')))
 
-    if not osp.isfile(ts_path):
-        print(f'Not found: {ts_path}', file=sys.stderr)
+    if not targets:
+        print(f'No translation source files found in: {trans_dir}', file=sys.stderr)
         return 1
 
-    # 1) lrelease on PATH
-    for cmd in ('lrelease', 'lrelease-qt6'):
-        try:
-            r = subprocess.run(
-                [cmd, ts_path, '-qm', qm_path],
-                cwd=root,
-                capture_output=True,
-                text=True,
-                timeout=60,
-            )
-            if r.returncode == 0:
-                print(f'Compiled: {qm_path}')
-                return 0
-            if r.stderr and 'not found' not in r.stderr.lower():
-                print(r.stderr, file=sys.stderr)
-        except FileNotFoundError:
-            pass
+    ok = 0
+    fail = 0
+    for ts_path in targets:
+        qm_path = ts_path[:-3] + '.qm'
+        if _compile_one(root, ts_path, qm_path):
+            ok += 1
+        else:
+            fail += 1
+            print(f'Failed to compile: {ts_path}', file=sys.stderr)
 
-    # 2) pylrelease6
-    try:
-        r = subprocess.run(
-            [sys.executable, '-m', 'pylrelease6', ts_path, '-qm', qm_path],
-            cwd=root,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if r.returncode == 0:
-            print(f'Compiled: {qm_path}')
-            return 0
-    except Exception:
-        pass
+    if fail == 0:
+        print(f'All translations compiled successfully ({ok}/{ok}).')
+        return 0
 
-    # 3) pyside6-lrelease
-    try:
-        r = subprocess.run(
-            [sys.executable, '-m', 'PySide6.scripts.pyside_tool', 'lrelease', ts_path, '-qm', qm_path],
-            cwd=root,
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if r.returncode == 0:
-            print(f'Compiled: {qm_path}')
-            return 0
-    except Exception:
-        pass
-
-    print('Could not find lrelease / pylrelease6 / pyside6-lrelease.', file=sys.stderr)
+    print('Could not compile one or more translations. Compiler candidates tried:', file=sys.stderr)
     print('Install one of:', file=sys.stderr)
     print('  - Qt Linguist / Qt SDK (add bin/ to PATH), then run: lrelease translate/zh_CN.ts', file=sys.stderr)
     print('  - pip install pyqt6-tools  then: python -m pylrelease6 translate/zh_CN.ts -qm translate/zh_CN.qm', file=sys.stderr)
     print('  - pip install pyside6  then use pyside6-lrelease if available.', file=sys.stderr)
-    print('See docs/TRANSLATIONS.md for details.', file=sys.stderr)
+    print(f'Successful: {ok}, Failed: {fail}', file=sys.stderr)
     return 1
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Motivation
- Ensure the app can load a display language by compiling a missing `.qm` from a `.ts` source automatically at startup if possible.
- Make the translation compilation utility more robust and flexible when building `.qm` files from `.ts` files.
- Provide clearer diagnostics and support multiple compiler backends so users can build translations with whichever tooling is available.

### Description
- Added `_lrelease_candidates` and `ensure_qm_for_display_language` to `launch.py` and invoke `ensure_qm_for_display_language(config.display_lang, shared.TRANSLATE_DIR, LOGGER)` before loading the translator so missing `<lang>.qm` files are compiled from `<lang>.ts` when possible.
- Reworked `scripts/compile_translation.py` by introducing `_compile_one`, accepting explicit targets or falling back to all `*.ts` files via `glob`, increasing timeouts, and printing per-command debug output and aggregate success/failure counts.
- Unified the set of compiler candidates to try in order: `pyside6-lrelease`, `lrelease`, `lrelease-qt6`, `python -m pylrelease6`, and `python -m PySide6.scripts.pyside_tool lrelease`, and improved error handling and messages.
- Improved logging and return codes so the script reports which files compiled, which failed, and gives actionable install hints.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f36a2086b0832c8bfb46f02a2c71c7)