### PR TITLE
Bundle unidic_lite data files in PyInstaller spec

### DIFF
--- a/launch.spec
+++ b/launch.spec
@@ -1,6 +1,7 @@
 # PyInstaller spec for BallonsTranslator (launch.py)
 import os
 import subprocess
+from PyInstaller.utils.hooks import collect_data_files
 
 # 获取提交哈希值
 commit_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').strip()
@@ -34,6 +35,8 @@ optional_datas = [
 
 datas = [entry for entry in base_datas if os.path.exists(entry[0])]
 datas.extend(entry for entry in optional_datas if os.path.exists(entry[0]))
+# Ensure unidic_lite dictionary assets (e.g. dicdir/version) are bundled for manga_ocr tokenizer.
+datas.extend(collect_data_files('unidic_lite'))
 
 a = Analysis([
         'launch.py',


### PR DESCRIPTION
### Motivation
- Ensure the unidic_lite tokenizer dictionary assets (e.g. `dicdir/version`) are included in the frozen application so tokenization (used by manga_ocr and related code) works after packaging.

### Description
- Import `collect_data_files` from `PyInstaller.utils.hooks` and extend `datas` with `collect_data_files('unidic_lite')`, and add a short comment explaining the addition.

### Testing
- Built the PyInstaller bundle using the updated `launch.spec` and verified that the `unidic_lite` data files were included in the generated distribution (build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3d5592634832c86c1e5c44580c69f)