### PR TITLE
Add context-run macros, triage/translation QA tools, shortcut improvements and startup UI toggles

### DIFF
--- a/launch.py
+++ b/launch.py
@@ -411,6 +411,8 @@ def main():
         except Exception:
             pass
         shared.FIRST_RUN_NO_CONFIG = False
+        # Force welcome/start screen after first-setup flow so users land on onboarding UI.
+        shared.FORCE_SHOW_WELCOME_ON_STARTUP = True
 
     # Download selected model packages; defer to after window is shown (GUI) so user can retry from Tools if it fails
     if args.headless or getattr(args, 'headless_continuous', False):

--- a/tests/test_context_run_macros_default.py
+++ b/tests/test_context_run_macros_default.py
@@ -1,0 +1,17 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.__getattr__ = lambda name: 1
+sys.modules["cv2"] = cv2_stub
+
+from utils.config import ProgramConfig
+
+
+def test_context_run_macros_default_present():
+    cfg = ProgramConfig()
+    assert isinstance(cfg.context_run_macros, list)
+    assert cfg.context_run_macros
+    ids = {m.get('id') for m in cfg.context_run_macros}
+    assert 'detect_ocr_translate' in ids
+    assert 'ocr_translate_inpaint' in ids

--- a/tests/test_context_run_macros_parse.py
+++ b/tests/test_context_run_macros_parse.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.__getattr__ = lambda name: 1
+sys.modules["cv2"] = cv2_stub
+
+from utils.config import parse_context_run_macros
+
+
+def test_parse_context_run_macros_valid_and_invalid():
+    out = parse_context_run_macros('[{"id":"m1","label":"Macro A","mode":2,"detect_first":false}]')
+    assert out[0]['id'] == 'm1'
+    assert out[0]['mode'] == 2
+
+    try:
+        parse_context_run_macros('{"bad":1}')
+        assert False
+    except ValueError:
+        pass

--- a/tests/test_environment_doctor.py
+++ b/tests/test_environment_doctor.py
@@ -1,0 +1,13 @@
+from utils.environment_doctor import run_environment_doctor
+
+
+def test_environment_doctor_returns_structured_checks():
+    checks = run_environment_doctor()
+    assert isinstance(checks, list)
+    assert checks
+    for item in checks:
+        assert isinstance(item, tuple)
+        assert len(item) == 3
+    names = {c[0] for c in checks}
+    assert 'python' in names
+    assert 'auth:huggingface' in names

--- a/tests/test_proj_run_profiles.py
+++ b/tests/test_proj_run_profiles.py
@@ -1,0 +1,34 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.IMREAD_COLOR = getattr(cv2_stub, "IMREAD_COLOR", 1)
+cv2_stub.IMREAD_GRAYSCALE = getattr(cv2_stub, "IMREAD_GRAYSCALE", 0)
+cv2_stub.COLOR_GRAY2RGB = getattr(cv2_stub, "COLOR_GRAY2RGB", 0)
+cv2_stub.COLOR_RGB2BGR = getattr(cv2_stub, "COLOR_RGB2BGR", 0)
+cv2_stub.COLOR_RGBA2BGRA = getattr(cv2_stub, "COLOR_RGBA2BGRA", 0)
+cv2_stub.IMWRITE_JPEG_QUALITY = getattr(cv2_stub, "IMWRITE_JPEG_QUALITY", 1)
+cv2_stub.IMWRITE_WEBP_QUALITY = getattr(cv2_stub, "IMWRITE_WEBP_QUALITY", 64)
+cv2_stub.cvtColor = getattr(cv2_stub, "cvtColor", lambda img, code: img)
+cv2_stub.imencode = getattr(cv2_stub, "imencode", lambda ext, img, enc: (True, types.SimpleNamespace(tofile=lambda p: None)))
+sys.modules["cv2"] = cv2_stub
+
+
+def _missing_attr(name):
+    return 1
+cv2_stub.__getattr__ = _missing_attr
+
+from utils.proj_imgtrans import ProjImgTrans
+
+
+def test_proj_run_profiles_round_trip_in_dict_only():
+    p = ProjImgTrans()
+    p.directory = '/tmp/nonexistent'
+    p.current_img = None
+    p.run_profiles = {'fast': {'ocr': 'manga_ocr', 'translator': 'google'}}
+    d = p.to_dict()
+    assert d['run_profiles']['fast']['ocr'] == 'manga_ocr'
+
+    p2 = ProjImgTrans()
+    p2.load_from_dict({'pages': {}, 'image_info': {}, 'run_profiles': d['run_profiles']})
+    assert 'fast' in p2.run_profiles

--- a/tests/test_proj_triage_flags.py
+++ b/tests/test_proj_triage_flags.py
@@ -1,0 +1,21 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.__getattr__ = lambda name: 1
+sys.modules["cv2"] = cv2_stub
+
+from utils.proj_imgtrans import ProjImgTrans
+
+
+def test_triage_flags_add_and_mark_reviewed():
+    p = ProjImgTrans()
+    p.pages = {'p1': []}
+    p._image_info = {'p1': {'finish_code': 0, 'ignored': False}}
+
+    p.add_triage_flags('p1', [1, 2])
+    assert p._image_info['p1']['triage_flags']['1'] == 'open'
+    assert p._image_info['p1']['triage_flags']['2'] == 'open'
+
+    p.mark_triage_reviewed('p1', [2])
+    assert p._image_info['p1']['triage_flags']['2'] == 'reviewed'

--- a/tests/test_shortcut_run_ids.py
+++ b/tests/test_shortcut_run_ids.py
@@ -1,0 +1,15 @@
+from utils.shortcuts import get_default_shortcuts
+
+
+def test_run_context_shortcut_ids_exist():
+    d = get_default_shortcuts()
+    for key in [
+        'run.detect_page',
+        'run.translate',
+        'run.ocr',
+        'run.ocr_translate',
+        'run.ocr_translate_inpaint',
+        'run.macro_detect_ocr_translate',
+        'run.macro_ocr_translate_inpaint',
+    ]:
+        assert key in d

--- a/tests/test_shortcuts_conflicts.py
+++ b/tests/test_shortcuts_conflicts.py
@@ -1,0 +1,30 @@
+from utils.shortcuts import find_shortcut_conflicts, classify_shortcut_conflicts, auto_resolve_shortcut_conflicts
+
+
+def test_find_shortcut_conflicts_detects_duplicates_only():
+    m = {
+        'a': 'Ctrl+S',
+        'b': 'Ctrl+S',
+        'c': 'Ctrl+O',
+        'd': '',
+    }
+    got = find_shortcut_conflicts(m)
+    assert got == {'Ctrl+S': ['a', 'b']}
+
+
+def test_classify_and_auto_resolve_conflicts():
+    m = {
+        'go.prev_page': 'A',
+        'go.prev_page_alt': 'A',
+        'file.open_folder': 'Ctrl+O',
+        'file.save_proj': 'Ctrl+O',
+    }
+    c = classify_shortcut_conflicts(m)
+    assert 'A' in c['alias']
+    assert 'Ctrl+O' in c['hard']
+
+    r = auto_resolve_shortcut_conflicts(m)
+    assert r['go.prev_page'] == 'A'
+    assert r['go.prev_page_alt'] == ''
+    assert r['file.open_folder'] == 'Ctrl+O'
+    assert r['file.save_proj'] == ''

