### PR TITLE
Fix GPU device options missing from module/device selectors

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -302,25 +302,52 @@ import torch
 
 DEFAULT_DEVICE = 'cpu'
 AVAILABLE_DEVICES = ['cpu']
-if hasattr(torch, 'cuda') and torch.cuda.is_available():
-    DEFAULT_DEVICE = 'cuda'
-    AVAILABLE_DEVICES.append(DEFAULT_DEVICE)
-if hasattr(torch, 'xpu')  and torch.xpu.is_available():
-    DEFAULT_DEVICE = 'xpu' if torch.xpu.is_available() else 'cpu'
-    AVAILABLE_DEVICES.append(DEFAULT_DEVICE)
-if hasattr(torch, 'backends') and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-    DEFAULT_DEVICE = 'mps'
-    AVAILABLE_DEVICES.append(DEFAULT_DEVICE)
 
-try: 
+# Build a single source of truth for runtime device options shown in module/device selectors.
+def _append_unique_device(device_name: str):
+    if device_name and device_name not in AVAILABLE_DEVICES:
+        AVAILABLE_DEVICES.append(device_name)
+
+# CUDA / ROCm (both typically exposed through torch.cuda).
+try:
+    if hasattr(torch, 'cuda'):
+        cuda_count = int(torch.cuda.device_count())
+        if torch.cuda.is_available() or cuda_count > 0:
+            DEFAULT_DEVICE = 'cuda'
+            _append_unique_device('cuda')
+            for idx in range(cuda_count):
+                _append_unique_device(f'cuda:{idx}')
+except Exception:
+    pass
+
+# Intel XPU
+try:
+    if hasattr(torch, 'xpu') and torch.xpu.is_available():
+        DEFAULT_DEVICE = 'xpu'
+        _append_unique_device('xpu')
+except Exception:
+    pass
+
+# Apple Silicon MPS
+try:
+    if hasattr(torch, 'backends') and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
+        DEFAULT_DEVICE = 'mps'
+        _append_unique_device('mps')
+except Exception:
+    pass
+
+# DirectML (privateuseone)
+try:
     import torch_directml
     if hasattr(torch, 'privateuseone') and torch_directml.device_count() > 0:
         torch.dml = torch_directml
         DEFAULT_DEVICE = f'privateuseone:{torch.dml.default_device()}'
-        AVAILABLE_DEVICES += [f"privateuseone:{d}" for d in range(torch.dml.device_count())]
-except:
+        for d in range(torch.dml.device_count()):
+            _append_unique_device(f'privateuseone:{d}')
+except Exception:
     # directml is not supported
     pass
+
 BF16_SUPPORTED = DEFAULT_DEVICE == 'cuda' and torch.cuda.is_bf16_supported() or DEFAULT_DEVICE == 'xpu' and torch.xpu.is_bf16_supported()
 
 def is_nvidia():


### PR DESCRIPTION
### Motivation
- Module/device pickers were only showing `Default` and `cpu` because runtime device discovery was fragile and didn’t expose GPU device options in `AVAILABLE_DEVICES`.
- The goal is to harden device detection so GPU runtimes (including indexed CUDA devices) appear in module selectors and the default device picker.

### Description
- Centralized runtime device option population in `modules/base.py` by introducing `_append_unique_device` and building `AVAILABLE_DEVICES` from a single source of truth.
- Improved CUDA/ROCm detection by checking both `torch.cuda.is_available()` and `torch.cuda.device_count()` and adding `cuda` plus indexed entries (`cuda:0`, `cuda:1`, ...) when present.
- Preserved and deduplicated detection for XPU, MPS, and DirectML (privateuseone) while keeping the CPU fallback intact.
- `DEVICE_SELECTOR()` continues to read from `AVAILABLE_DEVICES`, so UI selectors and module defaults automatically pick up discovered devices.

### Testing
- Ran `python -m compileall -f -q modules/base.py` and it completed successfully.
- Performed a runtime smoke check with `python - <<'PY' ... import modules.base as b ... PY` that printed `DEFAULT_DEVICE`, `AVAILABLE_DEVICES`, and `DEVICE_SELECTOR()`; the script ran successfully and showed CPU-only results in this environment (expected because no CUDA devices are exposed here).
- No automated test suites were modified or run beyond the compile and runtime smoke check described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f3d77ea0f8832c97aa67e56711dcc0)