### PR TITLE
Fix startup UI visibility during deferred model download

### DIFF
--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -962,7 +962,9 @@ class MainWindow(mainwindow_cls):
         if getattr(shared, 'DEFER_INITIAL_MODEL_DOWNLOAD', False) and not self._initial_model_download_done:
             shared.DEFER_INITIAL_MODEL_DOWNLOAD = False
             self._initial_model_download_done = True
-            self._run_deferred_model_download()
+            # Run after the event loop gets a chance to paint the window.
+            # Calling a modal dialog directly from showEvent can keep the main UI hidden on some setups.
+            QTimer.singleShot(0, self._run_deferred_model_download)
         if not self._startup_health_shown:
             self._startup_health_shown = True
             QTimer.singleShot(250, self._show_startup_health_overlay)


### PR DESCRIPTION
### Motivation
- On some systems opening a modal model-download dialog directly in `MainWindow.showEvent` can block the window's first paint, leaving logs and downloads complete but no visible UI, so the initial deferred download should be queued after the event loop gets a chance to paint.

### Description
- Replace the direct call to `self._run_deferred_model_download()` with `QTimer.singleShot(0, self._run_deferred_model_download)` and add a clarifying comment in `ui/mainwindow.py` so the modal progress dialog is launched after the main window is shown.

### Testing
- Ran `python -m compileall -f -q ui/mainwindow.py` and `python launch.py --help`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3d1eed5ac832c8b6c25dec501a7f0)