--- a/tests/test_translation_review.py
+++ b/tests/test_translation_review.py
@@ -1,0 +1,19 @@
+from utils.translation_review import extract_glossary_candidates, check_translation_guardrails
+
+
+def test_extract_glossary_candidates_picks_repeated_terms():
+    src = ["Alice uses Mana Burst", "Mana Burst hits Bob", "Alice recovers mana"]
+    got = extract_glossary_candidates(src, [], min_freq=2)
+    sources = {x['source'] for x in got}
+    assert 'Alice' in sources
+    assert 'Mana' in sources or 'Burst' in sources
+
+
+def test_guardrails_flags_expected_issues():
+    glossary = [{"source": "宗门", "target": "Sect"}]
+    issues = check_translation_guardrails("宗门", "宗门", glossary=glossary, max_len_ratio=1.1)
+    assert any("Untranslated source carry-over" in i for i in issues)
+    assert any("Glossary mismatch" in i for i in issues)
+
+    issues2 = check_translation_guardrails("short", "this is a very very long translation", glossary=[])
+    assert any("overlong" in i for i in issues2)

--- a/ui/canvas.py
+++ b/ui/canvas.py
@@ -21,6 +21,7 @@ from .page_search_widget import PageSearchWidget
 from utils import shared as C
 from utils.config import pcfg
 from utils.config import context_menu_visible
+from utils.shortcuts import get_shortcut
 from utils.proj_imgtrans import ProjImgTrans
 from .context_menu_config_dialog import ContextMenuConfigDialog, CONTEXT_MENU_ITEMS
 
@@ -218,6 +219,8 @@ class Canvas(QGraphicsScene):
     run_detect_region = Signal(QRectF, bool)  # rect, replace_page (True = "Detect text on page" -> replace blocks)
 
     download_page_requested = Signal(str)  # "result" | "inpainted" | "original"
+    triage_add_selected_signal = Signal(list)
+    triage_mark_reviewed_selected_signal = Signal(list)
 
 
     begin_scale_tool = Signal(QPointF)
@@ -1170,6 +1173,7 @@ class Canvas(QGraphicsScene):
 
             # --- Block (selection) ---
             merge_blocks_act = split_regions_act = move_up_act = move_down_act = None
+            triage_add_act = triage_mark_act = None
             create_textbox_act = None
             block_menu = None
             if context_menu_visible('create_textbox'):
@@ -1197,6 +1201,9 @@ class Canvas(QGraphicsScene):
                     move_down_act = block_menu.addAction(self.tr("Move block(s) down"))
                     move_down_act.setEnabled(n_sel == 1 and n_total > 0 and sel[0].idx < n_total - 1)
                     actions_map['block_move_down'] = move_down_act
+                if block_menu is not None:
+                    triage_add_act = block_menu.addAction(self.tr("Add selected to triage worklist"))
+                    triage_mark_act = block_menu.addAction(self.tr("Mark selected as reviewed"))
 
             # --- Image / Overlay (selection) ---
             import_image_act = clear_overlay_act = None
@@ -1324,6 +1331,7 @@ class Canvas(QGraphicsScene):
             # --- Run (pipeline) ---
             detect_region_act = detect_page_act = translate_act = ocr_act = None
             ocr_translate_act = ocr_translate_inpaint_act = inpaint_act = None
+            macro_actions = {}
             run_menu = None
             if context_menu_visible('run_detect_region') and saved_rect is not None:
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
@@ -1332,27 +1340,43 @@ class Canvas(QGraphicsScene):
             if context_menu_visible('run_detect_page'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 detect_page_act = run_menu.addAction(self.tr("Detect text on page"))
+                detect_page_act.setShortcut(QKeySequence.fromString(get_shortcut("run.detect_page", getattr(pcfg, "shortcuts", None))))
                 actions_map['run_detect_page'] = detect_page_act
             if context_menu_visible('run_translate'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 translate_act = run_menu.addAction(self.tr("Translate"))
+                translate_act.setShortcut(QKeySequence.fromString(get_shortcut("run.translate", getattr(pcfg, "shortcuts", None))))
                 actions_map['run_translate'] = translate_act
             if context_menu_visible('run_ocr'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 ocr_act = run_menu.addAction(self.tr("OCR"))
+                ocr_act.setShortcut(QKeySequence.fromString(get_shortcut("run.ocr", getattr(pcfg, "shortcuts", None))))
                 actions_map['run_ocr'] = ocr_act
             if context_menu_visible('run_ocr_translate'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 ocr_translate_act = run_menu.addAction(self.tr("OCR and translate"))
+                ocr_translate_act.setShortcut(QKeySequence.fromString(get_shortcut("run.ocr_translate", getattr(pcfg, "shortcuts", None))))
                 actions_map['run_ocr_translate'] = ocr_translate_act
             if context_menu_visible('run_ocr_translate_inpaint'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 ocr_translate_inpaint_act = run_menu.addAction(self.tr("OCR, translate and inpaint"))
+                ocr_translate_inpaint_act.setShortcut(QKeySequence.fromString(get_shortcut("run.ocr_translate_inpaint", getattr(pcfg, "shortcuts", None))))
                 actions_map['run_ocr_translate_inpaint'] = ocr_translate_inpaint_act
             if context_menu_visible('run_inpaint'):
                 if run_menu is None: run_menu = menu.addMenu(self.tr("Run"))
                 inpaint_act = run_menu.addAction(self.tr("Inpaint"))
                 actions_map['run_inpaint'] = inpaint_act
+            if run_menu is not None:
+                run_menu.addSeparator()
+                for m in (getattr(pcfg, 'context_run_macros', None) or []):
+                    label = str(m.get('label', 'Macro'))
+                    act = run_menu.addAction(self.tr(label))
+                    mid = str(m.get('id', ''))
+                    if mid == 'detect_ocr_translate':
+                        act.setShortcut(QKeySequence.fromString(get_shortcut('run.macro_detect_ocr_translate', getattr(pcfg, 'shortcuts', None))))
+                    elif mid == 'ocr_translate_inpaint':
+                        act.setShortcut(QKeySequence.fromString(get_shortcut('run.macro_ocr_translate_inpaint', getattr(pcfg, 'shortcuts', None))))
+                    macro_actions[act] = m
 
             download_menu = None
             download_result_act = download_inpainted_act = download_original_act = None
@@ -1369,6 +1393,16 @@ class Canvas(QGraphicsScene):
             # Rebuild menu with pinned items at top
             menu_new = QMenu(self.gv)
             menu_new.setStyleSheet(menu.styleSheet())
+            pin_toggle_actions = {}
+            pin_manage_sub = menu_new.addMenu(self.tr("Pin quick actions"))
+            for key, obj in actions_map.items():
+                if isinstance(obj, QMenu):
+                    continue
+                act = pin_manage_sub.addAction(key)
+                act.setCheckable(True)
+                act.setChecked(key in pinned)
+                pin_toggle_actions[act] = key
+            menu_new.addSeparator()
             for key in pinned:
                 if key in actions_map:
                     o = actions_map[key]
@@ -1467,6 +1501,10 @@ class Canvas(QGraphicsScene):
                 self.merge_selected_blocks_signal.emit()
             elif split_regions_act is not None and rst == split_regions_act:
                 self.split_selected_regions_signal.emit()
+            elif triage_add_act is not None and rst == triage_add_act:
+                self.triage_add_selected_signal.emit([it.idx for it in sel])
+            elif triage_mark_act is not None and rst == triage_mark_act:
+                self.triage_mark_reviewed_selected_signal.emit([it.idx for it in sel])
             elif move_up_act is not None and rst == move_up_act:
                 self.move_blocks_up_signal.emit()
             elif move_down_act is not None and rst == move_down_act:
@@ -1584,6 +1622,11 @@ class Canvas(QGraphicsScene):
                 self.run_blktrans.emit(2)
             elif rst == inpaint_act:
                 self.run_blktrans.emit(3)
+            elif rst in macro_actions:
+                m = macro_actions.get(rst) or {}
+                if bool(m.get('detect_first', False)) and self.imgtrans_proj is not None and self.imgtrans_proj.img_valid and self.sceneRect().isValid():
+                    self.run_detect_region.emit(self.sceneRect(), True)
+                self.run_blktrans.emit(int(m.get('mode', 1)))
             elif download_result_act is not None and rst == download_result_act:
                 self.download_page_requested.emit("result")
             elif download_inpainted_act is not None and rst == download_inpainted_act:

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -647,6 +647,19 @@ class ConfigPanel(Widget):
         )
         self.auto_update_from_github_checker.stateChanged.connect(self.on_auto_update_from_github_changed)
 
+        self.show_model_download_result_dialog_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Show model download result popup on startup'),
+            discription=self.tr('When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.')
+        )
+        self.show_model_download_result_dialog_checker.stateChanged.connect(self.on_show_model_download_result_dialog_changed)
+
+        self.show_startup_health_dialog_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Show startup health popup on startup'),
+            discription=self.tr('When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.')
+        )
+        self.show_startup_health_dialog_checker.stateChanged.connect(self.on_show_startup_health_dialog_changed)
+
+
         self.dev_mode_checker, _ = generalConfigPanel.addCheckBox(
             self.tr('Dev mode (show all modules)'),
             discription=self.tr(
@@ -1222,6 +1235,12 @@ class ConfigPanel(Widget):
     def on_auto_update_from_github_changed(self):
         pcfg.auto_update_from_github = self.auto_update_from_github_checker.isChecked()
 
+    def on_show_model_download_result_dialog_changed(self):
+        pcfg.show_model_download_result_dialog = self.show_model_download_result_dialog_checker.isChecked()
+
+    def on_show_startup_health_dialog_changed(self):
+        pcfg.show_startup_health_dialog = self.show_startup_health_dialog_checker.isChecked()
+
     def on_dev_mode_changed(self):
         pcfg.dev_mode = self.dev_mode_checker.isChecked()
         try:
@@ -1770,6 +1789,8 @@ class ConfigPanel(Widget):
         self.let_show_only_custom_fonts.setChecked(pcfg.let_show_only_custom_fonts_flag)
         self.recent_proj_list_max_spin.setValue(getattr(pcfg, 'recent_proj_list_max', 14))
         self.show_welcome_screen_checker.setChecked(getattr(pcfg, 'show_welcome_screen', True))
+        self.show_model_download_result_dialog_checker.setChecked(getattr(pcfg, 'show_model_download_result_dialog', True))
+        self.show_startup_health_dialog_checker.setChecked(getattr(pcfg, 'show_startup_health_dialog', True))
         self.dev_mode_checker.setChecked(getattr(pcfg, 'dev_mode', False))
         self.logical_dpi_spin.setValue(getattr(pcfg, 'logical_dpi', 0))
         self.confirm_before_run_checker.setChecked(getattr(pcfg, 'confirm_before_run', True))

--- a/ui/context_menu_config_dialog.py
+++ b/ui/context_menu_config_dialog.py
@@ -21,9 +21,10 @@ from qtpy.QtWidgets import (
     QAbstractItemView,
     QSizePolicy,
     QMenu,
+    QPlainTextEdit,
 )
 
-from utils.config import pcfg, save_config, CONTEXT_MENU_DEFAULT
+from utils.config import pcfg, save_config, CONTEXT_MENU_DEFAULT, parse_context_run_macros
 
 
 def _all_keys_with_labels() -> List[Tuple[str, str]]:
@@ -149,6 +150,20 @@ class ContextMenuConfigDialog(QDialog):
         pinned_layout.addWidget(clear_pinned_btn)
         layout.addWidget(pinned_group)
 
+        preset_row = QHBoxLayout()
+        preset_row.addWidget(QLabel(self.tr("Quick profiles:")))
+        btn_edit = QPushButton(self.tr("Editing-focused"))
+        btn_edit.clicked.connect(lambda: self._apply_profile("editing"))
+        preset_row.addWidget(btn_edit)
+        btn_pipe = QPushButton(self.tr("Pipeline-focused"))
+        btn_pipe.clicked.connect(lambda: self._apply_profile("pipeline"))
+        preset_row.addWidget(btn_pipe)
+        btn_layout = QPushButton(self.tr("Layout-focused"))
+        btn_layout.clicked.connect(lambda: self._apply_profile("layout"))
+        preset_row.addWidget(btn_layout)
+        preset_row.addStretch(1)
+        layout.addLayout(preset_row)
+
         scroll = QScrollArea(self)
         scroll.setWidgetResizable(True)
         scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
@@ -179,6 +194,19 @@ class ContextMenuConfigDialog(QDialog):
         scroll.setWidget(content)
         layout.addWidget(scroll)
 
+        macros_group = QGroupBox(self.tr("Run macros (JSON list)"))
+        macros_layout = QVBoxLayout(macros_group)
+        self._macros_edit = QPlainTextEdit(self)
+        self._macros_edit.setPlaceholderText('[{"id":"detect_ocr_translate","label":"Macro: Detect+OCR+Translate","mode":1,"detect_first":true}]')
+        try:
+            import json
+            self._macros_edit.setPlainText(json.dumps(getattr(pcfg, 'context_run_macros', []), ensure_ascii=False, indent=2))
+        except Exception:
+            self._macros_edit.setPlainText('[]')
+        self._macros_edit.setMaximumHeight(140)
+        macros_layout.addWidget(self._macros_edit)
+        layout.addWidget(macros_group)
+
         btn_layout = QHBoxLayout()
         btn_layout.addStretch(1)
         restore_btn = QPushButton(self.tr("Restore defaults"))
@@ -194,6 +222,17 @@ class ContextMenuConfigDialog(QDialog):
         layout.addLayout(btn_layout)
 
         self._refresh_pinned_list()
+
+    def _apply_profile(self, profile: str):
+        editing_keys = {
+            'edit_copy','edit_paste','edit_copy_trans','edit_paste_trans','edit_delete','edit_select_all',
+            'text_trim','text_upper','text_lower','format_apply','format_layout','format_fit_to_bubble','create_textbox'
+        }
+        pipeline_keys = {'run_detect_region','run_detect_page','run_translate','run_ocr','run_ocr_translate','run_ocr_translate_inpaint','run_inpaint'}
+        layout_keys = {'format_apply','format_layout','format_fit_to_bubble','format_auto_fit','format_auto_fit_binary','format_balloon_shape','format_resize_to_fit_content','format_center_in_bubble','format_angle','format_squeeze'}
+        chosen = editing_keys if profile == 'editing' else pipeline_keys if profile == 'pipeline' else layout_keys
+        for key, cb in self._checkboxes.items():
+            cb.setChecked(key in chosen)
 
     def _refresh_pinned_list(self):
         self._pinned_list.clear()
@@ -245,5 +284,11 @@ class ContextMenuConfigDialog(QDialog):
             if k and k not in self._pinned_keys:
                 self._pinned_keys.append(k)
         pcfg.context_menu_pinned = self._pinned_keys
+        try:
+            pcfg.context_run_macros = parse_context_run_macros(self._macros_edit.toPlainText())
+        except Exception as e:
+            from qtpy.QtWidgets import QMessageBox
+            QMessageBox.warning(self, self.tr('Invalid run macros JSON'), str(e))
+            return
         save_config()
         super().accept()

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -208,12 +208,13 @@ class MainWindow(mainwindow_cls):
         FramelessMoveResize.toggleMaxState(self)
         self.setAcceptDrops(True)
 
-        if open_dir != '' and osp.exists(open_dir):
+        force_welcome = bool(getattr(shared, 'FORCE_SHOW_WELCOME_ON_STARTUP', False))
+        if not force_welcome and open_dir != '' and osp.exists(open_dir):
             if osp.isfile(open_dir) and open_dir.lower().endswith('.json'):
                 self.openJsonProj(open_dir)
             else:
                 self.OpenProj(open_dir)
-        elif pcfg.open_recent_on_startup:
+        elif not force_welcome and pcfg.open_recent_on_startup:
             # Auto-open most recent project when user has this preference.
             if len(self.leftBar.recent_proj_list) > 0:
                 proj_dir = self.leftBar.recent_proj_list[0]
@@ -221,9 +222,10 @@ class MainWindow(mainwindow_cls):
                     self.OpenProj(proj_dir)
 
         if not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
-            # When no project is loaded, always show welcome screen so user can open or create one.
-            if self.imgtrans_proj.is_empty or not self.imgtrans_proj.directory:
+            # When no project is loaded (or first-setup requests onboarding), show welcome screen.
+            if force_welcome or self.imgtrans_proj.is_empty or not self.imgtrans_proj.directory:
                 self._show_welcome_screen()
+                shared.FORCE_SHOW_WELCOME_ON_STARTUP = False
 
         if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
             self.run_batch(**exec_args)
@@ -441,6 +443,8 @@ class MainWindow(mainwindow_cls):
         self.canvas.move_blocks_down_signal.connect(self.on_move_blocks_down)
         self.canvas.import_image_to_blk.connect(self.on_import_image_to_blk)
         self.canvas.clear_overlay_signal.connect(self.on_clear_overlay)
+        self.canvas.triage_add_selected_signal.connect(self.on_add_selected_to_triage)
+        self.canvas.triage_mark_reviewed_selected_signal.connect(self.on_mark_selected_triage_reviewed)
 
         self.app.installEventFilter(self)
         self.canvas.gv.installEventFilter(self)
@@ -1102,6 +1106,12 @@ class MainWindow(mainwindow_cls):
         self.titleBar.batch_queue_trigger.connect(self.on_open_batch_queue)
         self.titleBar.manage_models_trigger.connect(self.on_open_manage_models)
         self.titleBar.retry_models_trigger.connect(self.on_retry_model_downloads)
+        self.titleBar.environment_doctor_trigger.connect(self.on_environment_doctor)
+        self.titleBar.translation_qa_report_trigger.connect(self.on_translation_qa_report_current_page)
+        self.titleBar.ocr_triage_trigger.connect(self.on_open_ocr_triage_current_page)
+        self.titleBar.auto_extract_glossary_trigger.connect(self.on_auto_extract_glossary_current_page)
+        self.titleBar.save_run_profile_trigger.connect(self.on_save_run_profile_snapshot)
+        self.titleBar.apply_run_profile_trigger.connect(self.on_apply_run_profile_snapshot)
         self.titleBar.show_model_download_diag_trigger.connect(self.on_show_model_download_diagnostics)
         self.titleBar.copy_startup_diag_trigger.connect(self.on_copy_startup_diagnostics)
         self.titleBar.export_startup_diag_trigger.connect(self.on_export_startup_report)
@@ -1888,6 +1898,8 @@ class MainWindow(mainwindow_cls):
         return "\n".join(lines)
 
     def _show_startup_health_overlay(self):
+        if not getattr(pcfg, 'show_startup_health_dialog', True):
+            return
         stages = getattr(shared, "STARTUP_HEALTH", []) or []
         if not stages:
             return
@@ -1999,6 +2011,8 @@ class MainWindow(mainwindow_cls):
             LOGGER.debug("Window geometry recovery skipped: %s", e)
 
     def _show_model_download_result_dialog(self, *, title: str, status: str, summary: dict, details: str = ''):
+        if not getattr(pcfg, 'show_model_download_result_dialog', True):
+            return
         downloaded = int((summary or {}).get('downloaded', 0))
         failed = int((summary or {}).get('failed', 0))
         skipped = int((summary or {}).get('skipped', 0))
@@ -2121,7 +2135,7 @@ class MainWindow(mainwindow_cls):
                     summary=summary,
                     details=partial_details + '\n\n' + tip
                 )
-            if success:
+            if status == "success":
                 defaults_summary = self._reset_modules_to_core_defaults()
                 create_info_dialog({
                     'title': self.tr('Download complete. Defaults updated.'),
@@ -4392,6 +4406,150 @@ class MainWindow(mainwindow_cls):
                 skip_ignored_in_batch=skip_ignored,
                 pages_to_process=pages_to_process,
             )
+
+    def on_environment_doctor(self):
+        from utils.environment_doctor import run_environment_doctor
+        checks = run_environment_doctor()
+        lines = [f"{name}: {status} ({detail})" for name, status, detail in checks]
+        create_info_dialog({'title': self.tr('Environment doctor report'), 'text': '\n'.join(lines)})
+
+    def on_translation_qa_report_current_page(self):
+        if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
+            create_info_dialog({'title': self.tr('No page loaded'), 'text': self.tr('Open a project/page first.')})
+            return
+        from utils.translation_review import extract_glossary_candidates, check_translation_guardrails
+        page = self.imgtrans_proj.current_img
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        src_texts = [getattr(b, 'text', '') or '' for b in blks]
+        trans_texts = [getattr(b, 'translation', '') or '' for b in blks]
+        glossary = getattr(self.imgtrans_proj, 'translation_glossary', None) or []
+        issues = []
+        for i, b in enumerate(blks):
+            for issue in check_translation_guardrails(getattr(b, 'text', ''), getattr(b, 'translation', ''), glossary=glossary):
+                issues.append(f"#{i+1}: {issue}")
+        candidates = extract_glossary_candidates(src_texts, trans_texts, min_freq=2)[:20]
+        empty_ocr = [str(i+1) for i,b in enumerate(blks) if not (getattr(b, 'text', '') or '').strip()]
+        lines = [self.tr('Page: ') + str(page), self.tr('Blocks: ') + str(len(blks))]
+        lines.append(self.tr('Likely OCR triage (empty source): ') + (', '.join(empty_ocr) if empty_ocr else self.tr('none')))
+        lines.append(self.tr('Guardrail issues: ') + str(len(issues)))
+        lines.extend(issues[:50])
+        if candidates:
+            lines.append(self.tr('Glossary candidates (source -> target):'))
+            lines.extend([f"- {c.get('source','')} -> " for c in candidates])
+        create_info_dialog({'title': self.tr('Translation QA report'), 'text': '\n'.join(lines)})
+
+    def on_save_run_profile_snapshot(self):
+        if self.imgtrans_proj is None:
+            return
+        from qtpy.QtWidgets import QInputDialog
+        name, ok = QInputDialog.getText(self, self.tr('Save run profile'), self.tr('Profile name:'))
+        if not ok or not str(name).strip():
+            return
+        cfg = pcfg.module
+        snap = {
+            'textdetector': getattr(cfg, 'textdetector', ''),
+            'ocr': getattr(cfg, 'ocr', ''),
+            'inpainter': getattr(cfg, 'inpainter', ''),
+            'translator': getattr(cfg, 'translator', ''),
+        }
+        if not isinstance(getattr(self.imgtrans_proj, 'run_profiles', None), dict):
+            self.imgtrans_proj.run_profiles = {}
+        self.imgtrans_proj.run_profiles[str(name).strip()] = snap
+        self.imgtrans_proj.save()
+        create_info_dialog({'title': self.tr('Saved'), 'text': self.tr('Run profile saved to project.')})
+
+    def on_apply_run_profile_snapshot(self):
+        if self.imgtrans_proj is None:
+            return
+        profiles = getattr(self.imgtrans_proj, 'run_profiles', None) or {}
+        if not profiles:
+            create_info_dialog({'title': self.tr('No profiles'), 'text': self.tr('No run profiles found in this project.')})
+            return
+        from qtpy.QtWidgets import QInputDialog
+        names = sorted(list(profiles.keys()))
+        name, ok = QInputDialog.getItem(self, self.tr('Apply run profile'), self.tr('Select profile:'), names, 0, False)
+        if not ok or not name:
+            return
+        snap = profiles.get(name) or {}
+        if snap.get('textdetector'):
+            self.module_manager.setTextDetector(snap['textdetector'])
+        if snap.get('ocr'):
+            self.module_manager.setOCR(snap['ocr'])
+        if snap.get('inpainter'):
+            self.module_manager.setInpainter(snap['inpainter'])
+        if snap.get('translator'):
+            self.module_manager.setTranslator(snap['translator'])
+        create_info_dialog({'title': self.tr('Applied'), 'text': self.tr('Run profile applied.')})
+
+    def on_open_ocr_triage_current_page(self):
+        if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
+            create_info_dialog({'title': self.tr('No page loaded'), 'text': self.tr('Open a project/page first.')})
+            return
+        from utils.translation_review import check_translation_guardrails
+        from ui.ocr_triage_dialog import OcrTriageDialog
+        page = self.imgtrans_proj.current_img
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        glossary = getattr(self.imgtrans_proj, 'translation_glossary', None) or []
+        rows = []
+        triage_state = (self.imgtrans_proj._image_info.get(page, {}) or {}).get('triage_flags', {})
+        for i, b in enumerate(blks):
+            src = (getattr(b, 'text', '') or '').strip()
+            trn = (getattr(b, 'translation', '') or '').strip()
+            state = triage_state.get(str(i), 'none')
+            if state != 'none':
+                rows.append({'block': i + 1, 'source': src, 'translation': trn, 'issue': self.tr('Triage state: ') + state})
+            if not src:
+                rows.append({'block': i + 1, 'source': src, 'translation': trn, 'issue': self.tr('Empty OCR source text')})
+            for issue in check_translation_guardrails(src, trn, glossary=glossary):
+                rows.append({'block': i + 1, 'source': src, 'translation': trn, 'issue': issue})
+        if not rows:
+            create_info_dialog({'title': self.tr('OCR triage worklist'), 'text': self.tr('No triage issues found on current page.')})
+            return
+        dlg = OcrTriageDialog(rows, self)
+        dlg.exec()
+
+    def on_auto_extract_glossary_current_page(self):
+        if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
+            create_info_dialog({'title': self.tr('No page loaded'), 'text': self.tr('Open a project/page first.')})
+            return
+        from utils.translation_review import extract_glossary_candidates
+        page = self.imgtrans_proj.current_img
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        src_texts = [getattr(b, 'text', '') or '' for b in blks]
+        candidates = extract_glossary_candidates(src_texts, None, min_freq=2)
+        if not candidates:
+            create_info_dialog({'title': self.tr('Auto-extract glossary'), 'text': self.tr('No glossary candidates found on current page.')})
+            return
+        existing = getattr(self.imgtrans_proj, 'translation_glossary', None) or []
+        seen = {str(g.get('source', '')).strip() for g in existing if isinstance(g, dict)}
+        added = []
+        for c in candidates:
+            src = str(c.get('source', '')).strip()
+            if not src or src in seen:
+                continue
+            existing.append({'source': src, 'target': ''})
+            seen.add(src)
+            added.append(src)
+        self.imgtrans_proj.translation_glossary = existing
+        self.imgtrans_proj.save()
+        preview = ', '.join(added[:20]) if added else self.tr('None (all candidates already existed).')
+        create_info_dialog({'title': self.tr('Auto-extract glossary complete'), 'text': self.tr('Added terms: {0}').format(preview)})
+
+    def on_add_selected_to_triage(self, idx_list: list):
+        if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
+            return
+        page = self.imgtrans_proj.current_img
+        self.imgtrans_proj.add_triage_flags(page, idx_list)
+        self.imgtrans_proj.save()
+        create_info_dialog({'title': self.tr('Triage updated'), 'text': self.tr('Selected blocks added to triage worklist.')})
+
+    def on_mark_selected_triage_reviewed(self, idx_list: list):
+        if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
+            return
+        page = self.imgtrans_proj.current_img
+        self.imgtrans_proj.mark_triage_reviewed(page, idx_list)
+        self.imgtrans_proj.save()
+        create_info_dialog({'title': self.tr('Triage updated'), 'text': self.tr('Selected blocks marked as reviewed.')})
 
     def setupRegisterWidget(self):
         self.titleBar.viewMenu.addSeparator()

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -673,6 +673,30 @@ class TitleBar(Widget):
         relaunchCpuOnlyAction.setToolTip(self.tr('Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.'))
         self.relaunch_cpu_only_trigger = relaunchCpuOnlyAction.triggered
 
+        environmentDoctorAction = QAction(self.tr('Environment doctor...'), self)
+        environmentDoctorAction.setToolTip(self.tr('Run dependency and auth checks and show a report.'))
+        self.environment_doctor_trigger = environmentDoctorAction.triggered
+
+        ocrTriageAction = QAction(self.tr('OCR triage worklist (current page)...'), self)
+        ocrTriageAction.setToolTip(self.tr('Show blocks that likely need OCR/translation review and triage.'))
+        self.ocr_triage_trigger = ocrTriageAction.triggered
+
+        autoExtractGlossaryAction = QAction(self.tr('Auto-extract glossary (current page)...'), self)
+        autoExtractGlossaryAction.setToolTip(self.tr('Extract frequent source terms and append to project glossary.'))
+        self.auto_extract_glossary_trigger = autoExtractGlossaryAction.triggered
+
+        translationQaAction = QAction(self.tr('Translation QA report (current page)...'), self)
+        translationQaAction.setToolTip(self.tr('Run glossary candidate extraction and guardrail checks on current page.'))
+        self.translation_qa_report_trigger = translationQaAction.triggered
+
+        saveRunProfileAction = QAction(self.tr('Save run profile snapshot...'), self)
+        saveRunProfileAction.setToolTip(self.tr('Save current module selections as a project-local run profile.'))
+        self.save_run_profile_trigger = saveRunProfileAction.triggered
+
+        applyRunProfileAction = QAction(self.tr('Apply run profile snapshot...'), self)
+        applyRunProfileAction.setToolTip(self.tr('Apply a previously saved project-local run profile.'))
+        self.apply_run_profile_trigger = applyRunProfileAction.triggered
+
         releaseCachesAction = QAction(self.tr('Release model caches'), self)
         releaseCachesAction.setToolTip(self.tr('Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.'))
         self.release_model_caches_trigger = releaseCachesAction.triggered
@@ -688,6 +712,12 @@ class TitleBar(Widget):
         projectMenu.addAction(reRunOCRAction)
         projectMenu.addAction(validateProjAction)
         projectMenu.addAction(showBatchReportAction)
+        projectMenu.addSeparator()
+        projectMenu.addAction(saveRunProfileAction)
+        projectMenu.addAction(applyRunProfileAction)
+        projectMenu.addAction(translationQaAction)
+        projectMenu.addAction(ocrTriageAction)
+        projectMenu.addAction(autoExtractGlossaryAction)
         exportMenuTools = QMenu(self.tr('Export'), self)
         exportMenuTools.addAction(batchExportAction)
         exportMenuTools.addAction(batchExportAsAction)
@@ -702,6 +732,7 @@ class TitleBar(Widget):
         modelsMenu = QMenu(self.tr('Models'), self)
         modelsMenu.addAction(manageModelsAction)
         modelsMenu.addAction(retryModelsAction)
+        modelsMenu.addAction(environmentDoctorAction)
         modelsMenu.addAction(showDownloadDiagAction)
         modelsMenu.addSeparator()
         modelsMenu.addAction(copyStartupDiagAction)

--- a/ui/ocr_triage_dialog.py
+++ b/ui/ocr_triage_dialog.py
@@ -1,0 +1,26 @@
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QTableWidget, QTableWidgetItem, QPushButton, QHBoxLayout
+
+
+class OcrTriageDialog(QDialog):
+    def __init__(self, rows, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("OCR triage worklist"))
+        self.resize(760, 420)
+        lay = QVBoxLayout(self)
+        self.table = QTableWidget(self)
+        self.table.setColumnCount(4)
+        self.table.setHorizontalHeaderLabels([self.tr("Block"), self.tr("Source"), self.tr("Translation"), self.tr("Issue")])
+        self.table.setRowCount(len(rows))
+        for r, row in enumerate(rows):
+            self.table.setItem(r, 0, QTableWidgetItem(str(row.get("block", ""))))
+            self.table.setItem(r, 1, QTableWidgetItem(str(row.get("source", ""))))
+            self.table.setItem(r, 2, QTableWidgetItem(str(row.get("translation", ""))))
+            self.table.setItem(r, 3, QTableWidgetItem(str(row.get("issue", ""))))
+        self.table.resizeColumnsToContents()
+        lay.addWidget(self.table)
+        btns = QHBoxLayout()
+        btns.addStretch()
+        close_btn = QPushButton(self.tr("Close"), self)
+        close_btn.clicked.connect(self.accept)
+        btns.addWidget(close_btn)
+        lay.addLayout(btns)

--- a/ui/shortcuts_dialog.py
+++ b/ui/shortcuts_dialog.py
@@ -2,6 +2,7 @@
 Keyboard shortcuts dialog: list all actions, edit keybindings, reset to default, apply.
 """
 from typing import Dict, List, Optional
+import json
 
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtGui import QKeySequence, QShortcut
@@ -20,9 +21,10 @@ from qtpy.QtWidgets import (
     QAbstractItemView,
     QMessageBox,
     QWidget,
+    QFileDialog,
 )
 
-from utils.shortcuts import get_shortcut_info, get_default_shortcuts
+from utils.shortcuts import get_shortcut_info, get_default_shortcuts, find_shortcut_conflicts, classify_shortcut_conflicts, auto_resolve_shortcut_conflicts
 from utils.config import pcfg, save_config
 
 
@@ -60,6 +62,13 @@ class ShortcutsDialog(QDialog):
         filter_layout.addWidget(self.category_combo)
         layout.addLayout(filter_layout)
 
+        jump_layout = QHBoxLayout()
+        jump_layout.addWidget(QLabel(self.tr("Find by key:")))
+        self.key_jump_edit = QKeySequenceEdit(self)
+        self.key_jump_edit.keySequenceChanged.connect(self._jump_to_key)
+        jump_layout.addWidget(self.key_jump_edit)
+        layout.addLayout(jump_layout)
+
         # Table: Category | Action | Shortcut
         self.table = QTableWidget(self)
         self.table.setColumnCount(4)
@@ -85,6 +94,12 @@ class ShortcutsDialog(QDialog):
         self.reset_all_btn = QPushButton(self.tr("Reset all to default"), self)
         self.reset_all_btn.clicked.connect(self._reset_all)
         btn_layout.addWidget(self.reset_all_btn)
+        self.export_btn = QPushButton(self.tr("Export JSON"), self)
+        self.export_btn.clicked.connect(self._export_json)
+        btn_layout.addWidget(self.export_btn)
+        self.import_btn = QPushButton(self.tr("Import JSON"), self)
+        self.import_btn.clicked.connect(self._import_json)
+        btn_layout.addWidget(self.import_btn)
         self.apply_btn = QPushButton(self.tr("Apply"), self)
         self.apply_btn.clicked.connect(self._apply)
         self.apply_btn.setDefault(True)
@@ -165,6 +180,47 @@ class ShortcutsDialog(QDialog):
                 )
             self.table.setRowHidden(row, not show)
 
+    def _jump_to_key(self):
+        seq = self.key_jump_edit.keySequence()
+        key = seq.toString(QKeySequence.SequenceFormat.PortableText) if not seq.isEmpty() else ""
+        if not key:
+            return
+        for row in range(self.table.rowCount()):
+            key_edit = self.table.cellWidget(row, 2)
+            if isinstance(key_edit, QKeySequenceEdit):
+                s = key_edit.keySequence().toString(QKeySequence.SequenceFormat.PortableText)
+                if s == key:
+                    self.table.selectRow(row)
+                    self.table.scrollToItem(self.table.item(row, 1))
+                    return
+
+    def _export_json(self):
+        path, _ = QFileDialog.getSaveFileName(self, self.tr("Export shortcuts"), "shortcuts.json", self.tr("JSON files (*.json)"))
+        if not path:
+            return
+        data = self.get_current_shortcuts()
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+
+    def _import_json(self):
+        path, _ = QFileDialog.getOpenFileName(self, self.tr("Import shortcuts"), "", self.tr("JSON files (*.json)"))
+        if not path:
+            return
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            if not isinstance(data, dict):
+                raise ValueError('invalid format')
+            for row in range(self.table.rowCount()):
+                key_edit = self.table.cellWidget(row, 2)
+                if isinstance(key_edit, QKeySequenceEdit):
+                    action_id = key_edit.property("action_id")
+                    if action_id in data:
+                        key = str(data.get(action_id) or "")
+                        key_edit.setKeySequence(QKeySequence.fromString(key) if key else QKeySequence())
+        except Exception as e:
+            QMessageBox.warning(self, self.tr("Import failed"), str(e))
+
     def _apply(self):
         # Collect current keys from key edits
         for row in range(self.table.rowCount()):
@@ -173,6 +229,36 @@ class ShortcutsDialog(QDialog):
                 action_id = key_edit.property("action_id")
                 seq = key_edit.keySequence()
                 self._current[action_id] = seq.toString(QKeySequence.SequenceFormat.PortableText) if not seq.isEmpty() else ""
+
+        # Validate duplicate assignments to avoid ambiguous behavior.
+        action_labels = {aid: desc for (aid, _d, _c, desc) in self._info}
+        classified = classify_shortcut_conflicts(self._current)
+        hard_conflicts = classified.get('hard', {})
+        alias_conflicts = classified.get('alias', {})
+        if hard_conflicts or alias_conflicts:
+            lines = [self.tr("Shortcut conflicts found:")]
+            if hard_conflicts:
+                lines.append(self.tr("Hard conflicts:"))
+                for key, action_ids in sorted(hard_conflicts.items()):
+                    names = [action_labels.get(aid, aid) for aid in action_ids]
+                    lines.append(f"• {key}: " + ", ".join(names))
+            if alias_conflicts:
+                lines.append(self.tr("Alias conflicts (alternate variants):"))
+                for key, action_ids in sorted(alias_conflicts.items()):
+                    names = [action_labels.get(aid, aid) for aid in action_ids]
+                    lines.append(f"• {key}: " + ", ".join(names))
+            lines.append("")
+            lines.append(self.tr("Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?"))
+            rst = QMessageBox.question(self, self.tr("Shortcut conflicts"), "\n".join(lines), QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+            if rst == QMessageBox.StandardButton.Yes:
+                self._current = auto_resolve_shortcut_conflicts(self._current)
+                for row in range(self.table.rowCount()):
+                    key_edit = self.table.cellWidget(row, 2)
+                    if isinstance(key_edit, QKeySequenceEdit):
+                        action_id = key_edit.property("action_id")
+                        key = self._current.get(action_id, "")
+                        key_edit.setKeySequence(QKeySequence.fromString(key) if key else QKeySequence())
+            return
 
         if not isinstance(pcfg.shortcuts, dict):
             pcfg.shortcuts = {}

--- a/utils/config.py
+++ b/utils/config.py
@@ -420,6 +420,8 @@ class ProgramConfig(Config):
     show_welcome_screen: bool = True
     # When True, check for and pull GitHub updates on startup. Can cause issues or bad results; use with caution.
     auto_update_from_github: bool = False
+    show_model_download_result_dialog: bool = True
+    show_startup_health_dialog: bool = True
     logical_dpi: int = 0
     confirm_before_run: bool = True
     let_fntsize_flag: int = 0
@@ -507,6 +509,10 @@ class ProgramConfig(Config):
     region_merge_settings: Dict = field(default_factory=dict)  # Region merge tool dialog (persisted)
     context_menu: Dict = field(default_factory=dict)  # Canvas right-click: action key -> visible (default True)
     context_menu_pinned: List = field(default_factory=list)  # Action keys to show at top of right-click menu (order preserved)
+    context_run_macros: List = field(default_factory=lambda: [
+        {'id': 'detect_ocr_translate', 'label': 'Macro: Detect+OCR+Translate', 'mode': 1, 'detect_first': True},
+        {'id': 'ocr_translate_inpaint', 'label': 'Macro: OCR+Translate+Inpaint', 'mode': 2, 'detect_first': False},
+    ])
     huggingface_token: str = ''  # Optional: gated models + faster HF downloads (Xet). Prefer env HF_TOKEN to avoid storing in config.
     translator_last_model_by_provider: Dict = field(default_factory=dict)  # Section 9: last-used model per LLM provider
     # When True, the "Add Open in BallonsTranslator to context menu?" dialog has been shown once (first launch); don't show again.
@@ -605,7 +611,7 @@ CONTEXT_MENU_DEFAULT = {
 CONFIG_KEY_ORDER = (
     "module", "drawpanel", "global_fontformat", "recent_proj_list", "show_page_list",
     "imgtrans_paintmode", "imgtrans_textedit", "imgtrans_textblock", "mask_transparency", "original_transparency",
-    "open_recent_on_startup", "recent_proj_list_max", "show_welcome_screen", "auto_update_from_github", "logical_dpi", "confirm_before_run",
+    "open_recent_on_startup", "recent_proj_list_max", "show_welcome_screen", "auto_update_from_github", "show_model_download_result_dialog", "show_startup_health_dialog", "logical_dpi", "confirm_before_run",
     "let_fntsize_flag", "let_fntstroke_flag", "let_fntcolor_flag", "let_fnt_scolor_flag", "let_fnteffect_flag",
     "let_alignment_flag", "let_writing_mode_flag", "let_family_flag", "let_autolayout_flag", "let_uppercase_flag",
     "let_show_only_custom_fonts_flag", "let_textstyle_indep_flag", "text_styles_path", "default_text_style_name",
@@ -629,7 +635,7 @@ CONFIG_KEY_ORDER = (
     "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
-    "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned",
+    "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_run_macros",
     "huggingface_token", "translator_last_model_by_provider",
     "windows_context_menu_offered",
 )
@@ -751,6 +757,11 @@ def load_config(config_path: str = shared.CONFIG_PATH):
         pcfg.context_menu = dict(CONTEXT_MENU_DEFAULT)
     if not isinstance(getattr(pcfg, 'context_menu_pinned', None), list):
         pcfg.context_menu_pinned = []
+    if not isinstance(getattr(pcfg, 'context_run_macros', None), list):
+        pcfg.context_run_macros = [
+            {'id': 'detect_ocr_translate', 'label': 'Macro: Detect+OCR+Translate', 'mode': 1, 'detect_first': True},
+            {'id': 'ocr_translate_inpaint', 'label': 'Macro: OCR+Translate+Inpaint', 'mode': 2, 'detect_first': False},
+        ]
     # Ensure all shortcut keys exist (merge defaults for any new action)
     try:
         from utils.shortcuts import get_default_shortcuts
@@ -938,3 +949,22 @@ def save_text_styles(raise_exception = False):
     os.replace(tmp_save_tgt, pcfg.text_styles_path)
     LOGGER.info('Text style saved')
     return True
+
+
+def parse_context_run_macros(raw: str):
+    import json
+    data = json.loads((raw or '').strip() or '[]')
+    if not isinstance(data, list):
+        raise ValueError('Run macros must be a JSON list.')
+    norm = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f'Run macro #{i+1} must be an object.')
+        label = str(item.get('label', '')).strip()
+        if not label:
+            raise ValueError(f'Run macro #{i+1} missing label.')
+        mode = int(item.get('mode', 1))
+        detect_first = bool(item.get('detect_first', False))
+        mid = str(item.get('id', f'macro_{i+1}')).strip()
+        norm.append({'id': mid, 'label': label, 'mode': mode, 'detect_first': detect_first})
+    return norm

--- a/utils/environment_doctor.py
+++ b/utils/environment_doctor.py
@@ -1,0 +1,23 @@
+"""Environment + dependency doctor checks."""
+from __future__ import annotations
+import importlib.util
+import os
+from typing import List, Tuple
+
+
+def _has(mod: str) -> bool:
+    try:
+        return importlib.util.find_spec(mod) is not None
+    except Exception:
+        return False
+
+
+def run_environment_doctor() -> List[Tuple[str, str, str]]:
+    checks: List[Tuple[str, str, str]] = []
+    checks.append(("python", "ok", os.sys.version.split()[0]))
+    for mod in ["torch", "qtpy", "cv2", "numpy", "PIL"]:
+        present = _has(mod)
+        checks.append((f"module:{mod}", "ok" if present else "warn", "installed" if present else "missing"))
+    hf = bool((os.environ.get("HF_TOKEN") or "").strip())
+    checks.append(("auth:huggingface", "ok" if hf else "warn", "token set" if hf else "HF_TOKEN not set"))
+    return checks

--- a/utils/proj_imgtrans.py
+++ b/utils/proj_imgtrans.py
@@ -110,6 +110,7 @@ class ProjImgTrans:
         self.inpainted_array: np.ndarray = None
         self.translation_glossary: List[Dict[str, str]] = []  # [{"source": "...", "target": "..."}]
         self.series_context_path: str = ""  # Folder or ID for cross-chapter consistency (e.g. urban_immortal_cultivator)
+        self.run_profiles: Dict[str, Dict] = {}  # project-local snapshots of selected run/module settings
         if directory is not None:
             self.load(directory)
 
@@ -189,6 +190,7 @@ class ProjImgTrans:
         self.translation_glossary = proj_dict.get('translation_glossary') or []
 
         self.series_context_path = (proj_dict.get('series_context_path') or "").strip()
+        self.run_profiles = proj_dict.get('run_profiles') or {}
 
         for p in self.pages:
             if p not in self._image_info:
@@ -247,6 +249,19 @@ class ProjImgTrans:
 
     def update_page_progress(self, pagename, code):
         self._ensure_image_info_entry(pagename)['finish_code'] |= code 
+
+    def add_triage_flags(self, pagename: str, idx_list: List[int]):
+        info = self._ensure_image_info_entry(pagename)
+        triage = info.setdefault('triage_flags', {})
+        for idx in idx_list or []:
+            triage[str(idx)] = 'open'
+
+    def mark_triage_reviewed(self, pagename: str, idx_list: List[int]):
+        info = self._ensure_image_info_entry(pagename)
+        triage = info.setdefault('triage_flags', {})
+        for idx in idx_list or []:
+            triage[str(idx)] = 'reviewed'
+
 
     def load_translation_from_txt(self, file_path: str):
         page_list = parse_txt_translation(file_path)
@@ -385,6 +400,8 @@ class ProjImgTrans:
             out['translation_glossary'] = self.translation_glossary
         if getattr(self, 'series_context_path', None):
             out['series_context_path'] = self.series_context_path
+        if getattr(self, 'run_profiles', None):
+            out['run_profiles'] = self.run_profiles
         return out
 
     def read_img(self, imgname: str) -> np.ndarray:

--- a/utils/shortcuts.py
+++ b/utils/shortcuts.py
@@ -51,6 +51,14 @@ SHORTCUT_SCHEMA: List[Tuple[str, str, str, str]] = [
     ("format.auto_fit_binary", "", "Format", "Auto fit font size (binary search)"),
     ("format.balloon_shape_auto", "", "Format", "Set balloon shape to Auto"),
     ("format.resize_to_fit_content", "", "Format", "Resize to fit content"),
+    # Context / Run shortcuts
+    ("run.detect_page", "", "Run", "Detect text on page"),
+    ("run.translate", "", "Run", "Translate"),
+    ("run.ocr", "", "Run", "OCR"),
+    ("run.ocr_translate", "", "Run", "OCR and translate"),
+    ("run.ocr_translate_inpaint", "", "Run", "OCR, translate and inpaint"),
+    ("run.macro_detect_ocr_translate", "", "Run", "Macro: Detect+OCR+Translate"),
+    ("run.macro_ocr_translate_inpaint", "", "Run", "Macro: OCR+Translate+Inpaint"),
     # Drawing panel tools
     ("draw.hand", "H", "Drawing", "Hand tool (pan)"),
     ("draw.inpaint", "J", "Drawing", "Inpaint brush"),
@@ -75,3 +83,37 @@ def get_shortcut(action_id: str, shortcuts_override: Optional[Dict[str, str]] = 
     if shortcuts_override and action_id in shortcuts_override:
         return shortcuts_override[action_id] or defaults.get(action_id, "")
     return defaults.get(action_id, "")
+
+
+def find_shortcut_conflicts(shortcuts_map: Dict[str, str]) -> Dict[str, List[str]]:
+    """Return key -> [action_ids] for duplicate non-empty shortcuts."""
+    key_to_actions: Dict[str, List[str]] = {}
+    for action_id, key in (shortcuts_map or {}).items():
+        k = (key or "").strip()
+        if not k:
+            continue
+        key_to_actions.setdefault(k, []).append(action_id)
+    return {k: v for k, v in key_to_actions.items() if len(v) > 1}
+
+
+def classify_shortcut_conflicts(shortcuts_map: Dict[str, str]) -> Dict[str, Dict[str, List[str]]]:
+    """Return {'hard': {key:[ids]}, 'alias': {key:[ids]}}."""
+    conflicts = find_shortcut_conflicts(shortcuts_map)
+    out = {'hard': {}, 'alias': {}}
+    for key, ids in conflicts.items():
+        base = {i.replace('_alt', '') for i in ids}
+        if len(base) == 1:
+            out['alias'][key] = ids
+        else:
+            out['hard'][key] = ids
+    return out
+
+
+def auto_resolve_shortcut_conflicts(shortcuts_map: Dict[str, str]) -> Dict[str, str]:
+    """Keep first action for each duplicate key, clear others."""
+    out = dict(shortcuts_map or {})
+    conflicts = find_shortcut_conflicts(out)
+    for _key, ids in conflicts.items():
+        for aid in ids[1:]:
+            out[aid] = ''
+    return out

--- a/utils/translation_review.py
+++ b/utils/translation_review.py
@@ -1,0 +1,44 @@
+"""Lightweight translation QA helpers: glossary extraction and guardrails."""
+from __future__ import annotations
+import re
+from collections import Counter
+from typing import Dict, List, Tuple
+
+_TOKEN_RE = re.compile(r"[A-Za-z][A-Za-z0-9_'-]{2,}")
+
+
+def extract_glossary_candidates(src_texts: List[str], translated_texts: List[str] | None = None, min_freq: int = 2) -> List[Dict[str, str]]:
+    """Heuristic term miner (LLM-free fallback) for project glossary bootstrapping."""
+    c = Counter()
+    # translated_texts reserved for future bilingual scoring; kept for API stability.
+    for t in src_texts or []:
+        c.update(_TOKEN_RE.findall(t or ""))
+    out = []
+    for tok, freq in c.most_common():
+        if freq < min_freq:
+            break
+        out.append({"source": tok, "target": ""})
+    return out
+
+
+def check_translation_guardrails(
+    source: str,
+    translated: str,
+    glossary: List[Dict[str, str]] | None = None,
+    max_len_ratio: float = 1.8,
+) -> List[str]:
+    issues: List[str] = []
+    s = (source or "").strip()
+    t = (translated or "").strip()
+    if s and t and s == t:
+        issues.append("Untranslated source carry-over detected.")
+    if s and t and len(t) > max(1, int(len(s) * max_len_ratio)):
+        issues.append(f"Translation may be overlong for bubble layout (len ratio > {max_len_ratio:.1f}).")
+    if glossary:
+        gl_map = {str(g.get('source', '')).strip(): str(g.get('target', '')).strip() for g in glossary if isinstance(g, dict)}
+        for gs, gt in gl_map.items():
+            if not gs or not gt:
+                continue
+            if gs in s and gt not in t:
+                issues.append(f"Glossary mismatch: expected '{gt}' for source term '{gs}'.")
+    return issues


### PR DESCRIPTION
### Motivation

- Add lightweight QA/triage and productivity features (context-run macros, OCR triage, translation QA, run profile snapshots) and make some startup/popups configurable. 
- Improve keyboard shortcut management with import/export and conflict detection/resolution. 
- Provide simple environment/dependency checks for easier troubleshooting and surface them in the UI.

### Description

- Added canvas context-menu support for user-defined run macros and keyboard shortcuts for run actions via `context_run_macros`, `get_shortcut`, and hooks in `ui/canvas.py`; added parsing with `parse_context_run_macros` in `utils/config.py`.  
- Implemented OCR triage workflow and translation QA helpers with `utils/translation_review.py`, `ui/ocr_triage_dialog.py`, new `ProjImgTrans` methods `add_triage_flags` and `mark_triage_reviewed`, and MainWindow handlers (`on_open_ocr_triage_current_page`, `on_add_selected_to_triage`, `on_mark_selected_triage_reviewed`, `on_translation_qa_report_current_page`).  
- Added `utils/environment_doctor.py` and wired an Environment Doctor command into menus and `MainWindow.on_environment_doctor`.  
- Extended the shortcuts dialog (`ui/shortcuts_dialog.py`) to support export/import JSON, find/classify/auto-resolve conflicts (new functions in `utils/shortcuts.py`), and a key-jump UI; added default run-related shortcut IDs in `utils/shortcuts.py`.  
- Added context menu configuration enhancements: JSON-editable run macros, quick profiles for pinned items, and pin-to-top management in `ui/context_menu_config_dialog.py` and `ui/canvas.py`.  
- Added new UI actions in `ui/mainwindowbars.py` and connected them in `ui/mainwindow.py`; added settings and config fields `show_model_download_result_dialog`, `show_startup_health_dialog`, and default `context_run_macros` in `utils/config.py`.  
- Minor startup flow tweak in `launch.py` to force showing the welcome/onboarding screen after first-run package selection.  
- New unit tests to cover parsing and behavior: `tests/test_context_run_macros_default.py`, `tests/test_context_run_macros_parse.py`, `tests/test_environment_doctor.py`, `tests/test_proj_run_profiles.py`, `tests/test_proj_triage_flags.py`, `tests/test_shortcut_run_ids.py`, `tests/test_shortcuts_conflicts.py`, and `tests/test_translation_review.py`.

### Testing

- Ran the unit tests in `tests/` with `pytest -q tests` which executed the new tests for macros parsing, environment doctor, proj triage/profile functions, shortcut conflict logic, and translation QA helpers, and all tests passed.  
- Exercised the new config parsing and UI flows in a local dev build to validate shortcut import/export and JSON macros parsing (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f49519f61c832caa5b93f85e3dccab)