### PR TITLE
Sync all locale .ts catalogs and add multi-locale update script

### DIFF
--- a/scripts/update_translation.py
+++ b/scripts/update_translation.py
@@ -1,32 +1,67 @@
 """
-Update Qt translation .ts file from UI sources.
+Update Qt translation .ts files from UI sources.
+
 Run from project root. Requires: pylupdate6 (PyQt6) or pylupdate5 (PyQt5).
-Generates translate/<locale>.ts (e.g. zh_CN.ts) from ui/**/*.py.
-Compile to .qm with: lrelease translate/zh_CN.ts
+By default, updates every existing `translate/*.ts` locale file so non-English
+locales stay in sync when new `self.tr(...)` strings are added in UI code.
+
+Usage:
+  python scripts/update_translation.py                # update all translate/*.ts
+  python scripts/update_translation.py --locale zh_CN # update only one locale
+
+Compile to .qm with: lrelease translate/<locale>.ts
 """
 import os
 import os.path as osp
+import argparse
 from glob import glob
 
-from qtpy.QtCore import QLocale
-SYSLANG = QLocale.system().name()
+
+def _run_update(program_dir: str, ui_list: str, ts_path: str) -> int:
+    cmd = f'pylupdate6 --no-obsolete --verbose {ui_list} -ts "{ts_path}"'
+    try:
+        import subprocess
+        result = subprocess.run(cmd, shell=True, cwd=program_dir)
+        if result.returncode == 0:
+            return 0
+    except Exception:
+        pass
+
+    cmd5 = f'pylupdate5 --no-obsolete --verbose {ui_list} -ts "{ts_path}"'
+    return os.system(cmd5)
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update Qt translation ts files from ui/**/*.py')
+    parser.add_argument('--locale', default='', help='Locale to update (e.g. zh_CN). Default: all translate/*.ts')
+    args = parser.parse_args()
+
     program_dir = osp.dirname(osp.dirname(osp.abspath(__file__)))
     translate_dir = osp.join(program_dir, 'translate')
-    translate_path = osp.join(translate_dir, SYSLANG + '.ts')
     ui_files = (
         glob(osp.join(program_dir, 'ui', '*.py')) +
         glob(osp.join(program_dir, 'ui', '**', '*.py'))
     )
     ui_list = ' '.join(f'"{f}"' for f in sorted(set(ui_files)))
-    cmd = f'pylupdate6 -verbose {ui_list} -ts "{translate_path}"'
-    try:
-        import subprocess
-        subprocess.run(cmd, shell=True, cwd=program_dir)
-    except Exception:
-        cmd5 = f'pylupdate5 -verbose {ui_list} -ts "{translate_path}"'
-        os.system(cmd5)
-    print(f'target language: {SYSLANG}')
-    print(f'Saved to {translate_path}')
-    print('Compile with: lrelease translate/' + SYSLANG + '.ts')
+
+    if args.locale:
+        targets = [osp.join(translate_dir, f'{args.locale}.ts')]
+    else:
+        targets = sorted(glob(osp.join(translate_dir, '*.ts')))
+
+    if not targets:
+        raise SystemExit('No .ts files found in translate/.')
+
+    failures = []
+    for ts_path in targets:
+        rc = _run_update(program_dir, ui_list, ts_path)
+        locale = osp.splitext(osp.basename(ts_path))[0]
+        if rc == 0:
+            print(f'Updated: {ts_path}')
+            print(f'Compile with: lrelease translate/{locale}.ts')
+        else:
+            failures.append((ts_path, rc))
+
+    if failures:
+        for ts_path, rc in failures:
+            print(f'Failed: {ts_path} (exit={rc})')
+        raise SystemExit(1)

--- a/translate/es_MX.ts
+++ b/translate/es_MX.ts
@@ -2,1497 +2,8785 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="es_MX" sourcelanguage="en_US">
 <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="632"/>
+        <location filename="../ui/mainwindowbars.py" line="1566" />
         <source>Text Detector</source>
         <translation>Detector de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="633"/>
+        <location filename="../ui/mainwindowbars.py" line="1567" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="634"/>
+        <location filename="../ui/mainwindowbars.py" line="1568" />
         <source>Inpaint</source>
         <translation>Relleno inteligente</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="640"/>
-        <source>Enable/disable paint mode</source>
-        <translation>Activar/desactivar modo pintura</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">Ejecutar</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="644"/>
-        <source>Enable/disable text edit mode</source>
-        <translation>Activar/desactivar modo edición de texto</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="650"/>
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
         <source>Original image opacity</source>
         <translation>Opacidad de imagen original</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="654"/>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
         <source>Text layer opacity</source>
         <translation>Opacidad de capa de texto</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="759"/>
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1073" />
         <source>Copy</source>
         <translation>Copiar</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="761"/>
+        <location filename="../ui/canvas.py" line="1078" />
         <source>Paste</source>
         <translation>Pegar</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="763"/>
-        <source>Delete</source>
-        <translation>Eliminar</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="765"/>
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1091" />
         <source>Copy source text</source>
         <translation>Copiar texto original</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="767"/>
+        <location filename="../ui/canvas.py" line="1096" />
         <source>Paste source text</source>
         <translation>Pegar texto original</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="769"/>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
         <source>Delete and Recover removed text</source>
         <translation>Borrar y recuperar texto eliminado</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="774"/>
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">A mayúsculas</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
         <source>Apply font formatting</source>
         <translation>Aplicar formato de fuente</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="775"/>
+        <location filename="../ui/canvas.py" line="1275" />
         <source>Auto layout</source>
         <translation>Diseño automático</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="776"/>
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
         <source>Reset Angle</source>
         <translation>Restablecer ángulo</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="777"/>
+        <location filename="../ui/canvas.py" line="1326" />
         <source>Squeeze</source>
         <translation>Comprimir</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="779"/>
-        <source>translate</source>
-        <translation>traducir</translation>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">Ejecutar</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="780"/>
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished">Traducir</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="781"/>
+        <location filename="../ui/canvas.py" line="1357" />
         <source>OCR and translate</source>
         <translation>OCR y traducir</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="782"/>
+        <location filename="../ui/canvas.py" line="1362" />
         <source>OCR, translate and inpaint</source>
         <translation>OCR, traducir y rellenar</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="783"/>
-        <source>inpaint</source>
-        <translation>inpaint</translation>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Rellenar</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-        <location filename="../ui/configpanel.py" line="351"/>
+        <location filename="../ui/configpanel.py" line="410" />
         <source>DL Module</source>
         <translation>Módulo DL</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="352"/>
+        <location filename="../ui/configpanel.py" line="411" />
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="354"/>
+        <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>Detección de texto</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="394"/>
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="356"/>
+        <location filename="../ui/configpanel.py" line="415" />
         <source>Inpaint</source>
         <translation>Relleno inteligente</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="357"/>
+        <location filename="../ui/configpanel.py" line="416" />
         <source>Translator</source>
         <translation>Traductor</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="358"/>
+        <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>Inicio</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="359"/>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="419" />
         <source>Typesetting</source>
         <translation>Composición tipográfica</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="360"/>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="421" />
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="361"/>
+        <location filename="../ui/configpanel.py" line="422" />
         <source>SalaDict</source>
         <translation>SalaDict</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand</source>
         <translation>Cargar modelos bajo demanda</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand to save memory.</source>
         <translation>Carga modelos bajo demanda para ahorrar memoria.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN</source>
         <translation>Vaciar caché después de EJECUTAR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN to save memory.</source>
         <translation>Vacíar la caché después de EJECUTAR para ahorrar memoria.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="384"/>
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="518" />
         <source>Unload All Models</source>
         <translation>Descargar todos los modelos</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="389"/>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
         <source>Detector</source>
         <translation>Detector</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="398"/>
+        <location filename="../ui/configpanel.py" line="626" />
         <source>Inpainter</source>
         <translation>Inpainter</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="406"/>
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
         <source>Reopen last project on startup</source>
         <translation>Reabrir el último proyecto al iniciar</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="410"/>
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
         <source>decide by program</source>
         <translation>decidir por programa</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="411"/>
+        <location filename="../ui/configpanel.py" line="840" />
         <source>use global setting</source>
         <translation>utilizar configuración global</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="421"/>
+        <location filename="../ui/configpanel.py" line="850" />
         <source>Font Size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="425"/>
+        <location filename="../ui/configpanel.py" line="854" />
         <source>Stroke Size</source>
         <translation>Tamaño de trazo</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="429"/>
+        <location filename="../ui/configpanel.py" line="858" />
         <source>Font Color</source>
         <translation>Color de fuente</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="432"/>
+        <location filename="../ui/configpanel.py" line="861" />
         <source>Stroke Color</source>
         <translation>Color de trazo</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="436"/>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
         <source>Effect</source>
         <translation>Efecto</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="439"/>
+        <location filename="../ui/configpanel.py" line="898" />
         <source>Alignment</source>
         <translation>Alineamiento</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="443"/>
+        <location filename="../ui/configpanel.py" line="902" />
         <source>Writing-mode</source>
         <translation>Modo escritura</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Keep existing</source>
         <translation>Mantener existentes</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Always use global setting</source>
         <translation>Utilizar siempre la configuración global</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Font Family</source>
         <translation>Familia de fuentes</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452"/>
+        <location filename="../ui/configpanel.py" line="911" />
         <source>Auto layout</source>
         <translation>Diseño automático</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452"/>
-        <source>Split translation into multi-lines according to the extracted balloon region.</source>
-        <translation>Dividir la traducción en multilíneas según la región del globo extraída.</translation>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="456"/>
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
         <source>To uppercase</source>
         <translation>A mayúsculas</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="459"/>
+        <location filename="../ui/configpanel.py" line="1108" />
         <source>Independent text styles for each projects</source>
         <translation>Estilos de texto independientes para cada proyecto</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="462"/>
+        <location filename="../ui/configpanel.py" line="1111" />
         <source>Show only custom fonts</source>
         <translation>Mostrar sólo fuentes personalizadas</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="466"/>
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
         <source>Result image format</source>
         <translation>Formato de la imagen resultante</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="471"/>
+        <location filename="../ui/configpanel.py" line="1128" />
         <source>Quality</source>
         <translation>Calidad</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="478"/>
-        <source>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md&quot;&gt;Installation guide&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/blob/dev/doc/saladict_es.md&quot;&gt;Guía de instalación&lt;/a&gt;</translation>
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="482"/>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/blob/dev/doc/saladict_es.md"&gt;Guía de instalación&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
         <source>Show mini menu when selecting text.</source>
         <translation>Mostrar mini menú al seleccionar texto.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="488"/>
+        <location filename="../ui/configpanel.py" line="1160" />
         <source>Shortcut</source>
         <translation>Acceso directo</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="491"/>
+        <location filename="../ui/configpanel.py" line="1163" />
         <source>Search Engines</source>
         <translation>Motores de búsqueda</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="353"/>
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
         <source>Mask Opacity</source>
         <translation>Opacidad de la máscara</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="100"/>
+        <location filename="../ui/io_thread.py" line="118" />
         <source>Export as doc...</source>
         <translation>Exportar como documento...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="106"/>
+        <location filename="../ui/io_thread.py" line="124" />
         <source>Overwrite </source>
         <translation>Sobrescribir </translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-        <location filename="../ui/text_panel.py" line="262"/>
+        <location filename="../ui/text_panel.py" line="275" />
         <source>Font Family</source>
         <translation>Familia de fuentes</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="267"/>
+        <location filename="../ui/text_panel.py" line="280" />
         <source>Font Size</source>
         <translation>Tamaño de fuente</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="269"/>
+        <location filename="../ui/text_panel.py" line="282" />
         <source>Change font size</source>
         <translation>Cambiar el tamaño de Fuente</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="279"/>
+        <location filename="../ui/text_panel.py" line="292" />
         <source>Change line spacing</source>
         <translation>Cambiar el interlineado</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="283"/>
+        <location filename="../ui/text_panel.py" line="296" />
         <source>Change font color</source>
         <translation>Cambiar color de fuente</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="300"/>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
         <source>Change stroke width</source>
         <translation>Cambiar anchura de trazo</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="303"/>
+        <location filename="../ui/text_panel.py" line="364" />
         <source>Stroke</source>
         <translation>Trazo</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="312"/>
+        <location filename="../ui/text_panel.py" line="373" />
         <source>Change stroke color</source>
         <translation>Cambiar color del trazo</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="325"/>
+        <location filename="../ui/text_panel.py" line="386" />
         <source>Change letter spacing</source>
         <translation>Cambiar interlineado de las letras</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="339"/>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">Opacidad</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
         <source>Global Font Format</source>
         <translation>Formato de fuente global</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="348"/>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
         <source>Advanced Text Format</source>
         <translation>Formato de texto avanzado</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Unfold</source>
         <translation>Desplegar</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Fold</source>
         <translation>Plegar</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="370"/>
+        <location filename="../ui/text_panel.py" line="462" />
         <source>Source</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="371"/>
+        <location filename="../ui/text_panel.py" line="463" />
         <source>Translation</source>
         <translation>Traducción</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="189"/>
+        <location filename="../ui/global_search_widget.py" line="192" />
         <source>Replace...</source>
         <translation>Reemplazar...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="195"/>
+        <location filename="../ui/global_search_widget.py" line="198" />
         <source>Replace all occurrences?</source>
         <translation>¿Reemplazar todas las ocurrencias?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="305"/>
+        <location filename="../ui/global_search_widget.py" line="308" />
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="308"/>
+        <location filename="../ui/global_search_widget.py" line="311" />
         <source>No results found. </source>
         <translation>No se han encontrado resultados.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="309"/>
+        <location filename="../ui/global_search_widget.py" line="312" />
         <source>Document changed. Press Enter to re-search.</source>
         <translation>Documento modificado. Pulse Intro para volver a buscar.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="310"/>
+        <location filename="../ui/global_search_widget.py" line="313" />
         <source>Found results: </source>
         <translation>Resultados encontrados: </translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="316"/>
+        <location filename="../ui/global_search_widget.py" line="319" />
         <source>Match Case</source>
         <translation>Distinguir mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="321"/>
+        <location filename="../ui/global_search_widget.py" line="324" />
         <source>Match Whole Word</source>
         <translation>Coincidir solo palabras completas</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="326"/>
+        <location filename="../ui/global_search_widget.py" line="329" />
         <source>Use Regular Expression</source>
         <translation>Utilizar expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Translation</source>
         <translation>Traducción</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="333"/>
+        <location filename="../ui/global_search_widget.py" line="336" />
         <source> in</source>
         <translation> en</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="336"/>
+        <location filename="../ui/global_search_widget.py" line="339" />
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="339"/>
+        <location filename="../ui/global_search_widget.py" line="342" />
         <source>Replace All</source>
         <translation>Reemplazar todo</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="341"/>
+        <location filename="../ui/global_search_widget.py" line="344" />
         <source>Replace All and Re-render all pages</source>
         <translation>Reemplazar todo y volver a renderizar todas las páginas</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="382"/>
+        <location filename="../ui/global_search_widget.py" line="385" />
         <source>Replace...</source>
         <translation>Reemplazar...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="487"/>
-        <source>Replace all occurrences re-render all pages? It can&apos;t be undone.</source>
+        <location filename="../ui/global_search_widget.py" line="490" />
+        <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>¿Sustituir todas las ocurrencias y volver a renderizar todas las páginas? No se puede deshacer.</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ImgtransProgressMessageBox</name>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="183" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="184" />
+        <source>OCR: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="185" />
+        <source>Inpainting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="186" />
+        <source>Translating: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="389"/>
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
         <source>OCR Failed.</source>
         <translation>OCR fallido.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="369"/>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation type="unfinished">Error de traducción.</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1022" />
         <source>Text Detection Failed.</source>
         <translation>Detección de texto fallida.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="450"/>
+        <location filename="../ui/module_manager.py" line="1526" />
         <source>Inpainting Failed.</source>
         <translation>Relleno fallido.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="136"/>
+        <location filename="../ui/io_thread.py" line="154" />
         <source>Import doc...</source>
         <translation>Importar documento...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="143"/>
+        <location filename="../ui/io_thread.py" line="161" />
         <source>Import *.docx</source>
         <translation>Importar *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="426"/>
+        <location filename="../ui/module_parse_widgets.py" line="533" />
         <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
         <translation>Dejar que el programa decida si es necesario utilizar el método de relleno seleccionado.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>InpaintPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="74"/>
+        <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>Grosor</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="79"/>
+        <location filename="../ui/drawingpanel.py" line="80" />
         <source>Shape</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="83" />
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="84" />
         <source>Rectangle</source>
         <translation>Rectángulo</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="92"/>
+        <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
         <source>Inpainter</source>
         <translation>Inpainter</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="122"/>
+        <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>Relleno fallido.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="25" />
         <source>Keyword</source>
         <translation>Palabra clave</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="26" />
         <source>Substitution</source>
         <translation>Sustitución</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="27" />
         <source>Use regex</source>
         <translation>Utilizar expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="28" />
         <source>Case sensitive</source>
         <translation>Distinguir entre mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="35"/>
+        <location filename="../ui/keywordsubwidget.py" line="35" />
         <source>New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="37"/>
+        <location filename="../ui/keywordsubwidget.py" line="37" />
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="77"/>
+        <location filename="../ui/mainwindowbars.py" line="104" />
         <source>Global Search (Ctrl+G)</source>
         <translation>Búsqueda global (Ctrl+G)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="88"/>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
         <translation>Abrir carpeta ...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="92"/>
+        <location filename="../ui/mainwindowbars.py" line="132" />
         <source>Open Project ... *.json</source>
         <translation>Abrir proyecto ... *.json</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="95"/>
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
         <source>Save Project</source>
         <translation>Guardar proyecto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="99"/>
+        <location filename="../ui/mainwindowbars.py" line="155" />
         <source>Export as Doc</source>
         <translation>Exportar como documento</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="101"/>
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
         <source>Import from Doc</source>
         <translation>Importar desde Documento</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="104"/>
-        <source>Export soure text as TXT</source>
-        <translation>Exportar texto fuente como TXT</translation>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="106"/>
+        <location filename="../ui/mainwindowbars.py" line="165" />
         <source>Export translation as TXT</source>
         <translation>Exportar traducción como TXT</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="109"/>
-        <source>Export soure text as markdown</source>
-        <translation>Exportar texto fuente como markdown</translation>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="111"/>
+        <location filename="../ui/mainwindowbars.py" line="170" />
         <source>Export translation as markdown</source>
         <translation>Exportar traducción como markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="114"/>
+        <location filename="../ui/mainwindowbars.py" line="173" />
         <source>Import translation from TXT/markdown</source>
         <translation>Importar traducción desde TXT/markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="117"/>
+        <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>Abrir reciente</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="143"/>
-        <source>RUN</source>
-        <translation>RUN</translation>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="237"/>
+        <location filename="../ui/mainwindowbars.py" line="303" />
         <source>Select Directory</source>
         <translation>Seleccionar directorio</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="244"/>
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>Importar *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="202"/>
+        <location filename="../ui/mainwindow.py" line="465" />
         <source>Keyword substitution for source text</source>
         <translation>Sustitución del texto original por palabras clave</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="206"/>
+        <location filename="../ui/mainwindow.py" line="469" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Sustitución de palabras clave en textos fuente de traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="210"/>
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>Sustitución de palabras clave para la traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="481"/>
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
         <source>Failed to load project </source>
         <translation>Error al cargar el proyecto </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="500"/>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
         <source>Failed to load project from</source>
         <translation>Error al cargar el proyecto desde</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="552"/>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
         <source>Restart to apply changes? 
 </source>
         <translation>¿Reiniciar para aplicar los cambios? 
 </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192"/>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">Resumen: descargados {0}, fallidos {1}, omitidos {2}.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">Abrir Administrar modelos</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation type="unfinished">Descarga de paquetes de modelos completada</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">Algunos paquetes de modelos fallaron. Elementos fallidos: {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation type="unfinished">Descarga de paquetes de modelos parcialmente completada</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">El modo solo local de primer inicio está activo. Usa Herramientas → Administrar modelos para importar/descargar modelos, o edita config/config.json para habilitar paquetes y reinicia.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">Descarga completada parcialmente.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">Descarga completa. Valores predeterminados actualizados.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation type="unfinished">Se han descargado los paquetes de modelos. Módulos aplicados:
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>unsaved</source>
         <translation>sin guardar</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192"/>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>saved</source>
         <translation>Guardado</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1226"/>
+        <location filename="../ui/mainwindow.py" line="3258" />
         <source>Saving image...</source>
         <translation>Guardando imagen...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239"/>
+        <location filename="../ui/mainwindow.py" line="3297" />
         <source>Confirmation</source>
         <translation>Confirmación</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239"/>
-        <source>Are you sure to run image translation again?
-All existing translation results will be cleared!</source>
-        <translation>¿Está seguro de volver a ejecutar la traducción de imágenes?
-¡Todos los resultados de traducción existentes se borrarán!</translation>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1287"/>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">Ejecutar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
         <source>Import Text Styles</source>
         <translation>Importar estilos de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1297"/>
-        <source>Failed to load from {p}</source>
-        <translation>Error al cargar desde {p}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1301"/>
+        <location filename="../ui/mainwindow.py" line="3417" />
         <source>Save Text Styles</source>
         <translation>Guardar estilos de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1318"/>
-        <source>Failed save to {savep}</source>
-        <translation>Error al guardar en {savep}</translation>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1344"/>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
         <source>Text file exported to </source>
         <translation>Archivo de texto exportado a </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1346"/>
+        <location filename="../ui/mainwindow.py" line="3565" />
         <source>Failed to export as TEXT file</source>
         <translation>Error al exportar como archivo TEXT</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1352"/>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
         <source>Import *.md/*.txt</source>
         <translation>Importar *.md/*.txt</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1364"/>
+        <location filename="../ui/mainwindow.py" line="3604" />
         <source>Translation imported and matched successfully.</source>
         <translation>Traducción importada y coincidida con éxito.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1366"/>
-        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from &quot;export TXT/markdown&quot;</source>
-        <translation>El archivo txt importado no coincide completamente con el proyecto actual, por favor asegúrate de que el archivo fuente esté estructurado como los resultados de &quot;exportar TXT/markdown&quot;</translation>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
+        <translation>El archivo txt importado no coincide completamente con el proyecto actual, por favor asegúrate de que el archivo fuente esté estructurado como los resultados de "exportar TXT/markdown"</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1368"/>
+        <location filename="../ui/mainwindow.py" line="3608" />
         <source>Missing pages: </source>
         <translation>Páginas que faltan: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1371"/>
+        <location filename="../ui/mainwindow.py" line="3611" />
         <source>Unexpected pages: </source>
         <translation>Páginas inesperadas: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1374"/>
+        <location filename="../ui/mainwindow.py" line="3614" />
         <source>Unmatched pages: </source>
         <translation>Páginas no coincidentes: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1380"/>
+        <location filename="../ui/mainwindow.py" line="3625" />
         <source>Failed to import translation from </source>
         <translation>Error al importar la traducción de </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1404"/>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
         <source>Export to </source>
         <translation>Exportar a </translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">Buscar en</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">Importar directorio local de modelos...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
+        <source>Select local model directory</source>
+        <translation type="unfinished">Seleccionar directorio local de modelos</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">Importar modelos locales</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">Selecciona manualmente paquetes de bajo nivel en lugar de usar un preajuste.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">Selección manual de paquetes</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
+        <source>Skip all downloads (local-only)</source>
+        <translation type="unfinished">Omitir todas las descargas (solo local)</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">No descargar ningún paquete de modelos ahora. Usar solo módulos/archivos ya locales.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">Paquete base no seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleManager</name>
     <message>
-        <location filename="../ui/module_manager.py" line="858"/>
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
         <source>Set Inpainter...</source>
         <translation>Establecer rellenador...</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>OCRConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="451"/>
+        <location filename="../ui/module_parse_widgets.py" line="830" />
         <source>Delete and restore region where OCR return empty string.</source>
         <translation>Borrar y restaurar la región donde el OCR devuelve una cadena vacía.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">Traducción</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageListView</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="51"/>
+        <location filename="../ui/mainwindow.py" line="88" />
         <source>Reveal in File Explorer</source>
         <translation>Revelar en el Explorador de archivos</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
-        <location filename="../ui/page_search_widget.py" line="207"/>
+        <location filename="../ui/page_search_widget.py" line="207" />
         <source>Find</source>
         <translation>Buscar</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="210"/>
+        <location filename="../ui/page_search_widget.py" line="210" />
         <source>No result</source>
         <translation>Ningún resultado</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="216"/>
+        <location filename="../ui/page_search_widget.py" line="216" />
         <source>Previous Match (Shift+Enter)</source>
         <translation>Coincidencia anterior (Shift+Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="221"/>
+        <location filename="../ui/page_search_widget.py" line="221" />
         <source>Next Match (Enter)</source>
         <translation>Siguiente coincidencia (Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="225"/>
+        <location filename="../ui/page_search_widget.py" line="225" />
         <source>Match Case</source>
         <translation>Distinguir mayúsculas y minúsculas</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="230"/>
+        <location filename="../ui/page_search_widget.py" line="230" />
         <source>Match Whole Word</source>
         <translation>Coincidir solo palabras completas</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="235"/>
+        <location filename="../ui/page_search_widget.py" line="235" />
         <source>Use Regular Expression</source>
         <translation>Utilizar expresiones regulares</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Translation</source>
         <translation>Traducción</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Source</source>
         <translation>fuente</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="242"/>
+        <location filename="../ui/page_search_widget.py" line="242" />
         <source>Range</source>
         <translation>Rango</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="249"/>
+        <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>Reemplazar</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="253"/>
+        <location filename="../ui/page_search_widget.py" line="253" />
         <source>Replace All</source>
         <translation>Reemplazar todo</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="290"/>
+        <location filename="../ui/page_search_widget.py" line="290" />
         <source>Close (Escape)</source>
         <translation>Cerrar (Escape)</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PenConfigPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="136"/>
+        <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="137"/>
+        <location filename="../ui/drawingpanel.py" line="153" />
         <source>Alpha</source>
         <translation>Alfa</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="145"/>
+        <location filename="../ui/drawingpanel.py" line="161" />
         <source>Thickness</source>
         <translation>Grosor</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="150"/>
+        <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="169" />
         <source>Circle</source>
         <translation>Círculo</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="170" />
         <source>Rectangle</source>
         <translation>Rectángulo</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="197"/>
+        <location filename="../ui/drawingpanel.py" line="214" />
         <source>Dilate</source>
         <translation>Dilatar</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 1</source>
-        <translation>método 1</translation>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 2</source>
-        <translation>método 2</translation>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>Use Existing Mask</source>
-        <translation>Utilizar máscara existente</translation>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="210"/>
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">Rectángulo</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="211"/>
+        <location filename="../ui/drawingpanel.py" line="241" />
         <source>run inpainting automatically.</source>
         <translation>ejecutar el relleno automáticamente.</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="213"/>
+        <location filename="../ui/drawingpanel.py" line="243" />
         <source>Inpaint</source>
         <translation>Rellenar</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="214"/>
+        <location filename="../ui/drawingpanel.py" line="244" />
         <source>Space</source>
         <translation>Espacio</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="216"/>
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="217"/>
+        <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="224"/>
+        <location filename="../ui/drawingpanel.py" line="258" />
         <source>Inpainter</source>
         <translation>Inpainter</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
-        <location filename="../ui/textedit_area.py" line="30"/>
+        <location filename="../ui/textedit_area.py" line="30" />
         <source>Search selected text on Internet</source>
         <translation>Buscar el texto seleccionado en Internet</translation>
     </message>
     <message>
-        <location filename="../ui/textedit_area.py" line="36"/>
+        <location filename="../ui/textedit_area.py" line="36" />
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>Buscar texto seleccionado en SalaDict, ver guía de instalación en configpanel</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished">Acceso directo</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">Traducción</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">Traductor</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished">Guardar</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextAdvancedFormatPanel</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146"/>
+        <location filename="../ui/text_advanced_format.py" line="170" />
         <source>Proportional</source>
         <translation>Proporcional</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146"/>
+        <location filename="../ui/text_advanced_format.py" line="171" />
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="156"/>
+        <location filename="../ui/text_advanced_format.py" line="175" />
         <source>Line Spacing Type</source>
         <translation>Tipo de interlineado</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="162"/>
+        <location filename="../ui/text_advanced_format.py" line="182" />
         <source>Set Text Opacity</source>
         <translation>Fijar opacidad del texto</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="164"/>
+        <location filename="../ui/text_advanced_format.py" line="184" />
         <source>Opacity</source>
         <translation>Opacidad</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="175"/>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
         <source>Shadow</source>
         <translation>Sombra</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextDetectConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="442"/>
+        <location filename="../ui/module_parse_widgets.py" line="615" />
         <source>Keep Existing Lines</source>
         <translation>Mantener líneas existentes</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextGradientGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="83"/>
+        <location filename="../ui/text_advanced_format.py" line="91" />
         <source>Gradient</source>
         <translation>Degradado</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="87"/>
+        <location filename="../ui/text_advanced_format.py" line="96" />
         <source>Start Color</source>
         <translation>Color inicial</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="93"/>
+        <location filename="../ui/text_advanced_format.py" line="100" />
         <source>End Color</source>
         <translation>Color final</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="98"/>
+        <location filename="../ui/text_advanced_format.py" line="102" />
         <source>Enable</source>
         <translation>Habilitar</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="102"/>
-        <source>Set Gradient Angle</source>
-        <translation>Fijar ángulo de degradado</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="104"/>
-        <source>Angle</source>
-        <translation>Ángulo</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="112"/>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="112" />
         <source>Set Gradient Size</source>
         <translation>Establecer tamaño de degradado</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="114"/>
+        <location filename="../ui/text_advanced_format.py" line="114" />
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation>Fijar ángulo de degradado</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation>Ángulo</translation>
+    </message>
+</context><context>
     <name>TextShadowGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="16"/>
+        <location filename="../ui/text_advanced_format.py" line="17" />
         <source>Set X offset</source>
         <translation>Establecer desplazamiento en X</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="26"/>
+        <location filename="../ui/text_advanced_format.py" line="28" />
         <source>Set Y offset</source>
         <translation>Establecer desplazamiento en Y</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="38"/>
+        <location filename="../ui/text_advanced_format.py" line="40" />
         <source>Set Shadow Strength</source>
         <translation>Establecer intensidad de sombra</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="40"/>
+        <location filename="../ui/text_advanced_format.py" line="42" />
         <source>Strength</source>
         <translation>Intensidad</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="48"/>
+        <location filename="../ui/text_advanced_format.py" line="51" />
         <source>Set Shadow Radius</source>
         <translation>Establecer radio de sombra</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="50"/>
+        <location filename="../ui/text_advanced_format.py" line="53" />
         <source>Radius</source>
         <translation>Radio</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="66"/>
+        <location filename="../ui/text_advanced_format.py" line="72" />
         <source>Offset</source>
         <translation>Desplazamiento</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStyleLabel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="86"/>
+        <location filename="../ui/text_style_presets.py" line="87" />
         <source>Click to set as Global format. Double click to edit name.</source>
         <translation>Haga clic para establecer el formato global. Haga doble clic para editar el nombre.</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="98"/>
+        <location filename="../ui/text_style_presets.py" line="99" />
         <source>Apply Text Style</source>
         <translation>Aplicar estilo de texto</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="103"/>
+        <location filename="../ui/text_style_presets.py" line="104" />
         <source>Update from active style</source>
         <translation>Actualizar desde estilo activo</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="120"/>
+        <location filename="../ui/text_style_presets.py" line="121" />
         <source>Delete Style</source>
         <translation>Eliminar estilo</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStylePresetPanel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="276"/>
+        <location filename="../ui/text_style_presets.py" line="277" />
         <source>Style</source>
         <translation>Estilo</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="439"/>
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
         <source>New Text Style</source>
         <translation>Nuevo estilo de texto</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="285"/>
+        <location filename="../ui/text_style_presets.py" line="286" />
         <source>Remove All</source>
         <translation>Quitar todo</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="299"/>
+        <location filename="../ui/text_style_presets.py" line="300" />
         <source>Remove all styles?</source>
         <translation>¿Quitar todos los estilos?</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="440"/>
+        <location filename="../ui/text_style_presets.py" line="462" />
         <source>Remove all</source>
         <translation>Eliminar todo</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="442"/>
+        <location filename="../ui/text_style_presets.py" line="464" />
         <source>Import Text Styles</source>
         <translation>Importar estilos de texto</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="443"/>
+        <location filename="../ui/text_style_presets.py" line="465" />
         <source>Export Text Styles</source>
         <translation>Exportar estilos de texto</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TitleBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="283"/>
+        <location filename="../ui/mainwindowbars.py" line="443" />
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="285"/>
+        <location filename="../ui/mainwindowbars.py" line="445" />
         <source>Undo</source>
         <translation>Deshacer</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="288"/>
+        <location filename="../ui/mainwindowbars.py" line="448" />
         <source>Redo</source>
         <translation>Rehacer</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="291"/>
+        <location filename="../ui/mainwindowbars.py" line="451" />
         <source>Search</source>
         <translation>Buscar en</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="294"/>
+        <location filename="../ui/mainwindowbars.py" line="454" />
         <source>Global Search</source>
         <translation>Búsqueda global</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="298"/>
+        <location filename="../ui/mainwindowbars.py" line="458" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Sustitución de palabras clave en textos fuente de traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="300"/>
+        <location filename="../ui/mainwindowbars.py" line="460" />
         <source>Keyword substitution for machine translation</source>
         <translation>Sustitución de palabras clave para la traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="302"/>
+        <location filename="../ui/mainwindowbars.py" line="462" />
         <source>Keyword substitution for source text</source>
         <translation>Sustitución del texto original por palabras clave</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="313"/>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>Ver</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="315"/>
+        <location filename="../ui/mainwindowbars.py" line="486" />
         <source>Display Language</source>
         <translation>Idioma de visualización</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="329"/>
+        <location filename="../ui/mainwindowbars.py" line="500" />
         <source>Drawing Board</source>
         <translation>Tablero de dibujo</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="331"/>
+        <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>Editor de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="333"/>
+        <location filename="../ui/mainwindowbars.py" line="504" />
         <source>Import Text Styles</source>
         <translation>Importar estilos de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="334"/>
+        <location filename="../ui/mainwindowbars.py" line="505" />
         <source>Export Text Styles</source>
         <translation>Exportar estilos de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="335"/>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
         <source>Dark Mode</source>
         <translation>Modo oscuro</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="355"/>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
         <source>Go</source>
         <translation>Ir</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="356"/>
+        <location filename="../ui/mainwindowbars.py" line="601" />
         <source>Previous Page</source>
         <translation>Página anterior</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="358"/>
+        <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>Página siguiente</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="381"/>
-        <source>Run</source>
-        <translation>Ejecutar</translation>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="371"/>
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
         <source>Enable Text Dection</source>
         <translation>Habilitar detección de texto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="372"/>
+        <location filename="../ui/mainwindowbars.py" line="764" />
         <source>Enable OCR</source>
         <translation>Habilitar OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="373"/>
+        <location filename="../ui/mainwindowbars.py" line="765" />
         <source>Enable Translation</source>
         <translation>Habilitar traducción</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="374"/>
+        <location filename="../ui/mainwindowbars.py" line="766" />
         <source>Enable Inpainting</source>
         <translation>Habilitar relleno inteligente</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="382"/>
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>Ejecutar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
         <source>Run without update textstyle</source>
         <translation>Ejecutar sin actualizar texttyle</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="383"/>
+        <location filename="../ui/mainwindowbars.py" line="775" />
         <source>Translate page</source>
         <translation>Traducir página</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">Abrir carpeta ...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">Abrir proyecto ... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">Guardar proyecto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">Exportar como documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished">Exportar traducción como TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished">Exportar traducción como markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">Importar desde Documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished">Importar traducción desde TXT/markdown</translation>
+    </message>
+</context><context>
     <name>TranslateThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="189"/>
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
         <source>Failed to set translator </source>
         <translation>Error al establecer el traductor </translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="239"/>
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>Error de traducción.</translation>
     </message>
+</context><context>
+    <name>TranslationContextDialog</name>
     <message>
-        <location filename="../ui/module_manager.py" line="241"/>
-        <source> is required for </source>
-        <translation> es necesario para </translation>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="379"/>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Sustitución de palabras clave en textos fuente de traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="382"/>
+        <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>Sustitución de palabras clave para la traducción automática</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="385"/>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
         <source>Keyword substitution for source text</source>
         <translation>Sustitución del texto original por palabras clave</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="392"/>
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
         <source>Source</source>
         <translation>fuente</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="394"/>
+        <location filename="../ui/module_parse_widgets.py" line="480" />
         <source>Target</source>
         <translation>destino</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TranslatorSelectionWidget</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="567"/>
+        <location filename="../ui/mainwindowbars.py" line="1468" />
         <source>Translate</source>
         <translation>Traducir</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
+        <location filename="../ui/mainwindowbars.py" line="1470" />
         <source>Source</source>
         <translation>Original</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="571"/>
+        <location filename="../ui/mainwindowbars.py" line="1472" />
         <source>Target</source>
         <translation>Objetivo</translation>
     </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
     <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>Copiar archivos de modelo desde una carpeta local existente al directorio data/models de esta aplicación.</translation>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package</source>
-        <translation>Paquete base</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package not selected</source>
-        <translation>Paquete base no seleccionado</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>No descargar ningún paquete de modelos ahora. Usar solo módulos/archivos ya locales.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>Descarga completa. Valores predeterminados actualizados.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download partially complete.</source>
-        <translation>Descarga completada parcialmente.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>El modo solo local de primer inicio está activo. Usa Herramientas → Administrar modelos para importar/descargar modelos, o edita config/config.json para habilitar paquetes y reinicia.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local model directory...</source>
-        <translation>Importar directorio local de modelos...</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local models</source>
-        <translation>Importar modelos locales</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">Deshacer</translation>
     </message>
     <message>
-        <source>Manual package selection</source>
-        <translation>Selección manual de paquetes</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">Rehacer</translation>
     </message>
     <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>Selecciona manualmente paquetes de bajo nivel en lugar de usar un preajuste.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download complete</source>
-        <translation>Descarga de paquetes de modelos completada</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download partially complete</source>
-        <translation>Descarga de paquetes de modelos parcialmente completada</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>Se han descargado los paquetes de modelos. Módulos aplicados:
-</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>Abrir Administrar modelos</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Select local model directory</source>
-        <translation>Seleccionar directorio local de modelos</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation>Omitir todas las descargas (solo local)</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>Algunos paquetes de modelos fallaron. Elementos fallidos: {0}</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished">Estilo</translation>
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>Resumen: descargados {0}, fallidos {1}, omitidos {2}.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">Eliminar</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">Traducción</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">Ejecutar</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/fr_FR.ts
+++ b/translate/fr_FR.ts
@@ -1,618 +1,2645 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="fr_FR" sourcelanguage="en_US">
 <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="632" />
+        <location filename="../ui/mainwindowbars.py" line="1566" />
         <source>Text Detector</source>
         <translation>Détecteur de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="633" />
+        <location filename="../ui/mainwindowbars.py" line="1567" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="634" />
+        <location filename="../ui/mainwindowbars.py" line="1568" />
         <source>Inpaint</source>
         <translation>Retoucher</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="640" />
-        <source>Enable/disable paint mode</source>
-        <translation>Activer/désactiver le mode retouche</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">Exécuter</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="644" />
-        <source>Enable/disable text edit mode</source>
-        <translation>Activer/désactiver le mode d'édition de texte</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="650" />
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
         <source>Original image opacity</source>
         <translation>Opacité de l'image d'origine</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="654" />
+        <location filename="../ui/mainwindowbars.py" line="1614" />
         <source>Text layer opacity</source>
         <translation>Opacité du calque</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="759" />
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">Éditer</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1073" />
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="761" />
+        <location filename="../ui/canvas.py" line="1078" />
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="763" />
-        <source>Delete</source>
-        <translation>Supprimer</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="765" />
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1091" />
         <source>Copy source text</source>
         <translation>Texte source</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="767" />
+        <location filename="../ui/canvas.py" line="1096" />
         <source>Paste source text</source>
         <translation>Coller la source:</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="769" />
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>Supprimer</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
         <source>Delete and Recover removed text</source>
         <translation>Supprimer et récupérer le texte supprimé</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="774" />
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">En majuscule</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
         <source>Apply font formatting</source>
         <translation>Appliquer la mise en forme de police</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="775" />
+        <location filename="../ui/canvas.py" line="1275" />
         <source>Auto layout</source>
         <translation>Mise en page automatique</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="776" />
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">Auto </translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
         <source>Reset Angle</source>
         <translation>Réinitialiser l'angle</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="777" />
+        <location filename="../ui/canvas.py" line="1326" />
         <source>Squeeze</source>
         <translation>Appuyer</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="779" />
-        <source>translate</source>
-        <translation>traduire</translation>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">Exécuter</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="780" />
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished">Traduire</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="781" />
+        <location filename="../ui/canvas.py" line="1357" />
         <source>OCR and translate</source>
         <translation>OCR et traduction</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="782" />
+        <location filename="../ui/canvas.py" line="1362" />
         <source>OCR, translate and inpaint</source>
         <translation>OCR, traduction et retouche</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="783" />
-        <source>inpaint</source>
-        <translation>retouche</translation>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Retoucher</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-        <location filename="../ui/configpanel.py" line="351" />
+        <location filename="../ui/configpanel.py" line="410" />
         <source>DL Module</source>
         <translation>Module DL</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="352" />
+        <location filename="../ui/configpanel.py" line="411" />
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="354" />
+        <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>Détection de texte</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="394" />
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="356" />
+        <location filename="../ui/configpanel.py" line="415" />
         <source>Inpaint</source>
         <translation>Retoucher</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="357" />
+        <location filename="../ui/configpanel.py" line="416" />
         <source>Translator</source>
         <translation>Traducteur</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="358" />
+        <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>Démarrage</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="359" />
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="419" />
         <source>Typesetting</source>
         <translation>Composition typographique</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="360" />
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="421" />
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="361" />
+        <location filename="../ui/configpanel.py" line="422" />
         <source>SalaDict</source>
         <translation>SalaDict</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376" />
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand</source>
         <translation>Charger les modèles à la demande</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376" />
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand to save memory.</source>
         <translation>Chargez les modèles à la demande pour économiser de la mémoire.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379" />
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN</source>
         <translation>Vider le cache après l'exécution</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379" />
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN to save memory.</source>
         <translation>Vider le cache après l'exécution pour sauvegarder la mémoire.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="384" />
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="518" />
         <source>Unload All Models</source>
         <translation>Décharger tous les modèles</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="389" />
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
         <source>Detector</source>
         <translation>Détecteur</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="398" />
+        <location filename="../ui/configpanel.py" line="626" />
         <source>Inpainter</source>
         <translation>Retoucheur</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="406" />
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
         <source>Reopen last project on startup</source>
         <translation>Rouvrir le dernier projet au démarrage</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="410" />
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
         <source>decide by program</source>
         <translation>Décider par programme</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="411" />
+        <location filename="../ui/configpanel.py" line="840" />
         <source>use global setting</source>
         <translation>Utiliser le réglage global</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="421" />
+        <location filename="../ui/configpanel.py" line="850" />
         <source>Font Size</source>
         <translation>Taille de police</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="425" />
+        <location filename="../ui/configpanel.py" line="854" />
         <source>Stroke Size</source>
         <translation>Taille du contour</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="429" />
+        <location filename="../ui/configpanel.py" line="858" />
         <source>Font Color</source>
         <translation>Couleur de police</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="432" />
+        <location filename="../ui/configpanel.py" line="861" />
         <source>Stroke Color</source>
         <translation>Couleur du contour</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="436" />
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
         <source>Effect</source>
         <translation>Résultat</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="439" />
+        <location filename="../ui/configpanel.py" line="898" />
         <source>Alignment</source>
         <translation>Alignement</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="443" />
+        <location filename="../ui/configpanel.py" line="902" />
         <source>Writing-mode</source>
         <translation>Mode de gravure</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446" />
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Keep existing</source>
         <translation>Conserver l'existant</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446" />
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Always use global setting</source>
         <translation>Toujours utiliser le paramètre global</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446" />
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Font Family</source>
         <translation>Famille de Polices</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="911" />
         <source>Auto layout</source>
         <translation>Mise en page automatique</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452" />
-        <source>Split translation into multi-lines according to the extracted balloon region.</source>
-        <translation>Divisez la traduction en plusieurs lignes en fonction de la région du ballon extraite.</translation>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="456" />
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">Auto </translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
         <source>To uppercase</source>
         <translation>En majuscule</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="459" />
+        <location filename="../ui/configpanel.py" line="1108" />
         <source>Independent text styles for each projects</source>
         <translation>Styles de texte indépendants pour chaque projet</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="462" />
+        <location filename="../ui/configpanel.py" line="1111" />
         <source>Show only custom fonts</source>
         <translation>Afficher uniquement les polices personnalisées</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="466" />
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
         <source>Result image format</source>
         <translation>Format de l'image du résultat</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="471" />
+        <location filename="../ui/configpanel.py" line="1128" />
         <source>Quality</source>
         <translation>Qualité</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="478" />
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
         <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
         <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Guide d'installation&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="482" />
+        <location filename="../ui/configpanel.py" line="1154" />
         <source>Show mini menu when selecting text.</source>
         <translation>Afficher le mini menu lors de la sélection du texte.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="488" />
+        <location filename="../ui/configpanel.py" line="1160" />
         <source>Shortcut</source>
         <translation>Raccourci</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="491" />
+        <location filename="../ui/configpanel.py" line="1163" />
         <source>Search Engines</source>
         <translation>Moteurs de recherche</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="353" />
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
         <source>Mask Opacity</source>
         <translation>Opacité du masque</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="100" />
+        <location filename="../ui/io_thread.py" line="118" />
         <source>Export as doc...</source>
         <translation>Exporter au format doc...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="106" />
+        <location filename="../ui/io_thread.py" line="124" />
         <source>Overwrite </source>
         <translation>Écraser</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-        <location filename="../ui/text_panel.py" line="262" />
+        <location filename="../ui/text_panel.py" line="275" />
         <source>Font Family</source>
         <translation>Famille de Polices</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="267" />
+        <location filename="../ui/text_panel.py" line="280" />
         <source>Font Size</source>
         <translation>Taille de police</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="269" />
+        <location filename="../ui/text_panel.py" line="282" />
         <source>Change font size</source>
         <translation>Modifier la taille de la police</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="279" />
+        <location filename="../ui/text_panel.py" line="292" />
         <source>Change line spacing</source>
         <translation>Changer l'espacement des lignes</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="283" />
+        <location filename="../ui/text_panel.py" line="296" />
         <source>Change font color</source>
         <translation>Changer la couleur de la police</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="300" />
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
         <source>Change stroke width</source>
         <translation>Modifier la largeur du contour</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="303" />
+        <location filename="../ui/text_panel.py" line="364" />
         <source>Stroke</source>
         <translation>Contour</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="312" />
+        <location filename="../ui/text_panel.py" line="373" />
         <source>Change stroke color</source>
         <translation>Changer la couleur du contour</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="325" />
+        <location filename="../ui/text_panel.py" line="386" />
         <source>Change letter spacing</source>
         <translation>Modifier l'espacement des lettres</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="339" />
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">Opacité</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
         <source>Global Font Format</source>
         <translation>Format de police global</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="348" />
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
         <source>Advanced Text Format</source>
         <translation>Format de texte avancé</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369" />
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Unfold</source>
         <translation>Déplier</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369" />
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Fold</source>
         <translation>Plier</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="370" />
+        <location filename="../ui/text_panel.py" line="462" />
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="371" />
+        <location filename="../ui/text_panel.py" line="463" />
         <source>Translation</source>
         <translation>Traduction</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="189" />
+        <location filename="../ui/global_search_widget.py" line="192" />
         <source>Replace...</source>
         <translation>Remplacer...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="195" />
+        <location filename="../ui/global_search_widget.py" line="198" />
         <source>Replace all occurrences?</source>
         <translation>Remplacer toutes les occurrences ?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="305" />
+        <location filename="../ui/global_search_widget.py" line="308" />
         <source>Find</source>
         <translation>Trouver</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="308" />
+        <location filename="../ui/global_search_widget.py" line="311" />
         <source>No results found. </source>
         <translation>Aucun résultat trouvé.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="309" />
+        <location filename="../ui/global_search_widget.py" line="312" />
         <source>Document changed. Press Enter to re-search.</source>
         <translation>Document modifié. Appuyez sur Entrée pour effectuer une nouvelle recherche.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="310" />
+        <location filename="../ui/global_search_widget.py" line="313" />
         <source>Found results: </source>
         <translation>Résultats trouvés :</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="316" />
+        <location filename="../ui/global_search_widget.py" line="319" />
         <source>Match Case</source>
         <translation>Tõstutundlik</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="321" />
+        <location filename="../ui/global_search_widget.py" line="324" />
         <source>Match Whole Word</source>
         <translation>Correspondance avec des Mots Entiers</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="326" />
+        <location filename="../ui/global_search_widget.py" line="329" />
         <source>Use Regular Expression</source>
         <translation>Utiliser l’expression régulière</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330" />
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Translation</source>
         <translation>Traduction</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330" />
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330" />
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>All</source>
         <translation>Tous</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="333" />
+        <location filename="../ui/global_search_widget.py" line="336" />
         <source> in</source>
         <translation>à</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="336" />
+        <location filename="../ui/global_search_widget.py" line="339" />
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="339" />
+        <location filename="../ui/global_search_widget.py" line="342" />
         <source>Replace All</source>
         <translation>Remplacer tout</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="341" />
+        <location filename="../ui/global_search_widget.py" line="344" />
         <source>Replace All and Re-render all pages</source>
         <translation>Remplacer tout et restituer toutes les pages</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="382" />
+        <location filename="../ui/global_search_widget.py" line="385" />
         <source>Replace...</source>
         <translation>Remplacer...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="487" />
+        <location filename="../ui/global_search_widget.py" line="490" />
         <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>Remplacer toutes les occurrences restituer toutes les pages ? Elle ne peut pas être annulée.</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ImgtransProgressMessageBox</name>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="183" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="184" />
+        <source>OCR: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="185" />
+        <source>Inpainting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="186" />
+        <source>Translating: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="389" />
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
         <source>OCR Failed.</source>
         <translation>Échec de la ROC !</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="369" />
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation type="unfinished">Échec de la traduction.</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1022" />
         <source>Text Detection Failed.</source>
         <translation>Échec de la détection</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="450" />
+        <location filename="../ui/module_manager.py" line="1526" />
         <source>Inpainting Failed.</source>
         <translation>Échec de la retouche.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="136" />
+        <location filename="../ui/io_thread.py" line="154" />
         <source>Import doc...</source>
         <translation>Importer doc...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="143" />
+        <location filename="../ui/io_thread.py" line="161" />
         <source>Import *.docx</source>
         <translation>Importer *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="426" />
+        <location filename="../ui/module_parse_widgets.py" line="533" />
         <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
         <translation>Laissez le programme décider s'il est nécessaire d'utiliser la méthode de retouche sélectionnée.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>InpaintPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="74" />
+        <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>Épaisseur</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="79" />
+        <location filename="../ui/drawingpanel.py" line="80" />
         <source>Shape</source>
         <translation>Forme</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81" />
+        <location filename="../ui/drawingpanel.py" line="83" />
         <source>Circle</source>
         <translation>Circulaire</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81" />
+        <location filename="../ui/drawingpanel.py" line="84" />
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
     <message>
         <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
         <source>Inpainter</source>
         <translation>Retoucheur</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="122" />
+        <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>Échec de la retouche.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24" />
+        <location filename="../ui/keywordsubwidget.py" line="25" />
         <source>Keyword</source>
         <translation>Mot clé</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24" />
+        <location filename="../ui/keywordsubwidget.py" line="26" />
         <source>Substitution</source>
         <translation>Remplacement</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24" />
+        <location filename="../ui/keywordsubwidget.py" line="27" />
         <source>Use regex</source>
         <translation>Utiliser regex</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24" />
+        <location filename="../ui/keywordsubwidget.py" line="28" />
         <source>Case sensitive</source>
         <translation>Sensible à la casse</translation>
     </message>
@@ -626,240 +2653,2184 @@
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="77" />
+        <location filename="../ui/mainwindowbars.py" line="104" />
         <source>Global Search (Ctrl+G)</source>
         <translation>Recherche globale (Ctrl+G)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="88" />
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
         <translation>Ouvrir le dossier</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="92" />
+        <location filename="../ui/mainwindowbars.py" line="132" />
         <source>Open Project ... *.json</source>
         <translation>Ouvrir un projet ... *.json</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="95" />
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
         <source>Save Project</source>
         <translation>Enregistrer le projet</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="99" />
+        <location filename="../ui/mainwindowbars.py" line="155" />
         <source>Export as Doc</source>
         <translation>Exporter au format Doc</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="101" />
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
         <source>Import from Doc</source>
         <translation>Importer depuis un fichier Doc</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="104" />
-        <source>Export soure text as TXT</source>
-        <translation>Exporter le texte source au format TXT</translation>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="106" />
+        <location filename="../ui/mainwindowbars.py" line="165" />
         <source>Export translation as TXT</source>
         <translation>Exporter la traduction au format TXT</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="109" />
-        <source>Export soure text as markdown</source>
-        <translation>Exporter le texte source au format Markdown</translation>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="111" />
+        <location filename="../ui/mainwindowbars.py" line="170" />
         <source>Export translation as markdown</source>
         <translation>Exporter la traduction au format Markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="114" />
+        <location filename="../ui/mainwindowbars.py" line="173" />
         <source>Import translation from TXT/markdown</source>
         <translation>Importer la traduction depuis un fichier TXT/Markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="117" />
+        <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>Ouvrir récent</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="143" />
-        <source>RUN</source>
-        <translation>EXÉCUTER</translation>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="237" />
+        <location filename="../ui/mainwindowbars.py" line="303" />
         <source>Select Directory</source>
         <translation>Sélectionner un annuaire</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="244" />
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>Importer *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="202" />
+        <location filename="../ui/mainwindow.py" line="465" />
         <source>Keyword substitution for source text</source>
         <translation>Substitution de mots-clés pour le texte source</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="206" />
+        <location filename="../ui/mainwindow.py" line="469" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Substitution de mots-clés pour le texte source de la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="210" />
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>Substitution de mots-clés pour la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="481" />
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
         <source>Failed to load project </source>
         <translation>Impossible d&amp;apos;ouvrir le gestionnaire &amp; #160;: %1</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="500" />
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
         <source>Failed to load project from</source>
         <translation>Échec du chargement du projet à partir de</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="552" />
-        <source>Restart to apply changes?</source>
-        <translation>Redémarrer pour appliquer les modifications ?</translation>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192" />
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
+        <source>Restart to apply changes? 
+</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">Résumé : téléchargés {0}, échecs {1}, ignorés {2}.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">Ouvrir Gérer les modèles</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation type="unfinished">Téléchargement des paquets de modèles terminé</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">Certains paquets de modèles ont échoué. Éléments en échec : {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation type="unfinished">Téléchargement des paquets de modèles partiellement terminé</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">Le mode local uniquement du premier lancement est actif. Utilisez Outils → Gérer les modèles pour importer/télécharger des modèles, ou modifiez config/config.json pour activer les paquets puis redémarrez.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">Téléchargement partiellement terminé.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">Téléchargement terminé. Paramètres par défaut mis à jour.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation type="unfinished">Les paquets de modèles ont été téléchargés. Modules appliqués :
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>unsaved</source>
         <translation>Non enregistré</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192" />
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>saved</source>
         <translation>Sauvegardé</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1226" />
+        <location filename="../ui/mainwindow.py" line="3258" />
         <source>Saving image...</source>
         <translation>Enregistrement de l'image...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239" />
+        <location filename="../ui/mainwindow.py" line="3297" />
         <source>Confirmation</source>
         <translation>Confirmation</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239" />
-        <source>Are you sure to run image translation again?
-All existing translation results will be cleared!</source>
-        <translation>Êtes-vous sûr de vouloir exécuter à nouveau la traduction d'image ?
-Tous les résultats de traduction existants seront effacés !</translation>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1287" />
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">Exécuter</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
         <source>Import Text Styles</source>
         <translation>Importer des styles de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1297" />
-        <source>Failed to load from {p}</source>
-        <translation>Échec du chargement à partir de {p}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1301" />
+        <location filename="../ui/mainwindow.py" line="3417" />
         <source>Save Text Styles</source>
         <translation>Styles du texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1318" />
-        <source>Failed save to {savep}</source>
-        <translation>Échec de l'enregistrement vers {savep}</translation>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1344" />
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
         <source>Text file exported to </source>
         <translation>Fichier texte exporté vers</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1346" />
+        <location filename="../ui/mainwindow.py" line="3565" />
         <source>Failed to export as TEXT file</source>
         <translation>Échec de l'exportation en tant que fichier TEXTE</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1352" />
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
         <source>Import *.md/*.txt</source>
         <translation>Importer *.md/*.txt</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1364" />
+        <location filename="../ui/mainwindow.py" line="3604" />
         <source>Translation imported and matched successfully.</source>
         <translation>Traduction importée et mise en correspondance réussie.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1366" />
+        <location filename="../ui/mainwindow.py" line="3606" />
         <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
         <translation>Le fichier txt importé ne correspond pas entièrement au projet en cours, veuillez vous assurer que le fichier txt source est structuré comme les résultats de « export TXT/Markdown »</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1368" />
+        <location filename="../ui/mainwindow.py" line="3608" />
         <source>Missing pages: </source>
         <translation>Pages manquantes :</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1371" />
+        <location filename="../ui/mainwindow.py" line="3611" />
         <source>Unexpected pages: </source>
         <translation>Pages inattendues :</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1374" />
+        <location filename="../ui/mainwindow.py" line="3614" />
         <source>Unmatched pages: </source>
         <translation>Pages non appariées :</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1380" />
+        <location filename="../ui/mainwindow.py" line="3625" />
         <source>Failed to import translation from </source>
         <translation>Échec de l'importation de la traduction à partir de</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1404" />
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
         <source>Export to </source>
         <translation>Exporter vers</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">Rechercher</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">Importer un répertoire local de modèles...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
+        <source>Select local model directory</source>
+        <translation type="unfinished">Sélectionner le répertoire local des modèles</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">Importer des modèles locaux</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">Sélectionnez manuellement les paquets bas niveau au lieu d'utiliser un préréglage.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">Sélection manuelle des paquets</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
+        <source>Skip all downloads (local-only)</source>
+        <translation type="unfinished">Ignorer tous les téléchargements (local uniquement)</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">Ne télécharger aucun paquet de modèles maintenant. Utiliser uniquement les modules/fichiers déjà locaux.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">Paquet cœur non sélectionné</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleManager</name>
     <message>
-        <location filename="../ui/module_manager.py" line="858" />
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
         <source>Set Inpainter...</source>
         <translation>Définir le Retoucheur...</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>OCRConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="451" />
+        <location filename="../ui/module_parse_widgets.py" line="830" />
         <source>Delete and restore region where OCR return empty string.</source>
         <translation>Supprimez et restaurez la région où l'OCR renvoie la chaîne vide.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">Source</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">Traduction</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageListView</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="51" />
+        <location filename="../ui/mainwindow.py" line="88" />
         <source>Reveal in File Explorer</source>
         <translation>Révéler dans l'Explorateur de fichiers</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
         <location filename="../ui/page_search_widget.py" line="207" />
@@ -918,6 +4889,7 @@ Tous les résultats de traduction existants seront effacés !</translation>
     </message>
     <message>
         <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>Remplacer</translation>
     </message>
@@ -931,99 +4903,166 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Close (Escape)</source>
         <translation>Fermer (Echap)</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PenConfigPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="136" />
+        <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="137" />
+        <location filename="../ui/drawingpanel.py" line="153" />
         <source>Alpha</source>
         <translation>Alpha</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="145" />
+        <location filename="../ui/drawingpanel.py" line="161" />
         <source>Thickness</source>
         <translation>Épaisseur</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="150" />
+        <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>Forme</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152" />
+        <location filename="../ui/drawingpanel.py" line="169" />
         <source>Circle</source>
         <translation>Circulaire</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152" />
+        <location filename="../ui/drawingpanel.py" line="170" />
         <source>Rectangle</source>
         <translation>Rectangle</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="197" />
+        <location filename="../ui/drawingpanel.py" line="214" />
         <source>Dilate</source>
         <translation>Dilater</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204" />
-        <source>method 1</source>
-        <translation>méthode 1</translation>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204" />
-        <source>method 2</source>
-        <translation>Méthode n ° 2</translation>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204" />
-        <source>Use Existing Mask</source>
-        <translation>Utiliser existante</translation>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="210" />
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">Rectangle</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
         <source>Auto</source>
         <translation>Auto </translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="211" />
+        <location filename="../ui/drawingpanel.py" line="241" />
         <source>run inpainting automatically.</source>
         <translation>exécutez automatiquement la fonction de retouche.</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="213" />
+        <location filename="../ui/drawingpanel.py" line="243" />
         <source>Inpaint</source>
         <translation>Retoucher</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="214" />
+        <location filename="../ui/drawingpanel.py" line="244" />
         <source>Space</source>
         <translation>Espace</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="216" />
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="217" />
+        <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="224" />
+        <location filename="../ui/drawingpanel.py" line="258" />
         <source>Inpainter</source>
         <translation>Retoucheur</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">Forme</translation>
+    </message>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
         <location filename="../ui/textedit_area.py" line="30" />
@@ -1035,79 +5074,708 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>Rechercher le texte sélectionné dans SalaDict, voir le guide d'installation dans configpanel</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished">Raccourci</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">Traduction</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">Traducteur</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished">Sauvegarder</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextAdvancedFormatPanel</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146" />
+        <location filename="../ui/text_advanced_format.py" line="170" />
         <source>Proportional</source>
         <translation>Proportionnel </translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146" />
+        <location filename="../ui/text_advanced_format.py" line="171" />
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="156" />
+        <location filename="../ui/text_advanced_format.py" line="175" />
         <source>Line Spacing Type</source>
         <translation>Interligne</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="162" />
+        <location filename="../ui/text_advanced_format.py" line="182" />
         <source>Set Text Opacity</source>
         <translation>Définir l'opacité du texte</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="164" />
+        <location filename="../ui/text_advanced_format.py" line="184" />
         <source>Opacity</source>
         <translation>Opacité</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="175" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
         <source>Shadow</source>
         <translation>Ombre</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextDetectConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <location filename="../ui/module_parse_widgets.py" line="615" />
         <source>Keep Existing Lines</source>
         <translation>Lignes existantes</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextGradientGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="83" />
+        <location filename="../ui/text_advanced_format.py" line="91" />
         <source>Gradient</source>
         <translation>Dégradé</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="87" />
+        <location filename="../ui/text_advanced_format.py" line="96" />
         <source>Start Color</source>
         <translation>Couleur Démarrer</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="93" />
+        <location filename="../ui/text_advanced_format.py" line="100" />
         <source>End Color</source>
         <translation>Couleur Fin</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="98" />
+        <location filename="../ui/text_advanced_format.py" line="102" />
         <source>Enable</source>
         <translation>Activer</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="102" />
-        <source>Set Gradient Angle</source>
-        <translation>Angle du dégradé</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="104" />
-        <source>Angle</source>
-        <translation>Angle</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
     </message>
     <message>
         <location filename="../ui/text_advanced_format.py" line="112" />
@@ -1119,377 +5787,2999 @@ Tous les résultats de traduction existants seront effacés !</translation>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation>Angle du dégradé</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation>Angle</translation>
+    </message>
+</context><context>
     <name>TextShadowGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="16" />
+        <location filename="../ui/text_advanced_format.py" line="17" />
         <source>Set X offset</source>
         <translation>X Compensation</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="26" />
+        <location filename="../ui/text_advanced_format.py" line="28" />
         <source>Set Y offset</source>
         <translation>Offset Y</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="38" />
+        <location filename="../ui/text_advanced_format.py" line="40" />
         <source>Set Shadow Strength</source>
         <translation>Définir l'intensité de l'ombre</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="40" />
+        <location filename="../ui/text_advanced_format.py" line="42" />
         <source>Strength</source>
         <translation>Intensité</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="48" />
+        <location filename="../ui/text_advanced_format.py" line="51" />
         <source>Set Shadow Radius</source>
         <translation>Définir le rayon d'ombre</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="50" />
+        <location filename="../ui/text_advanced_format.py" line="53" />
         <source>Radius</source>
         <translation>Rayon</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="66" />
+        <location filename="../ui/text_advanced_format.py" line="72" />
         <source>Offset</source>
         <translation>Décalage</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStyleLabel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="86" />
+        <location filename="../ui/text_style_presets.py" line="87" />
         <source>Click to set as Global format. Double click to edit name.</source>
         <translation>Cliquez pour définir le format Global. Double-cliquez pour modifier le nom.</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="98" />
+        <location filename="../ui/text_style_presets.py" line="99" />
         <source>Apply Text Style</source>
         <translation>Appliquez le style de texte</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="103" />
+        <location filename="../ui/text_style_presets.py" line="104" />
         <source>Update from active style</source>
         <translation>Mettre à jour à partir du style actif</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="120" />
+        <location filename="../ui/text_style_presets.py" line="121" />
         <source>Delete Style</source>
         <translation>Effacer style</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStylePresetPanel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="276" />
+        <location filename="../ui/text_style_presets.py" line="277" />
         <source>Style</source>
         <translation>Style</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="439" />
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
         <source>New Text Style</source>
         <translation>Nouveau style de texte</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="285" />
+        <location filename="../ui/text_style_presets.py" line="286" />
         <source>Remove All</source>
         <translation>Supprimer tout</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="299" />
+        <location filename="../ui/text_style_presets.py" line="300" />
         <source>Remove all styles?</source>
         <translation>Supprimer tous les styles ?</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="440" />
+        <location filename="../ui/text_style_presets.py" line="462" />
         <source>Remove all</source>
         <translation>Enlever tout</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="442" />
+        <location filename="../ui/text_style_presets.py" line="464" />
         <source>Import Text Styles</source>
         <translation>Importer des styles de texte</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="443" />
+        <location filename="../ui/text_style_presets.py" line="465" />
         <source>Export Text Styles</source>
         <translation>Exporter les styles de texte</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TitleBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="283" />
+        <location filename="../ui/mainwindowbars.py" line="443" />
         <source>Edit</source>
         <translation>Éditer</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="285" />
+        <location filename="../ui/mainwindowbars.py" line="445" />
         <source>Undo</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="288" />
+        <location filename="../ui/mainwindowbars.py" line="448" />
         <source>Redo</source>
         <translation>Rétablir</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="291" />
+        <location filename="../ui/mainwindowbars.py" line="451" />
         <source>Search</source>
         <translation>Rechercher</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="294" />
+        <location filename="../ui/mainwindowbars.py" line="454" />
         <source>Global Search</source>
         <translation>Recherche globale</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="298" />
+        <location filename="../ui/mainwindowbars.py" line="458" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Substitution de mots-clés pour le texte source de la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="300" />
+        <location filename="../ui/mainwindowbars.py" line="460" />
         <source>Keyword substitution for machine translation</source>
         <translation>Substitution de mots-clés pour la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="302" />
+        <location filename="../ui/mainwindowbars.py" line="462" />
         <source>Keyword substitution for source text</source>
         <translation>Substitution de mots-clés pour le texte source</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="313" />
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>Vue</translation>
     </message>
     <message>
-        <location filename="../ui/mainwEindowbars.py" line="315" />
+        <location filename="../ui/mainwindowbars.py" line="486" />
         <source>Display Language</source>
         <translation>Langue d’affichage</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="329" />
+        <location filename="../ui/mainwindowbars.py" line="500" />
         <source>Drawing Board</source>
         <translation>Planche à dessin</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="331" />
+        <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>Éditeur de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="333" />
+        <location filename="../ui/mainwindowbars.py" line="504" />
         <source>Import Text Styles</source>
         <translation>Importer des styles de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="334" />
+        <location filename="../ui/mainwindowbars.py" line="505" />
         <source>Export Text Styles</source>
         <translation>Exporter les styles de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="335" />
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
         <source>Dark Mode</source>
         <translation>Mode Sombre</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="355" />
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
         <source>Go</source>
         <translation>Aller</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="356" />
+        <location filename="../ui/mainwindowbars.py" line="601" />
         <source>Previous Page</source>
         <translation>Page précédente</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="358" />
+        <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>Page suivante</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="381" />
-        <source>Run</source>
-        <translation>Exécuter</translation>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="371" />
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
         <source>Enable Text Dection</source>
         <translation>Activer la section de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="372" />
+        <location filename="../ui/mainwindowbars.py" line="764" />
         <source>Enable OCR</source>
         <translation>Activer OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="373" />
+        <location filename="../ui/mainwindowbars.py" line="765" />
         <source>Enable Translation</source>
         <translation>Activer la traduction</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="374" />
+        <location filename="../ui/mainwindowbars.py" line="766" />
         <source>Enable Inpainting</source>
         <translation>Activer la retouche</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="382" />
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>Exécuter</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
         <source>Run without update textstyle</source>
         <translation>Exécuter sans mettre à jour le style de texte</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="383" />
+        <location filename="../ui/mainwindowbars.py" line="775" />
         <source>Translate page</source>
         <translation>Traduire la page</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">Ouvrir le dossier</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">Ouvrir un projet ... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">Enregistrer le projet</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">Exporter au format Doc</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished">Exporter la traduction au format TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished">Exporter la traduction au format Markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">Importer depuis un fichier Doc</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished">Importer la traduction depuis un fichier TXT/Markdown</translation>
+    </message>
+</context><context>
     <name>TranslateThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="189" />
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
         <source>Failed to set translator </source>
         <translation>Échec de la définition du traducteur</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="239" />
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>Échec de la traduction.</translation>
     </message>
+</context><context>
+    <name>TranslationContextDialog</name>
     <message>
-        <location filename="../ui/module_manager.py" line="241" />
-        <source> is required for </source>
-        <translation>générale est requise pour :</translation>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="379" />
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Substitution de mots-clés pour le texte source de la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="382" />
+        <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>Substitution de mots-clés pour la traduction auto</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="385" />
+        <location filename="../ui/module_parse_widgets.py" line="438" />
         <source>Keyword substitution for source text</source>
         <translation>Substitution de mots-clés pour le texte source</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="392" />
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="394" />
+        <location filename="../ui/module_parse_widgets.py" line="480" />
         <source>Target</source>
         <translation>Cible</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TranslatorSelectionWidget</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="567" />
+        <location filename="../ui/mainwindowbars.py" line="1468" />
         <source>Translate</source>
         <translation>Traduire</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569" />
+        <location filename="../ui/mainwindowbars.py" line="1470" />
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="571" />
+        <location filename="../ui/mainwindowbars.py" line="1472" />
         <source>Target</source>
         <translation>Cible</translation>
     </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
     <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>Copier les fichiers de modèle depuis un dossier local existant vers le répertoire data/models de cette application.</translation>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package</source>
-        <translation>Paquet cœur</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package not selected</source>
-        <translation>Paquet cœur non sélectionné</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>Ne télécharger aucun paquet de modèles maintenant. Utiliser uniquement les modules/fichiers déjà locaux.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>Téléchargement terminé. Paramètres par défaut mis à jour.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download partially complete.</source>
-        <translation>Téléchargement partiellement terminé.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>Le mode local uniquement du premier lancement est actif. Utilisez Outils → Gérer les modèles pour importer/télécharger des modèles, ou modifiez config/config.json pour activer les paquets puis redémarrez.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local model directory...</source>
-        <translation>Importer un répertoire local de modèles...</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local models</source>
-        <translation>Importer des modèles locaux</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
-        <source>Manual package selection</source>
-        <translation>Sélection manuelle des paquets</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">Rétablir</translation>
     </message>
     <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>Sélectionnez manuellement les paquets bas niveau au lieu d'utiliser un préréglage.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download complete</source>
-        <translation>Téléchargement des paquets de modèles terminé</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download partially complete</source>
-        <translation>Téléchargement des paquets de modèles partiellement terminé</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>Les paquets de modèles ont été téléchargés. Modules appliqués :
-</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>Ouvrir Gérer les modèles</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Select local model directory</source>
-        <translation>Sélectionner le répertoire local des modèles</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation>Ignorer tous les téléchargements (local uniquement)</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>Certains paquets de modèles ont échoué. Éléments en échec : {0}</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished">Style</translation>
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>Résumé : téléchargés {0}, échecs {1}, ignorés {2}.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">Supprimer</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">Traduction</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">Exécuter</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/hu_HU.ts
+++ b/translate/hu_HU.ts
@@ -2,1496 +2,8784 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="hu_HU" sourcelanguage="en_US">
 <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="632"/>
+        <location filename="../ui/mainwindowbars.py" line="1566" />
         <source>Text Detector</source>
         <translation>SzövegFelismerő</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="633"/>
+        <location filename="../ui/mainwindowbars.py" line="1567" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="634"/>
+        <location filename="../ui/mainwindowbars.py" line="1568" />
         <source>Inpaint</source>
         <translation>Belefestés</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="640"/>
-        <source>Enable/disable paint mode</source>
-        <translation>Festő mód engedélyezés/tiltás</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">Futtatás</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="644"/>
-        <source>Enable/disable text edit mode</source>
-        <translation>Szövegszerkesztő mód engedélyezés/tiltás</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="650"/>
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
         <source>Original image opacity</source>
         <translation>Eredeti kép átlátszóság</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="654"/>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
         <source>Text layer opacity</source>
         <translation>Szöveg réteg átlátszóság</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="759"/>
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">Szerkesztés</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1073" />
         <source>Copy</source>
         <translation>Másolás</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="761"/>
+        <location filename="../ui/canvas.py" line="1078" />
         <source>Paste</source>
         <translation>Beillesztés</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="763"/>
-        <source>Delete</source>
-        <translation>Törlés</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="765"/>
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1091" />
         <source>Copy source text</source>
         <translation>Forrás szöveg másolása</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="767"/>
+        <location filename="../ui/canvas.py" line="1096" />
         <source>Paste source text</source>
         <translation>Forrás szöveg beillesztése</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="769"/>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>Törlés</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
         <source>Delete and Recover removed text</source>
         <translation>Törlés és eltávolított szöveg visszaállítása</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="774"/>
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">Nagybetűsítés</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
         <source>Apply font formatting</source>
         <translation>Betűformázás alkalmazása</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="775"/>
+        <location filename="../ui/canvas.py" line="1275" />
         <source>Auto layout</source>
         <translation>Automata elrendezés</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="776"/>
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">Automata</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
         <source>Reset Angle</source>
         <translation>Forgatás visszaállítása</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="777"/>
+        <location filename="../ui/canvas.py" line="1326" />
         <source>Squeeze</source>
         <translation>Nyújtás</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="779"/>
-        <source>translate</source>
-        <translation>fordítás</translation>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">Futtatás</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="780"/>
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished">fordítás</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="781"/>
+        <location filename="../ui/canvas.py" line="1357" />
         <source>OCR and translate</source>
         <translation>OCR és fordítás</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="782"/>
+        <location filename="../ui/canvas.py" line="1362" />
         <source>OCR, translate and inpaint</source>
         <translation>OCR, fordítás és belefestés</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="783"/>
-        <source>inpaint</source>
-        <translation>Belefestés</translation>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Belefestés</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-        <location filename="../ui/configpanel.py" line="351"/>
+        <location filename="../ui/configpanel.py" line="410" />
         <source>DL Module</source>
         <translation>DL modul</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="352"/>
+        <location filename="../ui/configpanel.py" line="411" />
         <source>General</source>
         <translation>Általános</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="354"/>
+        <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>Szövegfelismerés</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="394"/>
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="356"/>
+        <location filename="../ui/configpanel.py" line="415" />
         <source>Inpaint</source>
         <translation>Belefestés</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="357"/>
+        <location filename="../ui/configpanel.py" line="416" />
         <source>Translator</source>
         <translation>Fordító</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="358"/>
+        <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>Indulás</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="359"/>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="419" />
         <source>Typesetting</source>
         <translation>Betűtípus</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="360"/>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="421" />
         <source>Save</source>
         <translation>Mentés</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="361"/>
+        <location filename="../ui/configpanel.py" line="422" />
         <source>SalaDict</source>
         <translation>SalaDict</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand</source>
         <translation>Modellek betöltése szükség szerint</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand to save memory.</source>
         <translation>Modellek betöltése szükség szerint csökkenti a memória igényt</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN</source>
         <translation>FUTTATÁS után cache törlése</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN to save memory.</source>
         <translation>FUTTATÁS után cache törlése csökkenti a memória igényt.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="384"/>
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="518" />
         <source>Unload All Models</source>
         <translation>Minden modell ejtése</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="389"/>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
         <source>Detector</source>
         <translation>Felismerő</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="398"/>
+        <location filename="../ui/configpanel.py" line="626" />
         <source>Inpainter</source>
         <translation>Belefestő</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="406"/>
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
         <source>Reopen last project on startup</source>
         <translation>Utolsó projekt megnyitása induláskor</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="410"/>
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
         <source>decide by program</source>
         <translation>A program dönti el</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="411"/>
+        <location filename="../ui/configpanel.py" line="840" />
         <source>use global setting</source>
         <translation>Globális beállítás használata</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="421"/>
+        <location filename="../ui/configpanel.py" line="850" />
         <source>Font Size</source>
         <translation>Betűméret</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="425"/>
+        <location filename="../ui/configpanel.py" line="854" />
         <source>Stroke Size</source>
         <translation>Körvonal méret</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="429"/>
+        <location filename="../ui/configpanel.py" line="858" />
         <source>Font Color</source>
         <translation>Betűszín</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="432"/>
+        <location filename="../ui/configpanel.py" line="861" />
         <source>Stroke Color</source>
         <translation>Körvonal szín</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="436"/>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
         <source>Effect</source>
         <translation>Effekt</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="439"/>
+        <location filename="../ui/configpanel.py" line="898" />
         <source>Alignment</source>
         <translation>Igazítás</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="443"/>
+        <location filename="../ui/configpanel.py" line="902" />
         <source>Writing-mode</source>
         <translation>Írásmód</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Keep existing</source>
         <translation>Meglévő megtartása</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Always use global setting</source>
         <translation>Mindig a globális beállítások használata</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="446"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Font Family</source>
         <translation>Betűcsalád</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452"/>
+        <location filename="../ui/configpanel.py" line="911" />
         <source>Auto layout</source>
         <translation>Automata elrendezés</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="452"/>
-        <source>Split translation into multi-lines according to the extracted balloon region.</source>
-        <translation>A fordítás elosztása több sorra a kivont szövegbuborékrésznek megfelelően.</translation>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="456"/>
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">Automata</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
         <source>To uppercase</source>
         <translation>Nagybetűsítés</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="459"/>
+        <location filename="../ui/configpanel.py" line="1108" />
         <source>Independent text styles for each projects</source>
         <translation>Eltérő szövegstílus minden egyes projektnek</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="462"/>
+        <location filename="../ui/configpanel.py" line="1111" />
         <source>Show only custom fonts</source>
         <translation>Csak egyedi betűtípusok mutatása</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="466"/>
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
         <source>Result image format</source>
         <translation>Végeredmény képformátuma</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="471"/>
+        <location filename="../ui/configpanel.py" line="1128" />
         <source>Quality</source>
         <translation>Minőség</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="478"/>
-        <source>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md&quot;&gt;Installation guide&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/blob/dev/doc/saladict_es.md&quot;&gt;Guía de instalación&lt;/a&gt;</translation>
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="482"/>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/blob/dev/doc/saladict_es.md"&gt;Guía de instalación&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
         <source>Show mini menu when selecting text.</source>
         <translation>Mini menü mutatása szövegkijelölés esetén</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="488"/>
+        <location filename="../ui/configpanel.py" line="1160" />
         <source>Shortcut</source>
         <translation>Gyorsbillentyű</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="491"/>
+        <location filename="../ui/configpanel.py" line="1163" />
         <source>Search Engines</source>
         <translation>Keresőmotorok</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="353"/>
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
         <source>Mask Opacity</source>
         <translation>Maszk átlátszóság</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="100"/>
+        <location filename="../ui/io_thread.py" line="118" />
         <source>Export as doc...</source>
         <translation>DOC exportálása...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="106"/>
+        <location filename="../ui/io_thread.py" line="124" />
         <source>Overwrite </source>
         <translation>Felülírás</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-        <location filename="../ui/text_panel.py" line="262"/>
+        <location filename="../ui/text_panel.py" line="275" />
         <source>Font Family</source>
         <translation>Betűtípus</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="267"/>
+        <location filename="../ui/text_panel.py" line="280" />
         <source>Font Size</source>
         <translation>Betűméret</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="269"/>
+        <location filename="../ui/text_panel.py" line="282" />
         <source>Change font size</source>
         <translation>Betűméret változtatása</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="279"/>
+        <location filename="../ui/text_panel.py" line="292" />
         <source>Change line spacing</source>
         <translation>Sortávolság változtatása</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="283"/>
+        <location filename="../ui/text_panel.py" line="296" />
         <source>Change font color</source>
         <translation>Betűszín változtatása</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="300"/>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
         <source>Change stroke width</source>
         <translation>Körvonal szélessége</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="303"/>
+        <location filename="../ui/text_panel.py" line="364" />
         <source>Stroke</source>
         <translation>Körvonal</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="312"/>
+        <location filename="../ui/text_panel.py" line="373" />
         <source>Change stroke color</source>
         <translation>Körvonal színe</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="325"/>
+        <location filename="../ui/text_panel.py" line="386" />
         <source>Change letter spacing</source>
         <translation>Betűtávolság változtatása</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="339"/>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">Átlátszóság</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
         <source>Global Font Format</source>
         <translation>Globális betű formátum</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="348"/>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
         <source>Advanced Text Format</source>
         <translation>Haladó szövegformázás</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Unfold</source>
         <translation>Kinyit</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="369"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Fold</source>
         <translation>Becsuk</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="370"/>
+        <location filename="../ui/text_panel.py" line="462" />
         <source>Source</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="371"/>
+        <location filename="../ui/text_panel.py" line="463" />
         <source>Translation</source>
         <translation>Fordítás</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="189"/>
+        <location filename="../ui/global_search_widget.py" line="192" />
         <source>Replace...</source>
         <translation>Csere...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="195"/>
+        <location filename="../ui/global_search_widget.py" line="198" />
         <source>Replace all occurrences?</source>
         <translation>Mindenhol cseréljek?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="305"/>
+        <location filename="../ui/global_search_widget.py" line="308" />
         <source>Find</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="308"/>
+        <location filename="../ui/global_search_widget.py" line="311" />
         <source>No results found. </source>
         <translation>Nincs találat.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="309"/>
+        <location filename="../ui/global_search_widget.py" line="312" />
         <source>Document changed. Press Enter to re-search.</source>
         <translation>Dokumentum megváltozott. Nyomj Enter-t az újra kereséshez.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="310"/>
+        <location filename="../ui/global_search_widget.py" line="313" />
         <source>Found results: </source>
         <translation>Találatok:</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="316"/>
+        <location filename="../ui/global_search_widget.py" line="319" />
         <source>Match Case</source>
         <translation>Kis- és nagybetű számít</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="321"/>
+        <location filename="../ui/global_search_widget.py" line="324" />
         <source>Match Whole Word</source>
         <translation>Teljes szóval egyező</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="326"/>
+        <location filename="../ui/global_search_widget.py" line="329" />
         <source>Use Regular Expression</source>
         <translation>Reguláris kifejezés használata</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Translation</source>
         <translation>Fordítás</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Source</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>All</source>
         <translation>Mind</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="333"/>
+        <location filename="../ui/global_search_widget.py" line="336" />
         <source> in</source>
         <translation>benne</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="336"/>
+        <location filename="../ui/global_search_widget.py" line="339" />
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="339"/>
+        <location filename="../ui/global_search_widget.py" line="342" />
         <source>Replace All</source>
         <translation>Összes cseréje</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="341"/>
+        <location filename="../ui/global_search_widget.py" line="344" />
         <source>Replace All and Re-render all pages</source>
         <translation>Összes cseréje és minden oldal újra mentése</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="382"/>
+        <location filename="../ui/global_search_widget.py" line="385" />
         <source>Replace...</source>
         <translation>Csere...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="487"/>
-        <source>Replace all occurrences re-render all pages? It can&apos;t be undone.</source>
+        <location filename="../ui/global_search_widget.py" line="490" />
+        <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>Összes cseréje és minden oldal újra mentése? Nem visszaállítható.</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ImgtransProgressMessageBox</name>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="183" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="184" />
+        <source>OCR: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="185" />
+        <source>Inpainting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="186" />
+        <source>Translating: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="389"/>
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
         <source>OCR Failed.</source>
         <translation>OCR nem sikerült.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="369"/>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation type="unfinished">Fordítás nem sikerült.</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1022" />
         <source>Text Detection Failed.</source>
         <translation>Szövegfelsimerés nem sikerült.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="450"/>
+        <location filename="../ui/module_manager.py" line="1526" />
         <source>Inpainting Failed.</source>
         <translation>Belefestés nem sikerült.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="136"/>
+        <location filename="../ui/io_thread.py" line="154" />
         <source>Import doc...</source>
         <translation>Doku importálása...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="143"/>
+        <location filename="../ui/io_thread.py" line="161" />
         <source>Import *.docx</source>
         <translation>*.docx importálása</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="426"/>
+        <location filename="../ui/module_parse_widgets.py" line="533" />
         <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
         <translation>A program dönti el, hogy melyik festési módszert kell használni.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>InpaintPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="74"/>
+        <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>Vastagság</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="79"/>
+        <location filename="../ui/drawingpanel.py" line="80" />
         <source>Shape</source>
         <translation>Alakzat</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="83" />
         <source>Circle</source>
         <translation>Kör</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="84" />
         <source>Rectangle</source>
         <translation>Négyzet</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="92"/>
+        <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
         <source>Inpainter</source>
         <translation>Belefestő</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="122"/>
+        <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>Belefestés nem sikerült.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="25" />
         <source>Keyword</source>
         <translation>Kulcsszó</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="26" />
         <source>Substitution</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="27" />
         <source>Use regex</source>
         <translation>Regex használata</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="28" />
         <source>Case sensitive</source>
         <translation>Kis- és nagybetű érzékeny</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="35"/>
+        <location filename="../ui/keywordsubwidget.py" line="35" />
         <source>New</source>
         <translation>Új</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="37"/>
+        <location filename="../ui/keywordsubwidget.py" line="37" />
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="77"/>
+        <location filename="../ui/mainwindowbars.py" line="104" />
         <source>Global Search (Ctrl+G)</source>
         <translation>Keresés mindenhol (Ctrl+G)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="88"/>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
         <translation>Mappa megnyitása...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="92"/>
+        <location filename="../ui/mainwindowbars.py" line="132" />
         <source>Open Project ... *.json</source>
         <translation>Peojekt megnyitása ... *.json</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="95"/>
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
         <source>Save Project</source>
         <translation>Projekt mentés</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="99"/>
+        <location filename="../ui/mainwindowbars.py" line="155" />
         <source>Export as Doc</source>
         <translation>Doc mentése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="101"/>
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
         <source>Import from Doc</source>
         <translation>Doc miportálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="104"/>
-        <source>Export soure text as TXT</source>
-        <translation>Eredeti szöveg exportálása TXT</translation>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="106"/>
+        <location filename="../ui/mainwindowbars.py" line="165" />
         <source>Export translation as TXT</source>
         <translation>Lefordított szöveg exportálása TXT</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="109"/>
-        <source>Export soure text as markdown</source>
-        <translation>Eredeti szöveg exportálása Markdown</translation>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="111"/>
+        <location filename="../ui/mainwindowbars.py" line="170" />
         <source>Export translation as markdown</source>
         <translation>Lefordított szöveg exportálása  markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="114"/>
+        <location filename="../ui/mainwindowbars.py" line="173" />
         <source>Import translation from TXT/markdown</source>
         <translation>Lefordított szöveg importálása TXT TXT/markdown</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="117"/>
+        <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>Legutóbbi megnyitása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="143"/>
-        <source>RUN</source>
-        <translation>FUTTATÁS</translation>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="237"/>
+        <location filename="../ui/mainwindowbars.py" line="303" />
         <source>Select Directory</source>
         <translation>Mappa  kiválasztása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="244"/>
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>*.docx importálás</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="202"/>
+        <location filename="../ui/mainwindow.py" line="465" />
         <source>Keyword substitution for source text</source>
         <translation>Eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="206"/>
+        <location filename="../ui/mainwindow.py" line="469" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Gépi fordított eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="210"/>
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>Gépi fordításban kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="481"/>
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
         <source>Failed to load project </source>
         <translation>Nem sikerült a projekt megnyitása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="500"/>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
         <source>Failed to load project from</source>
         <translation>Nem sikerült a projekt megnyitása innen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="552"/>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
         <source>Restart to apply changes? 
 </source>
         <translation>A változások beállításához újraindítsam a programot?</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192"/>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">Összegzés: letöltve {0}, sikertelen {1}, kihagyva {2}.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">Modellek kezelése megnyitása</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation type="unfinished">A modellcsomag letöltése kész</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">Néhány modellcsomag letöltése sikertelen. Sikertelen elemek: {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation type="unfinished">A modellcsomag letöltése részben kész</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">Az első indítás helyi módja aktív. A modellek importálásához/letöltéséhez használd az Eszközök → Modellek kezelése menüt, vagy szerkeszd a config/config.json fájlt a csomagok engedélyezéséhez, majd indítsd újra.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">A letöltés részben befejeződött.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">A letöltés kész. Az alapértelmezések frissítve.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation type="unfinished">A modellcsomagok letöltődtek. Alkalmazott modulok:
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>unsaved</source>
         <translation>mentetlen</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1192"/>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>saved</source>
         <translation>mentett</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1226"/>
+        <location filename="../ui/mainwindow.py" line="3258" />
         <source>Saving image...</source>
         <translation>Kép mentése...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239"/>
+        <location filename="../ui/mainwindow.py" line="3297" />
         <source>Confirmation</source>
         <translation>Megerősítés</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1239"/>
-        <source>Are you sure to run image translation again?
-All existing translation results will be cleared!</source>
-        <translation>Biztos, hogy újra fusson a fordítás?
-Minden eddigi fordítás elveszik!</translation>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1287"/>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">Futtatás</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
         <source>Import Text Styles</source>
         <translation>Szövegstílus importálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1297"/>
-        <source>Failed to load from {p}</source>
-        <translation>Nem sikerült betölteni innen {p}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1301"/>
+        <location filename="../ui/mainwindow.py" line="3417" />
         <source>Save Text Styles</source>
         <translation>Szövegstílus mentése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1318"/>
-        <source>Failed save to {savep}</source>
-        <translation>Nem sikerült a mentés ide {savep}</translation>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1344"/>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
         <source>Text file exported to </source>
         <translation>Szöveges fájl mentése ide</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1346"/>
+        <location filename="../ui/mainwindow.py" line="3565" />
         <source>Failed to export as TEXT file</source>
         <translation>Nem sikerült a TXT fájl exportálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1352"/>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
         <source>Import *.md/*.txt</source>
         <translation>*.md/*.txt importálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1364"/>
+        <location filename="../ui/mainwindow.py" line="3604" />
         <source>Translation imported and matched successfully.</source>
         <translation>Sikeres importálása és egyezése a fordításnak.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1366"/>
-        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from &quot;export TXT/markdown&quot;</source>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
         <translation>Az importált txt fájl nem felel meg teljesen az aktuális projektnek, kérjük, győződjön meg róla, hogy a forrás txt fájl szerkezete megegyezik a „TXT/markdown exportálás” eredményével.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1368"/>
+        <location filename="../ui/mainwindow.py" line="3608" />
         <source>Missing pages: </source>
         <translation>Hiányzó oldalak: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1371"/>
+        <location filename="../ui/mainwindow.py" line="3611" />
         <source>Unexpected pages: </source>
         <translation>Nem várt oldalak: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1374"/>
+        <location filename="../ui/mainwindow.py" line="3614" />
         <source>Unmatched pages: </source>
         <translation>Nem passzoló oldalak: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1380"/>
+        <location filename="../ui/mainwindow.py" line="3625" />
         <source>Failed to import translation from </source>
         <translation>Nem sikerült a fordítás importálása innen </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1404"/>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
         <source>Export to </source>
         <translation>Exportálás ide </translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">Keresés</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">Helyi modellkönyvtár importálása...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
+        <source>Select local model directory</source>
+        <translation type="unfinished">Helyi modellkönyvtár kiválasztása</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">Helyi modellek importálása</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">Előbeállítás helyett kézzel válassz alacsony szintű csomagokat.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">Kézi csomagválasztás</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
+        <source>Skip all downloads (local-only)</source>
+        <translation type="unfinished">Minden letöltés kihagyása (csak helyi)</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">Most ne tölts le modellcsomagot. Csak a már helyben elérhető modulokat/fájlokat használd.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">Az alapcsomag nincs kiválasztva</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleManager</name>
     <message>
-        <location filename="../ui/module_manager.py" line="858"/>
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
         <source>Set Inpainter...</source>
         <translation>Belefestő motor beállítása...</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>OCRConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="451"/>
+        <location filename="../ui/module_parse_widgets.py" line="830" />
         <source>Delete and restore region where OCR return empty string.</source>
         <translation>Terület törlése és visszaállítása ahol az OCR üres eredményt ad.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">Eredeti</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">Fordítás</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageListView</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="51"/>
+        <location filename="../ui/mainwindow.py" line="88" />
         <source>Reveal in File Explorer</source>
         <translation>Megnyitás Fájlkezelőben</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
-        <location filename="../ui/page_search_widget.py" line="207"/>
+        <location filename="../ui/page_search_widget.py" line="207" />
         <source>Find</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="210"/>
+        <location filename="../ui/page_search_widget.py" line="210" />
         <source>No result</source>
         <translation>Nincs eredmény</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="216"/>
+        <location filename="../ui/page_search_widget.py" line="216" />
         <source>Previous Match (Shift+Enter)</source>
         <translation>Előző találat (Shift+Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="221"/>
+        <location filename="../ui/page_search_widget.py" line="221" />
         <source>Next Match (Enter)</source>
         <translation>Következő találat (Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="225"/>
+        <location filename="../ui/page_search_widget.py" line="225" />
         <source>Match Case</source>
         <translation>Betűméret egyezés</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="230"/>
+        <location filename="../ui/page_search_widget.py" line="230" />
         <source>Match Whole Word</source>
         <translation>Teljes szóval egyező</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="235"/>
+        <location filename="../ui/page_search_widget.py" line="235" />
         <source>Use Regular Expression</source>
         <translation>Regex használata</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Translation</source>
         <translation>Fordítás</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Source</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>All</source>
         <translation>Mind</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="242"/>
+        <location filename="../ui/page_search_widget.py" line="242" />
         <source>Range</source>
         <translation>Tartomány</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="249"/>
+        <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>Csere</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="253"/>
+        <location filename="../ui/page_search_widget.py" line="253" />
         <source>Replace All</source>
         <translation>Összes cseréje</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="290"/>
+        <location filename="../ui/page_search_widget.py" line="290" />
         <source>Close (Escape)</source>
         <translation>Bezárás  (Escape)</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PenConfigPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="136"/>
+        <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
         <translation>Szín</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="137"/>
+        <location filename="../ui/drawingpanel.py" line="153" />
         <source>Alpha</source>
         <translation>Átlátszóság</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="145"/>
+        <location filename="../ui/drawingpanel.py" line="161" />
         <source>Thickness</source>
         <translation>Vastagság</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="150"/>
+        <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>Alakzat</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="169" />
         <source>Circle</source>
         <translation>Kör</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="170" />
         <source>Rectangle</source>
         <translation>Négyzet</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="197"/>
+        <location filename="../ui/drawingpanel.py" line="214" />
         <source>Dilate</source>
         <translation>Tágulás</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 1</source>
-        <translation>1 módszer</translation>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 2</source>
-        <translation>2 módszer</translation>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>Use Existing Mask</source>
-        <translation>Meglévő maszk használata</translation>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="210"/>
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">Négyzet</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
         <source>Auto</source>
         <translation>Automata</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="211"/>
+        <location filename="../ui/drawingpanel.py" line="241" />
         <source>run inpainting automatically.</source>
         <translation>Belefestés automata futtatása.</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="213"/>
+        <location filename="../ui/drawingpanel.py" line="243" />
         <source>Inpaint</source>
         <translation>Belefestés</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="214"/>
+        <location filename="../ui/drawingpanel.py" line="244" />
         <source>Space</source>
         <translation>Hely</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="216"/>
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
         <source>Delete</source>
         <translation>Törlés</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="217"/>
+        <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="224"/>
+        <location filename="../ui/drawingpanel.py" line="258" />
         <source>Inpainter</source>
         <translation>Belefestő modell</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">Alakzat</translation>
+    </message>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
-        <location filename="../ui/textedit_area.py" line="30"/>
+        <location filename="../ui/textedit_area.py" line="30" />
         <source>Search selected text on Internet</source>
         <translation>Kijelölt szöveg keresése az Interneten</translation>
     </message>
     <message>
-        <location filename="../ui/textedit_area.py" line="36"/>
+        <location filename="../ui/textedit_area.py" line="36" />
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>Kijelölt szöveg keresése a SalaDict-ben, lásd telepítési útmutató a beállításoknál</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished">Gyorsbillentyű</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">Fordítás</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">Fordító</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished">Mentés</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextAdvancedFormatPanel</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146"/>
+        <location filename="../ui/text_advanced_format.py" line="170" />
         <source>Proportional</source>
         <translation>Arányos</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="146"/>
+        <location filename="../ui/text_advanced_format.py" line="171" />
         <source>Distance</source>
         <translation>Távolság</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="156"/>
+        <location filename="../ui/text_advanced_format.py" line="175" />
         <source>Line Spacing Type</source>
         <translation>Sortávolság típusa</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="162"/>
+        <location filename="../ui/text_advanced_format.py" line="182" />
         <source>Set Text Opacity</source>
         <translation>Szöveg átlátszóság beállítása</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="164"/>
+        <location filename="../ui/text_advanced_format.py" line="184" />
         <source>Opacity</source>
         <translation>Átlátszóság</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="175"/>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
         <source>Shadow</source>
         <translation>Árnyék</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextDetectConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="442"/>
+        <location filename="../ui/module_parse_widgets.py" line="615" />
         <source>Keep Existing Lines</source>
         <translation>Meglévő sorok megtartása</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextGradientGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="83"/>
+        <location filename="../ui/text_advanced_format.py" line="91" />
         <source>Gradient</source>
         <translation>Átmenet</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="87"/>
+        <location filename="../ui/text_advanced_format.py" line="96" />
         <source>Start Color</source>
         <translation>Kezdő szín</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="93"/>
+        <location filename="../ui/text_advanced_format.py" line="100" />
         <source>End Color</source>
         <translation>Záró szín</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="98"/>
+        <location filename="../ui/text_advanced_format.py" line="102" />
         <source>Enable</source>
         <translation>Engedélyezés</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="102"/>
-        <source>Set Gradient Angle</source>
-        <translation>Átmenet szöge</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="104"/>
-        <source>Angle</source>
-        <translation>Szög</translation>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="112"/>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="112" />
         <source>Set Gradient Size</source>
         <translation>Átmenet mérete</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="114"/>
+        <location filename="../ui/text_advanced_format.py" line="114" />
         <source>Size</source>
         <translation>Méret</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation>Átmenet szöge</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation>Szög</translation>
+    </message>
+</context><context>
     <name>TextShadowGroup</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="16"/>
+        <location filename="../ui/text_advanced_format.py" line="17" />
         <source>Set X offset</source>
         <translation>X eltolás mértéke</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="26"/>
+        <location filename="../ui/text_advanced_format.py" line="28" />
         <source>Set Y offset</source>
         <translation>Y eltolás mértéke</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="38"/>
+        <location filename="../ui/text_advanced_format.py" line="40" />
         <source>Set Shadow Strength</source>
         <translation>Árnyék erőssége</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="40"/>
+        <location filename="../ui/text_advanced_format.py" line="42" />
         <source>Strength</source>
         <translation>Erősség</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="48"/>
+        <location filename="../ui/text_advanced_format.py" line="51" />
         <source>Set Shadow Radius</source>
         <translation>Árnyék rádiusza</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="50"/>
+        <location filename="../ui/text_advanced_format.py" line="53" />
         <source>Radius</source>
         <translation>Átmérő</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="66"/>
+        <location filename="../ui/text_advanced_format.py" line="72" />
         <source>Offset</source>
         <translation>Eltolás</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStyleLabel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="86"/>
+        <location filename="../ui/text_style_presets.py" line="87" />
         <source>Click to set as Global format. Double click to edit name.</source>
         <translation>Kattintson a gombra a Globális formátum beállításához. A név szerkesztéséhez kattintson duplán.</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="98"/>
+        <location filename="../ui/text_style_presets.py" line="99" />
         <source>Apply Text Style</source>
         <translation>Szövegstílus alkalmazása</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="103"/>
+        <location filename="../ui/text_style_presets.py" line="104" />
         <source>Update from active style</source>
         <translation>Frissítés az aktív stílusból</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="120"/>
+        <location filename="../ui/text_style_presets.py" line="121" />
         <source>Delete Style</source>
         <translation>Stílus törlése</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStylePresetPanel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="276"/>
+        <location filename="../ui/text_style_presets.py" line="277" />
         <source>Style</source>
         <translation>Stílus</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="439"/>
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
         <source>New Text Style</source>
         <translation>Új szövegstílus</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="285"/>
+        <location filename="../ui/text_style_presets.py" line="286" />
         <source>Remove All</source>
         <translation>Mind törlése</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="299"/>
+        <location filename="../ui/text_style_presets.py" line="300" />
         <source>Remove all styles?</source>
         <translation>Minden stílus törlése?</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="440"/>
+        <location filename="../ui/text_style_presets.py" line="462" />
         <source>Remove all</source>
         <translation>Mind törlése</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="442"/>
+        <location filename="../ui/text_style_presets.py" line="464" />
         <source>Import Text Styles</source>
         <translation>Szövegstílus importálása</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="443"/>
+        <location filename="../ui/text_style_presets.py" line="465" />
         <source>Export Text Styles</source>
         <translation>Szövegstílus exportálása</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TitleBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="283"/>
+        <location filename="../ui/mainwindowbars.py" line="443" />
         <source>Edit</source>
         <translation>Szerkesztés</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="285"/>
+        <location filename="../ui/mainwindowbars.py" line="445" />
         <source>Undo</source>
         <translation>Visszavonás</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="288"/>
+        <location filename="../ui/mainwindowbars.py" line="448" />
         <source>Redo</source>
         <translation>Mégis</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="291"/>
+        <location filename="../ui/mainwindowbars.py" line="451" />
         <source>Search</source>
         <translation>Keresés</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="294"/>
+        <location filename="../ui/mainwindowbars.py" line="454" />
         <source>Global Search</source>
         <translation>Keresés mindenhol</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="298"/>
+        <location filename="../ui/mainwindowbars.py" line="458" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Gépi fordított eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="300"/>
+        <location filename="../ui/mainwindowbars.py" line="460" />
         <source>Keyword substitution for machine translation</source>
         <translation>Gépi fordításban kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="302"/>
+        <location filename="../ui/mainwindowbars.py" line="462" />
         <source>Keyword substitution for source text</source>
         <translation>Eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="313"/>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>Nézet</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="315"/>
+        <location filename="../ui/mainwindowbars.py" line="486" />
         <source>Display Language</source>
         <translation>Program nyelve</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="329"/>
+        <location filename="../ui/mainwindowbars.py" line="500" />
         <source>Drawing Board</source>
         <translation>Rajztábla</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="331"/>
+        <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>Szövegszerkesztő</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="333"/>
+        <location filename="../ui/mainwindowbars.py" line="504" />
         <source>Import Text Styles</source>
         <translation>Szövegstílus importálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="334"/>
+        <location filename="../ui/mainwindowbars.py" line="505" />
         <source>Export Text Styles</source>
         <translation>Szövegstílus exportálása</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="335"/>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
         <source>Dark Mode</source>
         <translation>Sötét mód</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="355"/>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
         <source>Go</source>
         <translation>Indulás</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="356"/>
+        <location filename="../ui/mainwindowbars.py" line="601" />
         <source>Previous Page</source>
         <translation>Előző oldal</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="358"/>
+        <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>Következő oldal</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="381"/>
-        <source>Run</source>
-        <translation>Futtatás</translation>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="371"/>
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
         <source>Enable Text Dection</source>
         <translation>Szövegfelismerés engedélyezése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="372"/>
+        <location filename="../ui/mainwindowbars.py" line="764" />
         <source>Enable OCR</source>
         <translation>OCR engedélyezése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="373"/>
+        <location filename="../ui/mainwindowbars.py" line="765" />
         <source>Enable Translation</source>
         <translation>Fordítás engedélyezése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="374"/>
+        <location filename="../ui/mainwindowbars.py" line="766" />
         <source>Enable Inpainting</source>
         <translation>Belefestés engedélyezése</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="382"/>
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>Futtatás</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
         <source>Run without update textstyle</source>
         <translation>Futtatás szövegstílus frissítése nélkül</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="383"/>
+        <location filename="../ui/mainwindowbars.py" line="775" />
         <source>Translate page</source>
         <translation>Oldal fordítása</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">Mappa megnyitása...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">Peojekt megnyitása ... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">Projekt mentés</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">Doc mentése</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished">Lefordított szöveg exportálása TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished">Lefordított szöveg exportálása  markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">Doc miportálása</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished">Lefordított szöveg importálása TXT TXT/markdown</translation>
+    </message>
+</context><context>
     <name>TranslateThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="189"/>
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
         <source>Failed to set translator </source>
         <translation>Fordítás beállítása nem sikerült</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="239"/>
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>Fordítás nem sikerült.</translation>
     </message>
+</context><context>
+    <name>TranslationContextDialog</name>
     <message>
-        <location filename="../ui/module_manager.py" line="241"/>
-        <source> is required for </source>
-        <translation> ez szükséges a(z) </translation>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="379"/>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
         <source>Keyword substitution for machine translation source text</source>
         <translation>Gépi fordított eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="382"/>
+        <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>Gépi fordításban kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="385"/>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
         <source>Keyword substitution for source text</source>
         <translation>Eredeti szövegben kulcsszó csere</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="392"/>
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
         <source>Source</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="394"/>
+        <location filename="../ui/module_parse_widgets.py" line="480" />
         <source>Target</source>
         <translation>Cél</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TranslatorSelectionWidget</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="567"/>
+        <location filename="../ui/mainwindowbars.py" line="1468" />
         <source>Translate</source>
         <translation>fordítás</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
+        <location filename="../ui/mainwindowbars.py" line="1470" />
         <source>Source</source>
         <translation>Eredeti</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="571"/>
+        <location filename="../ui/mainwindowbars.py" line="1472" />
         <source>Target</source>
         <translation>Cél</translation>
     </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
     <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>Modellfájlok másolása egy meglévő helyi mappából az alkalmazás data/models könyvtárába.</translation>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package</source>
-        <translation>Alapcsomag</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package not selected</source>
-        <translation>Az alapcsomag nincs kiválasztva</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>Most ne tölts le modellcsomagot. Csak a már helyben elérhető modulokat/fájlokat használd.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>A letöltés kész. Az alapértelmezések frissítve.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download partially complete.</source>
-        <translation>A letöltés részben befejeződött.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>Az első indítás helyi módja aktív. A modellek importálásához/letöltéséhez használd az Eszközök → Modellek kezelése menüt, vagy szerkeszd a config/config.json fájlt a csomagok engedélyezéséhez, majd indítsd újra.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local model directory...</source>
-        <translation>Helyi modellkönyvtár importálása...</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local models</source>
-        <translation>Helyi modellek importálása</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">Visszavonás</translation>
     </message>
     <message>
-        <source>Manual package selection</source>
-        <translation>Kézi csomagválasztás</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">Mégis</translation>
     </message>
     <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>Előbeállítás helyett kézzel válassz alacsony szintű csomagokat.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download complete</source>
-        <translation>A modellcsomag letöltése kész</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download partially complete</source>
-        <translation>A modellcsomag letöltése részben kész</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>A modellcsomagok letöltődtek. Alkalmazott modulok:
-</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>Modellek kezelése megnyitása</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Select local model directory</source>
-        <translation>Helyi modellkönyvtár kiválasztása</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation>Minden letöltés kihagyása (csak helyi)</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>Néhány modellcsomag letöltése sikertelen. Sikertelen elemek: {0}</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished">Stílus</translation>
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>Összegzés: letöltve {0}, sikertelen {1}, kihagyva {2}.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">Törlés</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">Fordítás</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">Futtatás</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/ko_KR.ts
+++ b/translate/ko_KR.ts
@@ -2,1547 +2,8785 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ko_KR" sourcelanguage="en">
 <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
-        <source>translate page</source>
-        <translation>이 페이지 번역</translation>
+        <location filename="../ui/mainwindowbars.py" line="1566" />
+        <source>Text Detector</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
-        <source>stop</source>
-        <translation>중지</translation>
+        <location filename="../ui/mainwindowbars.py" line="1567" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
-        <source>translate current page</source>
-        <translation>현재 페이지를 번역</translation>
+        <location filename="../ui/mainwindowbars.py" line="1568" />
+        <source>Inpaint</source>
+        <translation type="unfinished">인페인트</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="569"/>
-        <source>stop translation</source>
-        <translation>번역 중지</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">실행</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="579"/>
-        <source>Enable/disable paint mode</source>
-        <translation>페인트 모드를 활성화/비활성화</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="583"/>
-        <source>Enable/disable text edit mode</source>
-        <translation>텍스트 편집 모드를 활성화/비활성화</translation>
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="589"/>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
         <source>Original image opacity</source>
         <translation>원본 이미지 불투명도</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="593"/>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
         <source>Text layer opacity</source>
         <translation>텍스트 레이어 불투명도</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="756"/>
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">편집</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1073" />
         <source>Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="758"/>
+        <location filename="../ui/canvas.py" line="1078" />
         <source>Paste</source>
         <translation>붙여넣기</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="760"/>
-        <source>Delete</source>
-        <translation>삭제</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="762"/>
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1091" />
         <source>Copy source text</source>
         <translation>소스 텍스트를 복사합니다</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="764"/>
+        <location filename="../ui/canvas.py" line="1096" />
         <source>Paste source text</source>
         <translation>소스 텍스트를 붙여 넣습니다</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="766"/>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>삭제</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
         <source>Delete and Recover removed text</source>
         <translation>삭제하고 원본 텍스트를 복원</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="771"/>
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">대문자로</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
         <source>Apply font formatting</source>
         <translation>글꼴 형식 적용</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="772"/>
+        <location filename="../ui/canvas.py" line="1275" />
         <source>Auto layout</source>
         <translation>자동 레이아웃</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="773"/>
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">자동</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
         <source>Reset Angle</source>
         <translation>각도 초기화</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="774"/>
+        <location filename="../ui/canvas.py" line="1326" />
         <source>Squeeze</source>
         <translation>텍스트 맞춤 크기 조절</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="776"/>
-        <source>translate</source>
-        <translation>번역</translation>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">실행</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="777"/>
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="778"/>
+        <location filename="../ui/canvas.py" line="1357" />
         <source>OCR and translate</source>
         <translation>OCR과 번역</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="779"/>
+        <location filename="../ui/canvas.py" line="1362" />
         <source>OCR, translate and inpaint</source>
         <translation>OCR, 번역 및 인페인트</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="780"/>
-        <source>inpaint</source>
-        <translation>인페인트</translation>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">인페인트</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-        <location filename="../ui/configpanel.py" line="351"/>
+        <location filename="../ui/configpanel.py" line="410" />
         <source>DL Module</source>
         <translation>DL 모듈</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="352"/>
+        <location filename="../ui/configpanel.py" line="411" />
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="354"/>
+        <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>텍스트 검출</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="393"/>
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="356"/>
+        <location filename="../ui/configpanel.py" line="415" />
         <source>Inpaint</source>
         <translation>인페인트</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="357"/>
+        <location filename="../ui/configpanel.py" line="416" />
         <source>Translator</source>
         <translation>번역기</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="358"/>
+        <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="359"/>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="419" />
         <source>Typesetting</source>
         <translation>글꼴</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="360"/>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="421" />
         <source>Save</source>
         <translation>저장</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="361"/>
+        <location filename="../ui/configpanel.py" line="422" />
         <source>SalaDict</source>
         <translation>SalaDict(확장)</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand</source>
         <translation>필요할 때만 모델로드</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="376"/>
+        <location filename="../ui/configpanel.py" line="443" />
         <source>Load models on demand to save memory.</source>
         <translation>메모리를 절약하기 위해 필요할 때만 모델을 로드</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN</source>
         <translation>실행 후 캐시 삭제</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="379"/>
+        <location filename="../ui/configpanel.py" line="456" />
         <source>Empty cache after RUN to save memory.</source>
         <translation>메모리를 절약하기 위해 실행 후 캐시 삭제</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="384"/>
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="518" />
         <source>Unload All Models</source>
         <translation>모든 모델 언로드</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="389"/>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
         <source>Detector</source>
         <translation>검출기</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="397"/>
+        <location filename="../ui/configpanel.py" line="626" />
         <source>Inpainter</source>
         <translation>인페인터</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="405"/>
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
         <source>Reopen last project on startup</source>
         <translation>시작시 마지막 프로젝트 다시 열기</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="409"/>
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
         <source>decide by program</source>
         <translation>프로그램이 결정</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="410"/>
+        <location filename="../ui/configpanel.py" line="840" />
         <source>use global setting</source>
         <translation>글로벌 설정 사용</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="420"/>
+        <location filename="../ui/configpanel.py" line="850" />
         <source>Font Size</source>
         <translation>글꼴 크기</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="424"/>
+        <location filename="../ui/configpanel.py" line="854" />
         <source>Stroke Size</source>
         <translation>획 크기</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="428"/>
+        <location filename="../ui/configpanel.py" line="858" />
         <source>Font Color</source>
         <translation>글꼴 색상</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="431"/>
+        <location filename="../ui/configpanel.py" line="861" />
         <source>Stroke Color</source>
         <translation>획 색상</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="435"/>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
         <source>Effect</source>
         <translation>효과</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="438"/>
+        <location filename="../ui/configpanel.py" line="898" />
         <source>Alignment</source>
         <translation>정렬</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="442"/>
+        <location filename="../ui/configpanel.py" line="902" />
         <source>Writing-mode</source>
         <translation>텍스트 방향(세로식질)</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="445"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Keep existing</source>
         <translation>기존 설정 유지</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="445"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Always use global setting</source>
         <translation>항상 글로벌 설정 사용</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="445"/>
+        <location filename="../ui/configpanel.py" line="905" />
         <source>Font Family</source>
         <translation>글꼴 스타일</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="451"/>
+        <location filename="../ui/configpanel.py" line="911" />
         <source>Auto layout</source>
         <translation>자동 레이아웃</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="451"/>
-        <source>Split translation into multi-lines according to the extracted balloon region.</source>
-        <translation>말풍선 모양에 맞게 번역본을 여러줄로 분할</translation>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="462"/>
-        <source>Adjust font size adaptively if it is set to &quot;decide by program.&quot;</source>
-        <translation type="obsolete">&quot;프로그램이 결정&quot;으로 설정된 경우 글꼴 크기를 적응형으로 조정</translation>
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="455"/>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">자동</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
         <source>To uppercase</source>
         <translation>대문자로</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="458"/>
+        <location filename="../ui/configpanel.py" line="1108" />
         <source>Independent text styles for each projects</source>
         <translation>프로젝트마다 독립적인 텍스트 스타일 사용</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="465"/>
+        <location filename="../ui/configpanel.py" line="1111" />
+        <source>Show only custom fonts</source>
+        <translation>커스텀 폰트만 표시</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
         <source>Result image format</source>
         <translation>결과 이미지 형식</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="470"/>
+        <location filename="../ui/configpanel.py" line="1128" />
         <source>Quality</source>
         <translation>품질</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="477"/>
-        <source>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md&quot;&gt;Installation guide&lt;/a&gt;</source>
-        <translation>&lt;a href = &quot;https://github.com/dmmaze/ballonstranslator/tree/master/doc/saladict.md&quot;&gt; 설치 안내서 &lt;/a&gt;</translation>
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="481"/>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href = "https://github.com/dmmaze/ballonstranslator/tree/master/doc/saladict.md"&gt; 설치 안내서 &lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
         <source>Show mini menu when selecting text.</source>
         <translation>텍스트 선택 시 미니 메뉴 표시</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="487"/>
+        <location filename="../ui/configpanel.py" line="1160" />
         <source>Shortcut</source>
         <translation>단축키</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="490"/>
+        <location filename="../ui/configpanel.py" line="1163" />
         <source>Search Engines</source>
         <translation>검색 엔진</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="461"/>
-        <source>Show only custom fonts</source>
-        <translation>커스텀 폰트만 표시</translation>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="353"/>
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
         <source>Mask Opacity</source>
         <translation>마스크 불투명도</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="100"/>
+        <location filename="../ui/io_thread.py" line="118" />
         <source>Export as doc...</source>
         <translation>DOC 내보내기 ...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="106"/>
+        <location filename="../ui/io_thread.py" line="124" />
         <source>Overwrite </source>
         <translation>덮어 쓰기</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-        <location filename="../ui/text_panel.py" line="295"/>
+        <location filename="../ui/text_panel.py" line="275" />
         <source>Font Family</source>
         <translation>글꼴 스타일</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="300"/>
+        <location filename="../ui/text_panel.py" line="280" />
         <source>Font Size</source>
         <translation>글꼴 크기</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="302"/>
+        <location filename="../ui/text_panel.py" line="282" />
         <source>Change font size</source>
         <translation>글꼴 크기 변경</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="312"/>
+        <location filename="../ui/text_panel.py" line="292" />
         <source>Change line spacing</source>
         <translation>줄 간격 변경</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="318"/>
+        <location filename="../ui/text_panel.py" line="296" />
         <source>Change font color</source>
         <translation>글꼴 색상 변경</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="332"/>
-        <source>Stroke</source>
-        <translation>획</translation>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="341"/>
-        <source>Change stroke color</source>
-        <translation>획 색상 변경</translation>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="348"/>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
         <source>Change stroke width</source>
         <translation>획 너비 변경</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="364"/>
+        <location filename="../ui/text_panel.py" line="364" />
+        <source>Stroke</source>
+        <translation>획</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="373" />
+        <source>Change stroke color</source>
+        <translation>획 색상 변경</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="386" />
         <source>Change letter spacing</source>
         <translation>자간 변경</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="373"/>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">불투명도</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
         <source>Global Font Format</source>
         <translation>글로벌 글꼴 형식</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="387"/>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
         <source>Advanced Text Format</source>
         <translation>고급 텍스트 형식</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="394"/>
-        <source>Effect</source>
-        <translation>효과</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="399"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Unfold</source>
         <translation>펄치기</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="399"/>
+        <location filename="../ui/text_panel.py" line="461" />
         <source>Fold</source>
         <translation>접기</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="400"/>
+        <location filename="../ui/text_panel.py" line="462" />
         <source>Source</source>
         <translation>원본</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="401"/>
+        <location filename="../ui/text_panel.py" line="463" />
         <source>Translation</source>
         <translation>번역</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="189"/>
+        <location filename="../ui/global_search_widget.py" line="192" />
         <source>Replace...</source>
         <translation>바꾸기...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="195"/>
+        <location filename="../ui/global_search_widget.py" line="198" />
         <source>Replace all occurrences?</source>
         <translation>모든 바꾸기를 적용 하시겠습니까?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="305"/>
+        <location filename="../ui/global_search_widget.py" line="308" />
         <source>Find</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="308"/>
+        <location filename="../ui/global_search_widget.py" line="311" />
         <source>No results found. </source>
         <translation>결과 없음</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="309"/>
+        <location filename="../ui/global_search_widget.py" line="312" />
         <source>Document changed. Press Enter to re-search.</source>
         <translation>문서가 변경되었습니다. 다시 검색하려면 Enter를 누르십시오.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="310"/>
+        <location filename="../ui/global_search_widget.py" line="313" />
         <source>Found results: </source>
         <translation>찾은 결과 :</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="316"/>
+        <location filename="../ui/global_search_widget.py" line="319" />
         <source>Match Case</source>
         <translation>일치 항목</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="321"/>
+        <location filename="../ui/global_search_widget.py" line="324" />
         <source>Match Whole Word</source>
         <translation>전체 단어 일치</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="326"/>
+        <location filename="../ui/global_search_widget.py" line="329" />
         <source>Use Regular Expression</source>
         <translation>정규 표현식 사용</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Translation</source>
         <translation>번역</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Source</source>
         <translation>원본</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="330"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>All</source>
         <translation>모두</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="333"/>
+        <location filename="../ui/global_search_widget.py" line="336" />
         <source> in</source>
         <translation>대상</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="336"/>
+        <location filename="../ui/global_search_widget.py" line="339" />
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="339"/>
+        <location filename="../ui/global_search_widget.py" line="342" />
         <source>Replace All</source>
         <translation>모두 바꾸기</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="341"/>
+        <location filename="../ui/global_search_widget.py" line="344" />
         <source>Replace All and Re-render all pages</source>
         <translation>모든 페이지에 바꾸기 후 재렌더링</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="382"/>
+        <location filename="../ui/global_search_widget.py" line="385" />
         <source>Replace...</source>
         <translation>바꾸기...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="487"/>
-        <source>Replace all occurrences re-render all pages? It can&apos;t be undone.</source>
+        <location filename="../ui/global_search_widget.py" line="490" />
+        <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>모든 페이지에 바꾸기 후 재렌더링 하시겠습니까? 되돌릴 수 없습니다.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImgtransProgressMessageBox</name>
     <message>
-        <location filename="../ui/custom_widget/message.py" line="160"/>
+        <location filename="../ui/custom_widget/message.py" line="183" />
         <source>Detecting: </source>
         <translation type="obsolete">검출 :</translation>
     </message>
     <message>
-        <location filename="../ui/custom_widget/message.py" line="161"/>
+        <location filename="../ui/custom_widget/message.py" line="184" />
         <source>OCR: </source>
         <translation type="obsolete">OCR :</translation>
     </message>
     <message>
-        <location filename="../ui/custom_widget/message.py" line="162"/>
+        <location filename="../ui/custom_widget/message.py" line="185" />
         <source>Inpainting: </source>
         <translation type="obsolete">인페인팅 :</translation>
     </message>
     <message>
-        <location filename="../ui/custom_widget/message.py" line="163"/>
+        <location filename="../ui/custom_widget/message.py" line="186" />
         <source>Translating: </source>
         <translation type="obsolete">번역 :</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="383"/>
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
         <source>OCR Failed.</source>
         <translation>OCR이 실패했습니다.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="370"/>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation type="unfinished">번역이 실패했습니다.</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1022" />
         <source>Text Detection Failed.</source>
         <translation>텍스트 검출에 실패했습니다.</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="444"/>
+        <location filename="../ui/module_manager.py" line="1526" />
         <source>Inpainting Failed.</source>
         <translation>인페인팅이 실패했습니다.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="136"/>
+        <location filename="../ui/io_thread.py" line="154" />
         <source>Import doc...</source>
         <translation>DOC 불러오기...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="143"/>
+        <location filename="../ui/io_thread.py" line="161" />
         <source>Import *.docx</source>
         <translation>*.docx 불러오기</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="372"/>
+        <location filename="../ui/module_parse_widgets.py" line="533" />
         <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
         <translation>선택한 인페인트 방식 사용 여부를 프로그램이 결정</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>InpaintPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="74"/>
+        <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>두께</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="79"/>
+        <location filename="../ui/drawingpanel.py" line="80" />
         <source>Shape</source>
         <translation>모양</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="83" />
         <source>Circle</source>
         <translation>원형</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="81"/>
+        <location filename="../ui/drawingpanel.py" line="84" />
         <source>Rectangle</source>
         <translation>사각형</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="92"/>
+        <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
         <source>Inpainter</source>
         <translation>인페인터</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="120"/>
+        <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>인페인팅이 실패했습니다.</translation>
     </message>
-</context>
-<context>
-    <name>InpainterStatusButton</name>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="75"/>
-        <source>Inpainter: </source>
-        <translation>인페인터 :</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="25" />
         <source>Keyword</source>
         <translation>키워드</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="26" />
         <source>Substitution</source>
         <translation>치환</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="27" />
         <source>Use regex</source>
         <translation>정규표현식 사용</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="28" />
         <source>Case sensitive</source>
         <translation>대/소문자 구분</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="35"/>
+        <location filename="../ui/keywordsubwidget.py" line="35" />
         <source>New</source>
         <translation>추가</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="37"/>
+        <location filename="../ui/keywordsubwidget.py" line="37" />
         <source>Delete</source>
         <translation>삭제</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="120"/>
+        <location filename="../ui/mainwindowbars.py" line="104" />
         <source>Global Search (Ctrl+G)</source>
         <translation>글로벌 검색 (Ctrl+G)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="131"/>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
         <translation>폴더 열기 ...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="135"/>
+        <location filename="../ui/mainwindowbars.py" line="132" />
         <source>Open Project ... *.json</source>
         <translation>프로젝트 열기 ... *.json</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="138"/>
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
         <source>Save Project</source>
         <translation>프로젝트 저장</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="142"/>
+        <location filename="../ui/mainwindowbars.py" line="155" />
         <source>Export as Doc</source>
         <translation>DOC 내보내기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="144"/>
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
         <source>Import from Doc</source>
         <translation>DOC 불러오기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="147"/>
-        <source>Export soure text as TXT</source>
-        <translation>원본 텍스트 TXT로 내보내기</translation>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="149"/>
+        <location filename="../ui/mainwindowbars.py" line="165" />
         <source>Export translation as TXT</source>
         <translation>번역 텍스트 TXT로 내보내기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="152"/>
-        <source>Export soure text as markdown</source>
-        <translation>원본 텍스트 마크다운 문서로 내보내기</translation>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="154"/>
+        <location filename="../ui/mainwindowbars.py" line="170" />
         <source>Export translation as markdown</source>
         <translation>번역 텍스트 마크다운 문서로 내보내기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="160"/>
+        <location filename="../ui/mainwindowbars.py" line="173" />
+        <source>Import translation from TXT/markdown</source>
+        <translation>텍스트/마크다운 파일에서 번역 불러오기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>최근 프로젝트</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="280"/>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="303" />
         <source>Select Directory</source>
         <translation>경로 선택</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="287"/>
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>*.docx 불러오기</translation>
     </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="186"/>
-        <source>RUN</source>
-        <translation>실행</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="157"/>
-        <source>Import translation from TXT/markdown</source>
-        <translation>텍스트/마크다운 파일에서 번역 불러오기</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="200"/>
-        <source>Keyword substitution for OCR</source>
-        <translation type="obsolete">OCR의 키워드 치환</translation>
+        <location filename="../ui/mainwindow.py" line="465" />
+        <source>Keyword substitution for source text</source>
+        <translation>OCR 결과에 대한 키워드 치환</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="211"/>
+        <location filename="../ui/mainwindow.py" line="469" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>원문에 대한 키워드 치환(전처리)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>번역문에 대한 키워드 치환(후처리)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="403"/>
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
         <source>Failed to load project </source>
         <translation>프로젝트를로드하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="422"/>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
         <source>Failed to load project from</source>
         <translation>프로젝트를로드하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="427"/>
-        <source>Restart to apply changes? 
-</source>
-        <translation type="obsolete">변경 사항을 적용하기 위해 다시 시작 하시겠습니까? 
-</translation>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1062"/>
-        <source>unsaved</source>
-        <translation>저장안됨</translation>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1062"/>
-        <source>saved</source>
-        <translation>저장</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1099"/>
-        <source>Saving image...</source>
-        <translation>이미지 저장 ...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1159"/>
-        <source>Import Text Styles</source>
-        <translation>텍스트 스타일 가져오기</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1173"/>
-        <source>Save Text Styles</source>
-        <translation>텍스트 스타일 내보내기</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1276"/>
-        <source>Export to </source>
-        <translation>내보내기</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="472"/>
+        <location filename="../ui/mainwindow.py" line="1020" />
         <source>Restart to apply changes? 
 </source>
         <translation>변경 사항을 적용하기 위해 다시 시작 하시겠습니까?
 </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1169"/>
-        <source>Failed to load from {p}</source>
-        <translation>불러오기에 실패하였습니다: {p}</translation>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1190"/>
-        <source>Failed save to {savep}</source>
-        <translation>저장에 실패하였습니다: {savep}</translation>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1216"/>
-        <source>Text file exported to </source>
-        <translation>텍스트 파일 저장됨: </translation>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1183"/>
-        <source>failed to export as TEXT file</source>
-        <translation type="obsolete">텍스트 파일로 내보내기에 실패하였습니다.</translation>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="203"/>
-        <source>Keyword substitution for source text</source>
-        <translation>OCR 결과에 대한 키워드 치환</translation>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1112"/>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">요약: 다운로드 {0}, 실패 {1}, 건너뜀 {2}.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">모델 관리 열기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation type="unfinished">모델 패키지 다운로드 완료</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">일부 모델 패키지가 실패했습니다. 실패 항목: {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation type="unfinished">모델 패키지 다운로드 부분 완료</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">첫 실행 로컬 전용 모드가 활성화되어 있습니다. 도구 → 모델 관리에서 모델을 가져오거나 다운로드하거나, config/config.json을 수정해 패키지를 활성화한 뒤 다시 시작하세요.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">다운로드가 부분적으로 완료되었습니다.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">다운로드 완료. 기본값이 업데이트되었습니다.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation type="unfinished">모델 패키지가 다운로드되었습니다. 적용된 모듈:
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>unsaved</source>
+        <translation>저장안됨</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>saved</source>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3258" />
+        <source>Saving image...</source>
+        <translation>이미지 저장 ...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3297" />
         <source>Confirmation</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1112"/>
-        <source>Are you sure to run image translation again?
-All existing translation results will be cleared!</source>
-        <translation>이미지 번역을 다시 실행하시겠습니까?
-모든 기존 번역 결과가 지워집니다!</translation>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1218"/>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">실행</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
+        <source>Import Text Styles</source>
+        <translation>텍스트 스타일 가져오기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3417" />
+        <source>Save Text Styles</source>
+        <translation>텍스트 스타일 내보내기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
+        <source>Text file exported to </source>
+        <translation>텍스트 파일 저장됨: </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3565" />
         <source>Failed to export as TEXT file</source>
         <translation>텍스트 파일을 내보내는 데 실패했습니다.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1224"/>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
         <source>Import *.md/*.txt</source>
         <translation>*.md/*.txt 불러오기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1236"/>
+        <location filename="../ui/mainwindow.py" line="3604" />
         <source>Translation imported and matched successfully.</source>
         <translation>번역을 성공적으로 불러왔습니다.</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1238"/>
-        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from &quot;export TXT/markdown&quot;</source>
-        <translation>불러온 텍스트 파일이 현재 프로젝트와 전체 매칭 되지 않습니다, 소스 텍스트가 &quot;텍스트/마크다운 파일 내보내기&quot; 메뉴로 생성된 파일과 동일한 구조인지 확인하세요</translation>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
+        <translation>불러온 텍스트 파일이 현재 프로젝트와 전체 매칭 되지 않습니다, 소스 텍스트가 "텍스트/마크다운 파일 내보내기" 메뉴로 생성된 파일과 동일한 구조인지 확인하세요</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1240"/>
+        <location filename="../ui/mainwindow.py" line="3608" />
         <source>Missing pages: </source>
         <translation>누락된 페이지: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1243"/>
+        <location filename="../ui/mainwindow.py" line="3611" />
         <source>Unexpected pages: </source>
         <translation>예상치 못한 페이지: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1246"/>
+        <location filename="../ui/mainwindow.py" line="3614" />
         <source>Unmatched pages: </source>
         <translation>불일치한 페이지: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1252"/>
+        <location filename="../ui/mainwindow.py" line="3625" />
         <source>Failed to import translation from </source>
         <translation>다음 파일에서 불러오기를 실패하였습니다: </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="207"/>
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>원문에 대한 키워드 치환(전처리)</translation>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
+        <source>Export to </source>
+        <translation>내보내기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">찾기</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">로컬 모델 디렉터리 가져오기...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
+        <source>Select local model directory</source>
+        <translation type="unfinished">로컬 모델 디렉터리 선택</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">로컬 모델 가져오기</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">프리셋 대신 저수준 패키지를 수동으로 선택합니다.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">수동 패키지 선택</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
+        <source>Skip all downloads (local-only)</source>
+        <translation type="unfinished">모든 다운로드 건너뛰기(로컬 전용)</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">지금은 어떤 모델 패키지도 다운로드하지 않습니다. 이미 로컬에 있는 모듈/파일만 사용합니다.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">핵심 패키지가 선택되지 않음</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleManager</name>
     <message>
-        <location filename="../ui/module_manager.py" line="871"/>
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished">검출 :</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
         <source>Set Inpainter...</source>
         <translation>인페인터 설정 ...</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="921"/>
-        <source>Invalid</source>
-        <translation>유효하지 않은</translation>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>OCRConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="404"/>
-        <source>Keyword substitution for OCR results</source>
-        <translation type="obsolete">OCR 결과 키워드 치환</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="395"/>
+        <location filename="../ui/module_parse_widgets.py" line="830" />
         <source>Delete and restore region where OCR return empty string.</source>
         <translation>OCR 결과가 없을 경우 원본 유지</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">원본</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">번역</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageListView</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="50"/>
+        <location filename="../ui/mainwindow.py" line="88" />
         <source>Reveal in File Explorer</source>
         <translation>파일 탐색기에서 열기</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
-        <location filename="../ui/page_search_widget.py" line="207"/>
+        <location filename="../ui/page_search_widget.py" line="207" />
         <source>Find</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="210"/>
+        <location filename="../ui/page_search_widget.py" line="210" />
         <source>No result</source>
         <translation>결과 없음</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="216"/>
+        <location filename="../ui/page_search_widget.py" line="216" />
         <source>Previous Match (Shift+Enter)</source>
         <translation>이전 찾기 (Shift+Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="221"/>
+        <location filename="../ui/page_search_widget.py" line="221" />
         <source>Next Match (Enter)</source>
         <translation>다음 찾기 (Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="225"/>
+        <location filename="../ui/page_search_widget.py" line="225" />
         <source>Match Case</source>
         <translation>일치 항목</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="230"/>
+        <location filename="../ui/page_search_widget.py" line="230" />
         <source>Match Whole Word</source>
         <translation>전체 단어 일치</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="235"/>
+        <location filename="../ui/page_search_widget.py" line="235" />
         <source>Use Regular Expression</source>
         <translation>정규 표현식 사용</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Translation</source>
         <translation>번역</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Source</source>
         <translation>원본</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="239"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>All</source>
         <translation>모두</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="242"/>
+        <location filename="../ui/page_search_widget.py" line="242" />
         <source>Range</source>
         <translation>범위</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="249"/>
+        <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>바꾸기</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="253"/>
+        <location filename="../ui/page_search_widget.py" line="253" />
         <source>Replace All</source>
         <translation>모두 바꾸기</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="290"/>
+        <location filename="../ui/page_search_widget.py" line="290" />
         <source>Close (Escape)</source>
         <translation>닫기</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PenConfigPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="136"/>
+        <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
         <translation>색상</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="137"/>
+        <location filename="../ui/drawingpanel.py" line="153" />
         <source>Alpha</source>
         <translation>불투명도</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="145"/>
+        <location filename="../ui/drawingpanel.py" line="161" />
         <source>Thickness</source>
         <translation>두께</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="150"/>
+        <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>모양</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="169" />
         <source>Circle</source>
         <translation>원형</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="152"/>
+        <location filename="../ui/drawingpanel.py" line="170" />
         <source>Rectangle</source>
         <translation>사각형</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="197"/>
+        <location filename="../ui/drawingpanel.py" line="214" />
         <source>Dilate</source>
         <translation>확장</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 1</source>
-        <translation>방법 1</translation>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>method 2</source>
-        <translation>방법 2</translation>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="210"/>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">사각형</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
         <source>Auto</source>
         <translation>자동</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="211"/>
+        <location filename="../ui/drawingpanel.py" line="241" />
         <source>run inpainting automatically.</source>
         <translation>자동 인페인팅 시도</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="213"/>
+        <location filename="../ui/drawingpanel.py" line="243" />
         <source>Inpaint</source>
         <translation>인페인트</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="214"/>
+        <location filename="../ui/drawingpanel.py" line="244" />
         <source>Space</source>
         <translation>여백</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="216"/>
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
         <source>Delete</source>
         <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="217"/>
+        <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="224"/>
+        <location filename="../ui/drawingpanel.py" line="258" />
         <source>Inpainter</source>
         <translation>인페인터</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
-        <source>Use Existing Mask</source>
-        <translation>기존 마스크 사용</translation>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">모양</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
-        <location filename="../ui/textedit_area.py" line="30"/>
+        <location filename="../ui/textedit_area.py" line="30" />
         <source>Search selected text on Internet</source>
         <translation>인터넷에서 선택한 텍스트 검색</translation>
     </message>
     <message>
-        <location filename="../ui/textedit_area.py" line="36"/>
+        <location filename="../ui/textedit_area.py" line="36" />
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>SalaDict에서 선택된 텍스트를 찾기, 설정에 설치 안내서를 참조하십시오.</translation>
     </message>
-</context>
-<context>
-    <name>TextAdvancedFormatPanel</name>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="31"/>
-        <source>Line Spacing Type: </source>
-        <translation type="obsolete">줄 바꿈 방식: </translation>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="21"/>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished">단축키</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
+        <source>Apply</source>
+        <translation type="unfinished">적용</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">번역</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">번역기</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished">저장</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextAdvancedFormatPanel</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="170" />
         <source>Proportional</source>
         <translation>비례</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="21"/>
+        <location filename="../ui/text_advanced_format.py" line="171" />
         <source>Distance</source>
         <translation>거리</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="31"/>
+        <location filename="../ui/text_advanced_format.py" line="175" />
         <source>Line Spacing Type</source>
         <translation>줄 바꿈 방식</translation>
     </message>
-</context>
-<context>
-    <name>TextEffectPanel</name>
     <message>
-        <location filename="../ui/text_effect.py" line="12"/>
-        <source>Gradient</source>
-        <translation>그라디언트</translation>
-    </message>
-</context>
-<context>
-    <name>TextEffectPanelDeprecated</name>
-    <message>
-        <location filename="../ui/text_graphical_effect.py" line="90"/>
-        <source>Effect</source>
-        <translation>효과</translation>
+        <location filename="../ui/text_advanced_format.py" line="182" />
+        <source>Set Text Opacity</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="100"/>
+        <location filename="../ui/text_advanced_format.py" line="184" />
         <source>Opacity</source>
-        <translation>불투명도</translation>
+        <translation type="unfinished">불투명도</translation>
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="105"/>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
         <source>Shadow</source>
-        <translation>그림자</translation>
+        <translation type="unfinished">그림자</translation>
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="108"/>
-        <source>Change shadow color</source>
-        <translation>그림자 색상 변경</translation>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="109"/>
-        <source>radius</source>
-        <translation>반지름</translation>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="112"/>
-        <source>strength</source>
-        <translation>강도</translation>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="115"/>
-        <source>x offset</source>
-        <translation>X 오프셋</translation>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="118"/>
-        <source>y offset</source>
-        <translation>y 오프셋</translation>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="122"/>
-        <source>Apply</source>
-        <translation>적용</translation>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="124"/>
-        <source>Cancel</source>
-        <translation>취소</translation>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextDetectConfigPanel</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="615" />
+        <source>Keep Existing Lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextGradientGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="91" />
+        <source>Gradient</source>
+        <translation type="unfinished">그라디언트</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="96" />
+        <source>Start Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="100" />
+        <source>End Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="102" />
+        <source>Enable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="112" />
+        <source>Set Gradient Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="114" />
+        <source>Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextShadowGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="17" />
+        <source>Set X offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="28" />
+        <source>Set Y offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="40" />
+        <source>Set Shadow Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="42" />
+        <source>Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="51" />
+        <source>Set Shadow Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="53" />
+        <source>Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="72" />
+        <source>Offset</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TextStyleLabel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="86"/>
+        <location filename="../ui/text_style_presets.py" line="87" />
         <source>Click to set as Global format. Double click to edit name.</source>
         <translation>글로벌 형식으로 설정하려면 클릭하십시오. 이름을 편집하려면 두 번 클릭하십시오.</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="98"/>
+        <location filename="../ui/text_style_presets.py" line="99" />
         <source>Apply Text Style</source>
         <translation>텍스트 스타일을 적용</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="103"/>
+        <location filename="../ui/text_style_presets.py" line="104" />
         <source>Update from active style</source>
         <translation>활성 스타일에서 업데이트</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="120"/>
+        <location filename="../ui/text_style_presets.py" line="121" />
         <source>Delete Style</source>
         <translation>스타일 삭제</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStylePresetPanel</name>
     <message>
-        <location filename="../ui/text_style_presets.py" line="276"/>
+        <location filename="../ui/text_style_presets.py" line="277" />
         <source>Style</source>
         <translation>스타일</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="439"/>
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
         <source>New Text Style</source>
         <translation>새 텍스트 스타일</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="285"/>
+        <location filename="../ui/text_style_presets.py" line="286" />
         <source>Remove All</source>
         <translation>모두 삭제</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="299"/>
+        <location filename="../ui/text_style_presets.py" line="300" />
         <source>Remove all styles?</source>
         <translation>모든 스타일을 삭제 하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="440"/>
+        <location filename="../ui/text_style_presets.py" line="462" />
         <source>Remove all</source>
         <translation>모두 삭제</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="442"/>
+        <location filename="../ui/text_style_presets.py" line="464" />
         <source>Import Text Styles</source>
         <translation>텍스트 스타일 가져오기</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="443"/>
+        <location filename="../ui/text_style_presets.py" line="465" />
         <source>Export Text Styles</source>
         <translation>텍스트 스타일 내보내기</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished">적용</translation>
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TitleBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="325"/>
+        <location filename="../ui/mainwindowbars.py" line="443" />
         <source>Edit</source>
         <translation>편집</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="327"/>
+        <location filename="../ui/mainwindowbars.py" line="445" />
         <source>Undo</source>
         <translation>실행 취소</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="330"/>
+        <location filename="../ui/mainwindowbars.py" line="448" />
         <source>Redo</source>
         <translation>다시 실행</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="333"/>
+        <location filename="../ui/mainwindowbars.py" line="451" />
         <source>Search</source>
         <translation>찾기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="336"/>
+        <location filename="../ui/mainwindowbars.py" line="454" />
         <source>Global Search</source>
         <translation>글로벌 검색</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="342"/>
+        <location filename="../ui/mainwindowbars.py" line="458" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>원문에 대한 키워드 치환(전처리)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="460" />
         <source>Keyword substitution for machine translation</source>
         <translation>번역문에 대한 키워드 치환(후처리)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="338"/>
-        <source>Keyword substitution for OCR results</source>
-        <translation type="obsolete">OCR 결과 키워드 치환</translation>
+        <location filename="../ui/mainwindowbars.py" line="462" />
+        <source>Keyword substitution for source text</source>
+        <translation>OCR 결과에 대한 키워드 치환</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="355"/>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>보기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="357"/>
+        <location filename="../ui/mainwindowbars.py" line="486" />
         <source>Display Language</source>
         <translation>디스플레이 언어</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="371"/>
+        <location filename="../ui/mainwindowbars.py" line="500" />
         <source>Drawing Board</source>
         <translation>그림판</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="373"/>
+        <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>텍스트 편집기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="366"/>
-        <source>Text Styles Panel</source>
-        <translation type="obsolete">텍스트 스타일 패널</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="375"/>
+        <location filename="../ui/mainwindowbars.py" line="504" />
         <source>Import Text Styles</source>
         <translation>텍스트 스타일 가져오기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="376"/>
+        <location filename="../ui/mainwindowbars.py" line="505" />
         <source>Export Text Styles</source>
         <translation>텍스트 스타일 내보내기</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="377"/>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
         <source>Dark Mode</source>
         <translation>다크 모드</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="397"/>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
         <source>Go</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="398"/>
+        <location filename="../ui/mainwindowbars.py" line="601" />
         <source>Previous Page</source>
         <translation>이전 페이지</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="400"/>
+        <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>다음 페이지</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="423"/>
-        <source>Run</source>
-        <translation>실행</translation>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="413"/>
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
         <source>Enable Text Dection</source>
         <translation>텍스트 검출 활성화</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="414"/>
+        <location filename="../ui/mainwindowbars.py" line="764" />
         <source>Enable OCR</source>
         <translation>OCR 활성화</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="415"/>
+        <location filename="../ui/mainwindowbars.py" line="765" />
         <source>Enable Translation</source>
         <translation>번역 활성화</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="416"/>
+        <location filename="../ui/mainwindowbars.py" line="766" />
         <source>Enable Inpainting</source>
         <translation>인페인팅 활성화</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="424"/>
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>실행</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
         <source>Run without update textstyle</source>
         <translation>텍스트 스타일 업데이트 없이 실행</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="425"/>
+        <location filename="../ui/mainwindowbars.py" line="775" />
         <source>Translate page</source>
         <translation>이 페이지 번역</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="344"/>
-        <source>Keyword substitution for source text</source>
-        <translation>OCR 결과에 대한 키워드 치환</translation>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="340"/>
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>원문에 대한 키워드 치환(전처리)</translation>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">폴더 열기 ...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">프로젝트 열기 ... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">프로젝트 저장</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">DOC 내보내기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished">번역 텍스트 TXT로 내보내기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished">번역 텍스트 마크다운 문서로 내보내기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">DOC 불러오기</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished">텍스트/마크다운 파일에서 번역 불러오기</translation>
+    </message>
+</context><context>
     <name>TranslateThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="187"/>
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
         <source>Failed to set translator </source>
         <translation>번역기를 설정하지 못했습니다</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="237"/>
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>번역이 실패했습니다.</translation>
     </message>
+</context><context>
+    <name>TranslationContextDialog</name>
     <message>
-        <location filename="../ui/module_manager.py" line="239"/>
-        <source> is required for </source>
-        <translation> 은(는) 다음을 위해 필요함: </translation>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="328"/>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>원문에 대한 키워드 치환(전처리)</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>번역문에 대한 키워드 치환(후처리)</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="338"/>
-        <source>Source</source>
-        <translation>원본</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="340"/>
-        <source>Target</source>
-        <translation>대상</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="331"/>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
         <source>Keyword substitution for source text</source>
         <translation>OCR 결과에 대한 키워드 치환</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="325"/>
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>원문에 대한 키워드 치환(전처리)</translation>
-    </message>
-</context>
-<context>
-    <name>TranslatorStatusButton</name>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="68"/>
-        <source>Translator: </source>
-        <translation>번역기:</translation>
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="68"/>
-        <source>Source: </source>
-        <translation>원본:</translation>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="68"/>
-        <source> is required for </source>
-        <translation type="obsolete"> 은(는) 다음을 위해 필요함: </translation>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="68"/>
-        <source>Target: </source>
-        <translation>대상:</translation>
-    </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
-    <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>기존 로컬 폴더의 모델 파일을 이 앱의 data/models 디렉터리로 복사합니다.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package</source>
-        <translation>핵심 패키지</translation>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package not selected</source>
-        <translation>핵심 패키지가 선택되지 않음</translation>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>지금은 어떤 모델 패키지도 다운로드하지 않습니다. 이미 로컬에 있는 모듈/파일만 사용합니다.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>다운로드 완료. 기본값이 업데이트되었습니다.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download partially complete.</source>
-        <translation>다운로드가 부분적으로 완료되었습니다.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>첫 실행 로컬 전용 모드가 활성화되어 있습니다. 도구 → 모델 관리에서 모델을 가져오거나 다운로드하거나, config/config.json을 수정해 패키지를 활성화한 뒤 다시 시작하세요.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
+        <source>Source</source>
+        <translation>원본</translation>
     </message>
     <message>
-        <source>Import local model directory...</source>
-        <translation>로컬 모델 디렉터리 가져오기...</translation>
+        <location filename="../ui/module_parse_widgets.py" line="480" />
+        <source>Target</source>
+        <translation>대상</translation>
+    </message>
+</context><context>
+    <name>TranslatorSelectionWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1468" />
+        <source>Translate</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local models</source>
-        <translation>로컬 모델 가져오기</translation>
+        <location filename="../ui/mainwindowbars.py" line="1470" />
+        <source>Source</source>
+        <translation type="unfinished">원본</translation>
     </message>
     <message>
-        <source>Manual package selection</source>
-        <translation>수동 패키지 선택</translation>
+        <location filename="../ui/mainwindowbars.py" line="1472" />
+        <source>Target</source>
+        <translation type="unfinished">대상</translation>
     </message>
     <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>프리셋 대신 저수준 패키지를 수동으로 선택합니다.</translation>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download complete</source>
-        <translation>모델 패키지 다운로드 완료</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download partially complete</source>
-        <translation>모델 패키지 다운로드 부분 완료</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>모델 패키지가 다운로드되었습니다. 적용된 모듈:
-</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>모델 관리 열기</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Select local model directory</source>
-        <translation>로컬 모델 디렉터리 선택</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation>모든 다운로드 건너뛰기(로컬 전용)</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>일부 모델 패키지가 실패했습니다. 실패 항목: {0}</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>요약: 다운로드 {0}, 실패 {1}, 건너뜀 {2}.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">실행 취소</translation>
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">다시 실행</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished">스타일</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">삭제</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">번역</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">실행</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished">취소</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/pt_BR.ts
+++ b/translate/pt_BR.ts
@@ -2,1354 +2,8784 @@
 <!DOCTYPE TS>
 <TS version="2.1">
   <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="563"/>
-      <source>translate page</source>
-      <translation>Traduzir página</translation>
+        <location filename="../ui/mainwindowbars.py" line="1566" />
+        <source>Text Detector</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="564"/>
-      <source>stop</source>
-      <translation>Parar</translation>
+        <location filename="../ui/mainwindowbars.py" line="1567" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="565"/>
-      <source>translate current page</source>
-      <translation>Traduzir página atual</translation>
+        <location filename="../ui/mainwindowbars.py" line="1568" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Retocar</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="566"/>
-      <source>stop translation</source>
-      <translation>Parar tradução</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">Executar</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="573"/>
-      <source>Enable/disable paint mode</source>
-      <translation>Ativar/desativar modo de pintura</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="577"/>
-      <source>Enable/disable text edit mode</source>
-      <translation>Ativar/desativar modo de edição de texto</translation>
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="583"/>
-      <source>Original image opacity</source>
-      <translation>Opacidade original da imagem</translation>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="587"/>
-      <source>Text layer opacity</source>
-      <translation>Opacidade da camada de texto</translation>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
+        <source>Original image opacity</source>
+        <translation>Opacidade original da imagem</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
+        <source>Text layer opacity</source>
+        <translation>Opacidade da camada de texto</translation>
+    </message>
+</context><context>
     <name>Canvas</name>
     <message>
-      <location filename="..\ui\canvas.py" line="743"/>
-      <source>Copy</source>
-      <translation>Copiar</translation>
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">Editar</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="745"/>
-      <source>Paste</source>
-      <translation>Colar</translation>
+        <location filename="../ui/canvas.py" line="1073" />
+        <source>Copy</source>
+        <translation>Copiar</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="747"/>
-      <source>Delete</source>
-      <translation>Excluir</translation>
+        <location filename="../ui/canvas.py" line="1078" />
+        <source>Paste</source>
+        <translation>Colar</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="749"/>
-      <source>Copy source text</source>
-      <translation>Copiar texto original</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="751"/>
-      <source>Paste source text</source>
-      <translation>Colar texto original</translation>
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="753"/>
-      <source>Delete and Recover removed text</source>
-      <translation>Excluir e recuperar texto removido</translation>
+        <location filename="../ui/canvas.py" line="1091" />
+        <source>Copy source text</source>
+        <translation>Copiar texto original</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="758"/>
-      <source>Apply font formatting</source>
-      <translation>Aplicar formatação de fonte</translation>
+        <location filename="../ui/canvas.py" line="1096" />
+        <source>Paste source text</source>
+        <translation>Colar texto original</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="759"/>
-      <source>Auto layout</source>
-      <translation>Layout automático</translation>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>Excluir</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="760"/>
-      <source>Reset Angle</source>
-      <translation>Redefinir ângulo</translation>
+        <location filename="../ui/canvas.py" line="1108" />
+        <source>Delete and Recover removed text</source>
+        <translation>Excluir e recuperar texto removido</translation>
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="761"/>
-      <source>Squeeze</source>
-      <translation>Comprimir</translation>
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="763"/>
-      <source>translate</source>
-      <translation>Traduzir</translation>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="764"/>
-      <source>OCR</source>
-      <translation>OCR</translation>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="765"/>
-      <source>OCR and translate</source>
-      <translation>OCR e traduzir</translation>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="766"/>
-      <source>OCR, translate and inpaint</source>
-      <translation>OCR, traduzir e inpaint</translation>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\canvas.py" line="767"/>
-      <source>inpaint</source>
-      <translation>Retocar</translation>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">Converter para maiúsculas</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
+        <source>Apply font formatting</source>
+        <translation>Aplicar formatação de fonte</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1275" />
+        <source>Auto layout</source>
+        <translation>Layout automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
+        <source>Reset Angle</source>
+        <translation>Redefinir ângulo</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1326" />
+        <source>Squeeze</source>
+        <translation>Comprimir</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">Executar</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
+        <source>OCR</source>
+        <translation>OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1357" />
+        <source>OCR and translate</source>
+        <translation>OCR e traduzir</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1362" />
+        <source>OCR, translate and inpaint</source>
+        <translation>OCR, traduzir e inpaint</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Retocar</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-      <location filename="..\ui\configpanel.py" line="360"/>
-      <source>DL Module</source>
-      <translation>Módulo DL</translation>
+        <location filename="../ui/configpanel.py" line="410" />
+        <source>DL Module</source>
+        <translation>Módulo DL</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="361"/>
-      <source>General</source>
-      <translation>Geral</translation>
+        <location filename="../ui/configpanel.py" line="411" />
+        <source>General</source>
+        <translation>Geral</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="363"/>
-      <source>Text Detection</source>
-      <translation>Detecção de Texto</translation>
+        <location filename="../ui/configpanel.py" line="413" />
+        <source>Text Detection</source>
+        <translation>Detecção de Texto</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="402"/>
-      <location filename="..\ui\configpanel.py" line="364"/>
-      <source>OCR</source>
-      <translation>OCR</translation>
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
+        <source>OCR</source>
+        <translation>OCR</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="365"/>
-      <source>Inpaint</source>
-      <translation>Inpaint</translation>
+        <location filename="../ui/configpanel.py" line="415" />
+        <source>Inpaint</source>
+        <translation>Inpaint</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="366"/>
-      <source>Translator</source>
-      <translation>Tradutor</translation>
+        <location filename="../ui/configpanel.py" line="416" />
+        <source>Translator</source>
+        <translation>Tradutor</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="367"/>
-      <source>Startup</source>
-      <translation>Inicialização</translation>
+        <location filename="../ui/configpanel.py" line="417" />
+        <source>Startup</source>
+        <translation>Inicialização</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="368"/>
-      <source>Typesetting</source>
-      <translation>Diagramação</translation>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="369"/>
-      <source>Save</source>
-      <translation>Salvamento automático</translation>
+        <location filename="../ui/configpanel.py" line="419" />
+        <source>Typesetting</source>
+        <translation>Diagramação</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="370"/>
-      <source>SalaDict</source>
-      <translation>SalaDict</translation>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="385"/>
-      <source>Load models on demand</source>
-      <translation>Carregar modelos sob demanda</translation>
+        <location filename="../ui/configpanel.py" line="421" />
+        <source>Save</source>
+        <translation>Salvamento automático</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="385"/>
-      <source>Load models on demand to save memory.</source>
-      <translation>Carregar modelos sob demanda para economizar memória.</translation>
+        <location filename="../ui/configpanel.py" line="422" />
+        <source>SalaDict</source>
+        <translation>SalaDict</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="388"/>
-      <source>Empty cache after RUN</source>
-      <translation>Limpar cache após EXECUTAR</translation>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="388"/>
-      <source>Empty cache after RUN to save memory.</source>
-      <translation>Limpar cache após EXECUTAR para economizar memória.</translation>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="393"/>
-      <source>Unload All Models</source>
-      <translation>Descarregar todos os modelos</translation>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="398"/>
-      <source>Detector</source>
-      <translation>Detector</translation>
+        <location filename="../ui/configpanel.py" line="443" />
+        <source>Load models on demand</source>
+        <translation>Carregar modelos sob demanda</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="406"/>
-      <source>Inpainter</source>
-      <translation>Inpainter</translation>
+        <location filename="../ui/configpanel.py" line="443" />
+        <source>Load models on demand to save memory.</source>
+        <translation>Carregar modelos sob demanda para economizar memória.</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="414"/>
-      <source>Reopen last project on startup</source>
-      <translation>Reabrir o último projeto na inicialização</translation>
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="418"/>
-      <source>decide by program</source>
-      <translation>Automático</translation>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="419"/>
-      <source>use global setting</source>
-      <translation>usar configuração global</translation>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="429"/>
-      <source>Font Size</source>
-      <translation>Tamanho da fonte</translation>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN</source>
+        <translation>Limpar cache após EXECUTAR</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="433"/>
-      <source>Stroke Size</source>
-      <translation>Espessura do traçado</translation>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN to save memory.</source>
+        <translation>Limpar cache após EXECUTAR para economizar memória.</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="437"/>
-      <source>Font Color</source>
-      <translation>Cor da fonte</translation>
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="440"/>
-      <source>Stroke Color</source>
-      <translation>Cor do traçado</translation>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="444"/>
-      <source>Effect</source>
-      <translation>Efeito</translation>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="447"/>
-      <source>Alignment</source>
-      <translation>Alinhamento</translation>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="451"/>
-      <source>Writing-mode</source>
-      <translation>Modo de escrita</translation>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="454"/>
-      <source>Keep existing</source>
-      <translation>Manter existente</translation>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="454"/>
-      <source>Always use global setting</source>
-      <translation>Sempre usar configuração global</translation>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="454"/>
-      <source>Font Family</source>
-      <translation>Família da fonte</translation>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="460"/>
-      <source>Auto layout</source>
-      <translation>Layout automático</translation>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="461"/>
-      <source>Split translation into multi-lines according to the extracted balloon region.</source>
-      <translation>Dividir a tradução em várias linhas de acordo com a região do balão extraída.</translation>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="462"/>
-      <source>Adjust font size adaptively if it is set to "decide by program."</source>
-      <translation>Ajustar o tamanho da fonte de forma adaptativa se estiver definido como "Automático".</translation>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="466"/>
-      <source>To uppercase</source>
-      <translation>Converter para maiúsculas</translation>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="470"/>
-      <source>Result image format</source>
-      <translation>Formato</translation>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="475"/>
-      <source>Quality</source>
-      <translation>Qualidade</translation>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="482"/>
-      <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
-      <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Guia de instalação&lt;/a&gt;</translation>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="486"/>
-      <source>Show mini menu when selecting text.</source>
-      <translation>Mostrar mini menu ao selecionar texto.</translation>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="492"/>
-      <source>Shortcut</source>
-      <translation>Atalho</translation>
+        <location filename="../ui/configpanel.py" line="518" />
+        <source>Unload All Models</source>
+        <translation>Descarregar todos os modelos</translation>
     </message>
     <message>
-      <location filename="..\ui\configpanel.py" line="495"/>
-      <source>Search Engines</source>
-      <translation>Motores de Busca</translation>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
+        <source>Detector</source>
+        <translation>Detector</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="626" />
+        <source>Inpainter</source>
+        <translation>Inpainter</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
+        <source>Reopen last project on startup</source>
+        <translation>Reabrir o último projeto na inicialização</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
+        <source>decide by program</source>
+        <translation>Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="840" />
+        <source>use global setting</source>
+        <translation>usar configuração global</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="850" />
+        <source>Font Size</source>
+        <translation>Tamanho da fonte</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="854" />
+        <source>Stroke Size</source>
+        <translation>Espessura do traçado</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="858" />
+        <source>Font Color</source>
+        <translation>Cor da fonte</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="861" />
+        <source>Stroke Color</source>
+        <translation>Cor do traçado</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
+        <source>Effect</source>
+        <translation>Efeito</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="898" />
+        <source>Alignment</source>
+        <translation>Alinhamento</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="902" />
+        <source>Writing-mode</source>
+        <translation>Modo de escrita</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Keep existing</source>
+        <translation>Manter existente</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Always use global setting</source>
+        <translation>Sempre usar configuração global</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Font Family</source>
+        <translation>Família da fonte</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="911" />
+        <source>Auto layout</source>
+        <translation>Layout automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
+        <source>To uppercase</source>
+        <translation>Converter para maiúsculas</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1108" />
+        <source>Independent text styles for each projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1111" />
+        <source>Show only custom fonts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
+        <source>Result image format</source>
+        <translation>Formato</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1128" />
+        <source>Quality</source>
+        <translation>Qualidade</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Guia de instalação&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
+        <source>Show mini menu when selecting text.</source>
+        <translation>Mostrar mini menu ao selecionar texto.</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1160" />
+        <source>Shortcut</source>
+        <translation>Atalho</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1163" />
+        <source>Search Engines</source>
+        <translation>Motores de Busca</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="349"/>
-      <source>Mask Opacity</source>
-      <translation>Opacidade da máscara</translation>
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
+        <source>Mask Opacity</source>
+        <translation>Opacidade da máscara</translation>
+    </message>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-      <location filename="..\ui\io_thread.py" line="100"/>
-      <source>Export as doc...</source>
-      <translation>Exportar como documento...</translation>
+        <location filename="../ui/io_thread.py" line="118" />
+        <source>Export as doc...</source>
+        <translation>Exportar como documento...</translation>
     </message>
     <message>
-      <location filename="..\ui\io_thread.py" line="106"/>
-      <source>Overwrite </source>
-      <translation>Sobrescrever </translation>
+        <location filename="../ui/io_thread.py" line="124" />
+        <source>Overwrite </source>
+        <translation>Sobrescrever </translation>
     </message>
-  </context>
-  <context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="927"/>
-      <source>Font Family</source>
-      <translation>Família da fonte</translation>
+        <location filename="../ui/text_panel.py" line="275" />
+        <source>Font Family</source>
+        <translation>Família da fonte</translation>
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="932"/>
-      <source>Font Size</source>
-      <translation>Tamanho da fonte</translation>
+        <location filename="../ui/text_panel.py" line="280" />
+        <source>Font Size</source>
+        <translation>Tamanho da fonte</translation>
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="934"/>
-      <source>Change font size</source>
-      <translation>Alterar tamanho da fonte</translation>
+        <location filename="../ui/text_panel.py" line="282" />
+        <source>Change font size</source>
+        <translation>Alterar tamanho da fonte</translation>
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="944"/>
-      <source>Change line spacing</source>
-      <translation>Alterar espaçamento entre linhas</translation>
+        <location filename="../ui/text_panel.py" line="292" />
+        <source>Change line spacing</source>
+        <translation>Alterar espaçamento entre linhas</translation>
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="950"/>
-      <source>Change font color</source>
-      <translation>Alterar cor da fonte</translation>
+        <location filename="../ui/text_panel.py" line="296" />
+        <source>Change font color</source>
+        <translation>Alterar cor da fonte</translation>
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="964"/>
-      <source>Stroke</source>
-      <translation>Traçado</translation>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="973"/>
-      <source>Change stroke color</source>
-      <translation>Alterar cor do traçado</translation>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="980"/>
-      <source>Change stroke width</source>
-      <translation>Alterar largura do traçado</translation>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="996"/>
-      <source>Change letter spacing</source>
-      <translation>Alterar espaçamento entre letras</translation>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1005"/>
-      <source>Global Font Format</source>
-      <translation>Formato de Fonte Global</translation>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1010"/>
-      <source>Effect</source>
-      <translation>Efeito</translation>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1015"/>
-      <source>Unfold</source>
-      <translation>Desdobrar</translation>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1015"/>
-      <source>Fold</source>
-      <translation>Dobrar</translation>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1016"/>
-      <source>Source</source>
-      <translation>Original</translation>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\fontformatpanel.py" line="1017"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
+        <source>Change stroke width</source>
+        <translation>Alterar largura do traçado</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="364" />
+        <source>Stroke</source>
+        <translation>Traçado</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="373" />
+        <source>Change stroke color</source>
+        <translation>Alterar cor do traçado</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="386" />
+        <source>Change letter spacing</source>
+        <translation>Alterar espaçamento entre letras</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">Opacidade</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
+        <source>Global Font Format</source>
+        <translation>Formato de Fonte Global</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
+        <source>Advanced Text Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Unfold</source>
+        <translation>Desdobrar</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Fold</source>
+        <translation>Dobrar</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="462" />
+        <source>Source</source>
+        <translation>Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="463" />
+        <source>Translation</source>
+        <translation>Tradução</translation>
+    </message>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="190"/>
-      <source>Replace...</source>
-      <translation>Substituir...</translation>
+        <location filename="../ui/global_search_widget.py" line="192" />
+        <source>Replace...</source>
+        <translation>Substituir...</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="196"/>
-      <source>Replace all occurrences?</source>
-      <translation>Substituir todas as ocorrências?</translation>
+        <location filename="../ui/global_search_widget.py" line="198" />
+        <source>Replace all occurrences?</source>
+        <translation>Substituir todas as ocorrências?</translation>
     </message>
-  </context>
-  <context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="306"/>
-      <source>Find</source>
-      <translation>Localizar</translation>
+        <location filename="../ui/global_search_widget.py" line="308" />
+        <source>Find</source>
+        <translation>Localizar</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="309"/>
-      <source>No results found. </source>
-      <translation>Nenhum resultado encontrado. </translation>
+        <location filename="../ui/global_search_widget.py" line="311" />
+        <source>No results found. </source>
+        <translation>Nenhum resultado encontrado. </translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="310"/>
-      <source>Document changed. Press Enter to re-search.</source>
-      <translation>Documento alterado. Pressione Enter para pesquisar novamente.</translation>
+        <location filename="../ui/global_search_widget.py" line="312" />
+        <source>Document changed. Press Enter to re-search.</source>
+        <translation>Documento alterado. Pressione Enter para pesquisar novamente.</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="311"/>
-      <source>Found results: </source>
-      <translation>Resultados encontrados: </translation>
+        <location filename="../ui/global_search_widget.py" line="313" />
+        <source>Found results: </source>
+        <translation>Resultados encontrados: </translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="317"/>
-      <source>Match Case</source>
-      <translation>Diferenciar maiúsculas de minúsculas</translation>
+        <location filename="../ui/global_search_widget.py" line="319" />
+        <source>Match Case</source>
+        <translation>Diferenciar maiúsculas de minúsculas</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="322"/>
-      <source>Match Whole Word</source>
-      <translation>Coincidir com palavra inteira</translation>
+        <location filename="../ui/global_search_widget.py" line="324" />
+        <source>Match Whole Word</source>
+        <translation>Coincidir com palavra inteira</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="327"/>
-      <source>Use Regular Expression</source>
-      <translation>Usar expressão regular</translation>
+        <location filename="../ui/global_search_widget.py" line="329" />
+        <source>Use Regular Expression</source>
+        <translation>Usar expressão regular</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="331"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../ui/global_search_widget.py" line="333" />
+        <source>Translation</source>
+        <translation>Tradução</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="331"/>
-      <source>Source</source>
-      <translation>Original</translation>
+        <location filename="../ui/global_search_widget.py" line="333" />
+        <source>Source</source>
+        <translation>Original</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="331"/>
-      <source>All</source>
-      <translation>Todos</translation>
+        <location filename="../ui/global_search_widget.py" line="333" />
+        <source>All</source>
+        <translation>Todos</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="334"/>
-      <source> in</source>
-      <translation> em</translation>
+        <location filename="../ui/global_search_widget.py" line="336" />
+        <source> in</source>
+        <translation> em</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="337"/>
-      <source>Replace</source>
-      <translation>Substituir</translation>
+        <location filename="../ui/global_search_widget.py" line="339" />
+        <source>Replace</source>
+        <translation>Substituir</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="340"/>
-      <source>Replace All</source>
-      <translation>Substituir tudo</translation>
+        <location filename="../ui/global_search_widget.py" line="342" />
+        <source>Replace All</source>
+        <translation>Substituir tudo</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="342"/>
-      <source>Replace All and Re-render all pages</source>
-      <translation>Substituir tudo e renderizar novamente todas as páginas</translation>
+        <location filename="../ui/global_search_widget.py" line="344" />
+        <source>Replace All and Re-render all pages</source>
+        <translation>Substituir tudo e renderizar novamente todas as páginas</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="383"/>
-      <source>Replace...</source>
-      <translation>Substituir...</translation>
+        <location filename="../ui/global_search_widget.py" line="385" />
+        <source>Replace...</source>
+        <translation>Substituir...</translation>
     </message>
     <message>
-      <location filename="..\ui\global_search_widget.py" line="488"/>
-      <source>Replace all occurrences re-render all pages? It can't be undone.</source>
-      <translation>Substituir todas as ocorrências e renderizar novamente todas as páginas? Isso não pode ser desfeito.</translation>
+        <location filename="../ui/global_search_widget.py" line="490" />
+        <source>Replace all occurrences re-render all pages? It can't be undone.</source>
+        <translation>Substituir todas as ocorrências e renderizar novamente todas as páginas? Isso não pode ser desfeito.</translation>
     </message>
-  </context>
-  <context>
+</context><context>
     <name>ImgtransProgressMessageBox</name>
     <message>
-      <location filename="..\ui\stylewidgets.py" line="159"/>
-      <source>Detecting: </source>
-      <translation>Detectando: </translation>
+        <location filename="../ui/custom_widget/message.py" line="183" />
+        <source>Detecting: </source>
+        <translation>Detectando: </translation>
     </message>
     <message>
-      <location filename="..\ui\stylewidgets.py" line="160"/>
-      <source>OCR: </source>
-      <translation>OCR: </translation>
+        <location filename="../ui/custom_widget/message.py" line="184" />
+        <source>OCR: </source>
+        <translation>OCR: </translation>
     </message>
     <message>
-      <location filename="..\ui\stylewidgets.py" line="161"/>
-      <source>Inpainting: </source>
-      <translation>Inpainting: </translation>
+        <location filename="../ui/custom_widget/message.py" line="185" />
+        <source>Inpainting: </source>
+        <translation>Inpainting: </translation>
     </message>
     <message>
-      <location filename="..\ui\stylewidgets.py" line="162"/>
-      <source>Translating: </source>
-      <translation>Traduzindo: </translation>
+        <location filename="../ui/custom_widget/message.py" line="186" />
+        <source>Translating: </source>
+        <translation>Traduzindo: </translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-      <location filename="..\ui\module_manager.py" line="384"/>
-      <location filename="..\ui\module_manager.py" line="318"/>
-      <source>OCR Failed.</source>
-      <translation>Falha no OCR.</translation>
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
+        <source>OCR Failed.</source>
+        <translation>Falha no OCR.</translation>
     </message>
     <message>
-      <location filename="..\ui\module_manager.py" line="371"/>
-      <source>Text Detection Failed.</source>
-      <translation>Falha na detecção de texto.</translation>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation type="unfinished">Falha na tradução.</translation>
     </message>
     <message>
-      <location filename="..\ui\module_manager.py" line="445"/>
-      <source>Inpainting Failed.</source>
-      <translation>Falha no Inpainting.</translation>
+        <location filename="../ui/module_manager.py" line="1022" />
+        <source>Text Detection Failed.</source>
+        <translation>Falha na detecção de texto.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/module_manager.py" line="1526" />
+        <source>Inpainting Failed.</source>
+        <translation>Falha no Inpainting.</translation>
+    </message>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-      <location filename="..\ui\io_thread.py" line="136"/>
-      <source>Import doc...</source>
-      <translation>Importar documento...</translation>
+        <location filename="../ui/io_thread.py" line="154" />
+        <source>Import doc...</source>
+        <translation>Importar documento...</translation>
     </message>
     <message>
-      <location filename="..\ui\io_thread.py" line="143"/>
-      <source>Import *.docx</source>
-      <translation>Importar *.docx</translation>
+        <location filename="../ui/io_thread.py" line="161" />
+        <source>Import *.docx</source>
+        <translation>Importar *.docx</translation>
     </message>
-  </context>
-  <context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-      <location filename="..\ui\module_parse_widgets.py" line="368"/>
-      <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
-      <translation>Permitir que o programa decida se é necessário usar o método de Inpainting selecionado.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="533" />
+        <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
+        <translation>Permitir que o programa decida se é necessário usar o método de Inpainting selecionado.</translation>
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>InpaintPanel</name>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="73"/>
-      <source>Thickness</source>
-      <translation>Espessura</translation>
+        <location filename="../ui/drawingpanel.py" line="75" />
+        <source>Thickness</source>
+        <translation>Espessura</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="78"/>
-      <source>Shape</source>
-      <translation>Forma</translation>
+        <location filename="../ui/drawingpanel.py" line="80" />
+        <source>Shape</source>
+        <translation>Forma</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="81"/>
-      <source>Circle</source>
-      <translation>Círculo</translation>
+        <location filename="../ui/drawingpanel.py" line="83" />
+        <source>Circle</source>
+        <translation>Círculo</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="82"/>
-      <source>Rectangle</source>
-      <translation>Retângulo</translation>
+        <location filename="../ui/drawingpanel.py" line="84" />
+        <source>Rectangle</source>
+        <translation>Retângulo</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="91"/>
-      <source>Inpainter</source>
-      <translation>Inpainter</translation>
+        <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
+        <source>Inpainter</source>
+        <translation>Inpainter</translation>
+    </message>
+</context><context>
     <name>InpaintThread</name>
     <message>
-      <location filename="..\ui\module_manager.py" line="121"/>
-      <source>Inpainting Failed.</source>
-      <translation>Falha no Inpainting.</translation>
+        <location filename="../ui/module_manager.py" line="197" />
+        <source>Inpainting Failed.</source>
+        <translation>Falha no Inpainting.</translation>
     </message>
-  </context>
-  <context>
-    <name>InpainterStatusButton</name>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="83"/>
-      <source>Inpainter: </source>
-      <translation>Inpainter: </translation>
-    </message>
-  </context>
-  <context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="25"/>
-      <source>Keyword</source>
-      <translation>Palavra-chave</translation>
+        <location filename="../ui/keywordsubwidget.py" line="25" />
+        <source>Keyword</source>
+        <translation>Palavra-chave</translation>
     </message>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="26"/>
-      <source>Substitution</source>
-      <translation>Substituição</translation>
+        <location filename="../ui/keywordsubwidget.py" line="26" />
+        <source>Substitution</source>
+        <translation>Substituição</translation>
     </message>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="27"/>
-      <source>Use regex</source>
-      <translation>Usar regex</translation>
+        <location filename="../ui/keywordsubwidget.py" line="27" />
+        <source>Use regex</source>
+        <translation>Usar regex</translation>
     </message>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="28"/>
-      <source>Case sensitive</source>
-      <translation>Diferenciar maiúsculas de minúsculas</translation>
+        <location filename="../ui/keywordsubwidget.py" line="28" />
+        <source>Case sensitive</source>
+        <translation>Diferenciar maiúsculas de minúsculas</translation>
     </message>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="35"/>
-      <source>New</source>
-      <translation>Novo</translation>
+        <location filename="../ui/keywordsubwidget.py" line="35" />
+        <source>New</source>
+        <translation>Novo</translation>
     </message>
     <message>
-      <location filename="..\ui\keywordsubwidget.py" line="37"/>
-      <source>Delete</source>
-      <translation>Excluir</translation>
+        <location filename="../ui/keywordsubwidget.py" line="37" />
+        <source>Delete</source>
+        <translation>Excluir</translation>
     </message>
-  </context>
-  <context>
+</context><context>
     <name>LeftBar</name>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="131"/>
-      <source>Global Search (Ctrl+G)</source>
-      <translation>Pesquisa Global (Ctrl+G)</translation>
+        <location filename="../ui/mainwindowbars.py" line="104" />
+        <source>Global Search (Ctrl+G)</source>
+        <translation>Pesquisa Global (Ctrl+G)</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="142"/>
-      <source>Open Folder ...</source>
-      <translation>Abrir Pasta ...</translation>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="146"/>
-      <source>Open Project ... *.json</source>
-      <translation>Abrir Projeto ... *.json</translation>
+        <location filename="../ui/mainwindowbars.py" line="128" />
+        <source>Open Folder ...</source>
+        <translation>Abrir Pasta ...</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="149"/>
-      <source>Save Project</source>
-      <translation>Salvar Projeto</translation>
+        <location filename="../ui/mainwindowbars.py" line="132" />
+        <source>Open Project ... *.json</source>
+        <translation>Abrir Projeto ... *.json</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="153"/>
-      <source>Export as Doc</source>
-      <translation>Exportar como Documento</translation>
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="155"/>
-      <source>Import from Doc</source>
-      <translation>Importar de Documento</translation>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="158"/>
-      <source>Open Recent</source>
-      <translation>Abrir Recentes</translation>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="273"/>
-      <source>Select Directory</source>
-      <translation>Selecionar Diretório</translation>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindowbars.py" line="280"/>
-      <source>Import *.docx</source>
-      <translation>Importar *.docx</translation>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
+        <source>Save Project</source>
+        <translation>Salvar Projeto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="155" />
+        <source>Export as Doc</source>
+        <translation>Exportar como Documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
+        <source>Import from Doc</source>
+        <translation>Importar de Documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="165" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="170" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="173" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="176" />
+        <source>Open Recent</source>
+        <translation>Abrir Recentes</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="303" />
+        <source>Select Directory</source>
+        <translation>Selecionar Diretório</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
+        <source>Import *.docx</source>
+        <translation>Importar *.docx</translation>
+    </message>
+</context><context>
     <name>MainWindow</name>
     <message>
-      <location filename="..\ui\mainwindow.py" line="194"/>
-      <source>Keyword substitution for OCR</source>
-      <translation>Substituição de palavras-chave para OCR</translation>
+        <location filename="../ui/mainwindow.py" line="465" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="198"/>
-      <source>Keyword substitution for machine translation</source>
-      <translation>Substituição de palavras-chave para tradução automática</translation>
+        <location filename="../ui/mainwindow.py" line="469" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="358"/>
-      <source>Failed to load project </source>
-      <translation>Falha ao carregar o projeto </translation>
+        <location filename="../ui/mainwindow.py" line="473" />
+        <source>Keyword substitution for machine translation</source>
+        <translation>Substituição de palavras-chave para tradução automática</translation>
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="377"/>
-      <source>Failed to load project from</source>
-      <translation>Falha ao carregar projeto de</translation>
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="427"/>
-      <source>Restart to apply changes? 
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
+        <source>Failed to load project </source>
+        <translation>Falha ao carregar o projeto </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
+        <source>Failed to load project from</source>
+        <translation>Falha ao carregar projeto de</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
+        <source>Restart to apply changes? 
 </source>
-    <translation>Deseja reiniciar para aplicar as alterações?
-</translation>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="960"/>
-      <source>unsaved</source>
-      <translation>não salvo</translation>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="960"/>
-      <source>saved</source>
-      <translation>salvo</translation>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="997"/>
-      <source>Saving image...</source>
-      <translation>Salvando imagem...</translation>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="1058"/>
-      <source>Import Text Styles</source>
-      <translation>Importar Estilos de Texto</translation>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="1072"/>
-      <source>Save Text Styles</source>
-      <translation>Salvar Estilos de Texto</translation>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\mainwindow.py" line="1134"/>
-      <source>Export to </source>
-      <translation>Exportar para </translation>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>ModuleManager</name>
     <message>
-      <location filename="..\ui\module_manager.py" line="856"/>
-      <source>Set Inpainter...</source>
-      <translation>Definir Inpainter...</translation>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\module_manager.py" line="906"/>
-      <source>Invalid</source>
-      <translation>Inválido</translation>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>OCRConfigPanel</name>
     <message>
-      <location filename="..\ui\module_parse_widgets.py" line="395"/>
-      <source>Keyword substitution for OCR results</source>
-      <translation>Substituição de palavras-chave para resultados de OCR</translation>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\module_parse_widgets.py" line="399"/>
-      <source>Delete and restore region where OCR return empty string.</source>
-      <translation>Excluir e restaurar a região onde o OCR retorna uma string vazia.</translation>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>PageListView</name>
     <message>
-      <location filename="..\ui\mainwindow.py" line="49"/>
-      <source>Reveal in File Explorer</source>
-      <translation>Mostrar no Explorador de Arquivos</translation>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>PageSearchWidget</name>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="207"/>
-      <source>Find</source>
-      <translation>Localizar</translation>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="210"/>
-      <source>No result</source>
-      <translation>Nenhum resultado</translation>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="216"/>
-      <source>Previous Match (Shift+Enter)</source>
-      <translation>Correspondência anterior (Shift+Enter)</translation>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="221"/>
-      <source>Next Match (Enter)</source>
-      <translation>Próxima correspondência (Enter)</translation>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="225"/>
-      <source>Match Case</source>
-      <translation>Diferenciar maiúsculas de minúsculas</translation>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="230"/>
-      <source>Match Whole Word</source>
-      <translation>Coincidir com palavra inteira</translation>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="235"/>
-      <source>Use Regular Expression</source>
-      <translation>Usar expressão regular</translation>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="239"/>
-      <source>Translation</source>
-      <translation>Tradução</translation>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="239"/>
-      <source>Source</source>
-      <translation>Original</translation>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="239"/>
-      <source>All</source>
-      <translation>Todos</translation>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="242"/>
-      <source>Range</source>
-      <translation>Intervalo</translation>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="249"/>
-      <location filename="..\ui\page_search_widget.py" line="245"/>
-      <source>Replace</source>
-      <translation>Substituir</translation>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="253"/>
-      <source>Replace All</source>
-      <translation>Substituir tudo</translation>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\page_search_widget.py" line="290"/>
-      <source>Close (Escape)</source>
-      <translation>Fechar (Esc)</translation>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>PenConfigPanel</name>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="135"/>
-      <source>Color</source>
-      <translation>Cor</translation>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="136"/>
-      <source>Alpha</source>
-      <translation>Alfa</translation>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="144"/>
-      <source>Thickness</source>
-      <translation>Espessura</translation>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="149"/>
-      <source>Shape</source>
-      <translation>Forma</translation>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">Resumo: baixados {0}, falhas {1}, ignorados {2}.</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="152"/>
-      <source>Circle</source>
-      <translation>Círculo</translation>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">Abrir Gerenciar modelos</translation>
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="153"/>
-      <source>Rectangle</source>
-      <translation>Retângulo</translation>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
     </message>
-  </context>
-  <context>
-    <name>RectPanel</name>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="197"/>
-      <source>Dilate</source>
-      <translation>Dilatar</translation>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="204"/>
-      <source>method 1</source>
-      <translation>método 1</translation>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-      <location filename="..\ui\drawingpanel.py" line="204"/>
-      <source>method 2</source>
-      <translation>método 2</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="205"/>
-      <source>Auto</source>
-      <translation>Automático</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="206"/>
-      <source>run inpainting automatically.</source>
-      <translation>executar Inpainting automaticamente.</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="208"/>
-      <source>Inpaint</source>
-      <translation>Retocar</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="209"/>
-      <source>Space</source>
-      <translation>Espaço</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="211"/>
-      <source>Delete</source>
-      <translation>Excluir</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="212"/>
-      <source>Ctrl+D</source>
-      <translation>Ctrl+D</translation>
-    </message>
-    <message>
-      <location filename="..\ui\drawingpanel.py" line="219"/>
-      <source>Inpainter</source>
-      <translation>Inpainter</translation>
-    </message>
-  </context>
-  <context>
-    <name>SelectTextMiniMenu</name>
-    <message>
-      <location filename="..\ui\textedit_area.py" line="30"/>
-      <source>Search selected text on Internet</source>
-      <translation>Pesquisar texto selecionado na Internet</translation>
-    </message>
-    <message>
-      <location filename="..\ui\textedit_area.py" line="36"/>
-      <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
-      <translation>Consultar texto selecionado no SalaDict, veja o guia de instalação no painel de configuração</translation>
-    </message>
-  </context>
-  <context>
-    <name>TextEffectPanel</name>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="90"/>
-      <source>Effect</source>
-      <translation>Efeito</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="100"/>
-      <location filename="..\ui\text_graphical_effect.py" line="99"/>
-      <source>Opacity</source>
-      <translation>Opacidade</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="105"/>
-      <source>Shadow</source>
-      <translation>Sombra</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="108"/>
-      <source>Change shadow color</source>
-      <translation>Alterar cor da sombra</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="109"/>
-      <source>radius</source>
-      <translation>raio</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="112"/>
-      <source>strength</source>
-      <translation>intensidade</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="115"/>
-      <source>x offset</source>
-      <translation>deslocamento x</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="118"/>
-      <source>y offset</source>
-      <translation>deslocamento y</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="122"/>
-      <source>Apply</source>
-      <translation>Aplicar</translation>
-    </message>
-    <message>
-      <location filename="..\ui\text_graphical_effect.py" line="124"/>
-      <source>Cancel</source>
-      <translation>Cancelar</translation>
-    </message>
-  </context>
-  <context>
-    <name>TextStyleArea</name>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="634"/>
-      <source>Style</source>
-      <translation>Estilo</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="803"/>
-      <location filename="..\ui\fontformatpanel.py" line="638"/>
-      <source>New Text Style</source>
-      <translation>Novo Estilo de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="643"/>
-      <source>Remove All</source>
-      <translation>Remover Todos</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="663"/>
-      <source>Remove all styles?</source>
-      <translation>Remover todos os estilos?</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="804"/>
-      <source>Remove all</source>
-      <translation>Remover todos</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="806"/>
-      <source>Import Text Styles</source>
-      <translation>Importar Estilos de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="807"/>
-      <source>Export Text Styles</source>
-      <translation>Exportar Estilos de Texto</translation>
-    </message>
-  </context>
-  <context>
-    <name>TextStyleLabel</name>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="434"/>
-      <source>Click to set as Global format. Double click to edit name.</source>
-      <translation>Clique para definir como formato global. Clique duas vezes para editar o nome.</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="446"/>
-      <source>Apply Text Style</source>
-      <translation>Aplicar Estilo de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="451"/>
-      <source>Update from active style</source>
-      <translation>Atualizar do estilo ativo</translation>
-    </message>
-    <message>
-      <location filename="..\ui\fontformatpanel.py" line="468"/>
-      <source>Delete Style</source>
-      <translation>Excluir Estilo</translation>
-    </message>
-  </context>
-  <context>
-    <name>TitleBar</name>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="318"/>
-      <source>Edit</source>
-      <translation>Editar</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="320"/>
-      <source>Undo</source>
-      <translation>Desfazer</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="323"/>
-      <source>Redo</source>
-      <translation>Refazer</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="326"/>
-      <source>Search</source>
-      <translation>Pesquisar</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="329"/>
-      <source>Global Search</source>
-      <translation>Pesquisa Global</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="333"/>
-      <source>Keyword substitution for machine translation</source>
-      <translation>Substituição de palavras-chave para tradução automática</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="335"/>
-      <source>Keyword substitution for OCR results</source>
-      <translation>Substituição de palavras-chave para resultados de OCR</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="346"/>
-      <source>View</source>
-      <translation>Exibir</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="348"/>
-      <source>Display Language</source>
-      <translation>Idioma de Exibição</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="362"/>
-      <source>Drawing Board</source>
-      <translation>Prancheta de Desenho</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="364"/>
-      <source>Text Editor</source>
-      <translation>Editor de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="366"/>
-      <source>Text Styles Panel</source>
-      <translation>Painel de Estilos de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="367"/>
-      <source>Import Text Styles</source>
-      <translation>Importar Estilos de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="368"/>
-      <source>Export Text Styles</source>
-      <translation>Exportar Estilos de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="369"/>
-      <source>Dark Mode</source>
-      <translation>Modo Escuro</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="391"/>
-      <source>Go</source>
-      <translation>Ir</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="392"/>
-      <source>Previous Page</source>
-      <translation>Página Anterior</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="394"/>
-      <source>Next Page</source>
-      <translation>Próxima Página</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="417"/>
-      <location filename="..\ui\mainwindowbars.py" line="404"/>
-      <source>Run</source>
-      <translation>Executar</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="407"/>
-      <source>Enable Text Dection</source>
-      <translation>Ativar Detecção de Texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="408"/>
-      <source>Enable OCR</source>
-      <translation>Ativar OCR</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="409"/>
-      <source>Enable Translation</source>
-      <translation>Ativar Tradução</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="410"/>
-      <source>Enable Inpainting</source>
-      <translation>Ativar Inpaint</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="418"/>
-      <source>Run without update textstyle</source>
-      <translation>Executar sem atualizar estilo de texto</translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="419"/>
-      <source>Translate page</source>
-      <translation>Traduzir página</translation>
-    </message>
-  </context>
-  <context>
-    <name>TranslateThread</name>
-    <message>
-      <location filename="..\ui\module_manager.py" line="188"/>
-      <source>Failed to set translator </source>
-      <translation>Falha ao definir o tradutor </translation>
-    </message>
-    <message>
-      <location filename="..\ui\module_manager.py" line="238"/>
-      <location filename="..\ui\module_manager.py" line="206"/>
-      <source>Translation Failed.</source>
-      <translation>Falha na tradução.</translation>
-    </message>
-  </context>
-  <context>
-    <name>TranslatorConfigPanel</name>
-    <message>
-      <location filename="..\ui\module_parse_widgets.py" line="329"/>
-      <source>Keyword substitution for machine translation</source>
-      <translation>Substituição de palavras-chave para tradução automática</translation>
-    </message>
-    <message>
-      <location filename="..\ui\module_parse_widgets.py" line="336"/>
-      <source>Source</source>
-      <translation>Original</translation>
-    </message>
-    <message>
-      <location filename="..\ui\module_parse_widgets.py" line="338"/>
-      <source>Target</source>
-      <translation>Alvo</translation>
-    </message>
-  </context>
-  <context>
-    <name>TranslatorStatusButton</name>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="76"/>
-      <source>Translator: </source>
-      <translation>Tradutor: </translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="77"/>
-      <source>Source: </source>
-      <translation>Original: </translation>
-    </message>
-    <message>
-      <location filename="..\ui\mainwindowbars.py" line="78"/>
-      <source>Target: </source>
-      <translation>Alvo: </translation>
-    </message>
-  </context>
-<context>
-    <name>StartupModelCoverage</name>
-    <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>Copiar arquivos de modelo de uma pasta local existente para o diretório data/models deste aplicativo.</translation>
-    </message>
-    <message>
-        <source>Core package</source>
-        <translation>Pacote principal</translation>
-    </message>
-    <message>
-        <source>Core package not selected</source>
-        <translation>Pacote principal não selecionado</translation>
-    </message>
-    <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>Não baixar nenhum pacote de modelo agora. Use apenas módulos/arquivos já locais.</translation>
-    </message>
-    <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>Download concluído. Padrões atualizados.</translation>
-    </message>
-    <message>
-        <source>Download partially complete.</source>
-        <translation>Download parcialmente concluído.</translation>
-    </message>
-    <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>O modo somente local da primeira execução está ativo. Use Ferramentas → Gerenciar modelos para importar/baixar modelos, ou edite config/config.json para habilitar pacotes e reinicie.</translation>
-    </message>
-    <message>
-        <source>Import local model directory...</source>
-        <translation>Importar diretório local de modelos...</translation>
-    </message>
-    <message>
-        <source>Import local models</source>
-        <translation>Importar modelos locais</translation>
-    </message>
-    <message>
-        <source>Manual package selection</source>
-        <translation>Seleção manual de pacotes</translation>
-    </message>
-    <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>Selecione manualmente pacotes de baixo nível em vez de usar uma predefinição.</translation>
-    </message>
-    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
         <source>Model package download complete</source>
-        <translation>Download de pacote de modelos concluído</translation>
+        <translation type="unfinished">Download de pacote de modelos concluído</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">Alguns pacotes de modelos falharam. Itens com falha: {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
         <source>Model package download partially complete</source>
-        <translation>Download de pacote de modelos parcialmente concluído</translation>
+        <translation type="unfinished">Download de pacote de modelos parcialmente concluído</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">O modo somente local da primeira execução está ativo. Use Ferramentas → Gerenciar modelos para importar/baixar modelos, ou edite config/config.json para habilitar pacotes e reinicie.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">Download parcialmente concluído.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">Download concluído. Padrões atualizados.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
         <source>Model packages have been downloaded. Applied modules:
 </source>
-        <translation>Os pacotes de modelos foram baixados. Módulos aplicados:
+        <translation type="unfinished">Os pacotes de modelos foram baixados. Módulos aplicados:
 </translation>
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>Abrir Gerenciar modelos</translation>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
     </message>
     <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>unsaved</source>
+        <translation>não salvo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>saved</source>
+        <translation>salvo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3258" />
+        <source>Saving image...</source>
+        <translation>Salvando imagem...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3297" />
+        <source>Confirmation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">Executar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
+        <source>Import Text Styles</source>
+        <translation>Importar Estilos de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3417" />
+        <source>Save Text Styles</source>
+        <translation>Salvar Estilos de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
+        <source>Text file exported to </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3565" />
+        <source>Failed to export as TEXT file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
+        <source>Import *.md/*.txt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3604" />
+        <source>Translation imported and matched successfully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3608" />
+        <source>Missing pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3611" />
+        <source>Unexpected pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3614" />
+        <source>Unmatched pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3625" />
+        <source>Failed to import translation from </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
+        <source>Export to </source>
+        <translation>Exportar para </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">Pesquisar</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">Importar diretório local de modelos...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
         <source>Select local model directory</source>
-        <translation>Selecionar diretório local de modelos</translation>
+        <translation type="unfinished">Selecionar diretório local de modelos</translation>
     </message>
     <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">Importar modelos locais</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">Selecione manualmente pacotes de baixo nível em vez de usar uma predefinição.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">Seleção manual de pacotes</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
         <source>Skip all downloads (local-only)</source>
-        <translation>Ignorar todos os downloads (somente local)</translation>
+        <translation type="unfinished">Ignorar todos os downloads (somente local)</translation>
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>Alguns pacotes de modelos falharam. Itens com falha: {0}</translation>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">Não baixar nenhum pacote de modelo agora. Use apenas módulos/arquivos já locais.</translation>
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>Resumo: baixados {0}, falhas {1}, ignorados {2}.</translation>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">Pacote principal não selecionado</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleManager</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished">Detectando: </translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
+        <source>Set Inpainter...</source>
+        <translation>Definir Inpainter...</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModuleThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OCRConfigPanel</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="830" />
+        <source>Delete and restore region where OCR return empty string.</source>
+        <translation>Excluir e restaurar a região onde o OCR retorna uma string vazia.</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">Tradução</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="88" />
+        <source>Reveal in File Explorer</source>
+        <translation>Mostrar no Explorador de Arquivos</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>PageSearchWidget</name>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="207" />
+        <source>Find</source>
+        <translation>Localizar</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="210" />
+        <source>No result</source>
+        <translation>Nenhum resultado</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="216" />
+        <source>Previous Match (Shift+Enter)</source>
+        <translation>Correspondência anterior (Shift+Enter)</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="221" />
+        <source>Next Match (Enter)</source>
+        <translation>Próxima correspondência (Enter)</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="225" />
+        <source>Match Case</source>
+        <translation>Diferenciar maiúsculas de minúsculas</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="230" />
+        <source>Match Whole Word</source>
+        <translation>Coincidir com palavra inteira</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="235" />
+        <source>Use Regular Expression</source>
+        <translation>Usar expressão regular</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="239" />
+        <source>Translation</source>
+        <translation>Tradução</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="239" />
+        <source>Source</source>
+        <translation>Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="239" />
+        <source>All</source>
+        <translation>Todos</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="242" />
+        <source>Range</source>
+        <translation>Intervalo</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
+        <source>Replace</source>
+        <translation>Substituir</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="253" />
+        <source>Replace All</source>
+        <translation>Substituir tudo</translation>
+    </message>
+    <message>
+        <location filename="../ui/page_search_widget.py" line="290" />
+        <source>Close (Escape)</source>
+        <translation>Fechar (Esc)</translation>
+    </message>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>PenConfigPanel</name>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="152" />
+        <source>Color</source>
+        <translation>Cor</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="153" />
+        <source>Alpha</source>
+        <translation>Alfa</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="161" />
+        <source>Thickness</source>
+        <translation>Espessura</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="166" />
+        <source>Shape</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="169" />
+        <source>Circle</source>
+        <translation>Círculo</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="170" />
+        <source>Rectangle</source>
+        <translation>Retângulo</translation>
+    </message>
+</context><context>
+    <name>RectPanel</name>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="214" />
+        <source>Dilate</source>
+        <translation>Dilatar</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">Retângulo</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
+        <source>Auto</source>
+        <translation>Automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="241" />
+        <source>run inpainting automatically.</source>
+        <translation>executar Inpainting automaticamente.</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="243" />
+        <source>Inpaint</source>
+        <translation>Retocar</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="244" />
+        <source>Space</source>
+        <translation>Espaço</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
+        <source>Delete</source>
+        <translation>Excluir</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="250" />
+        <source>Ctrl+D</source>
+        <translation>Ctrl+D</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="258" />
+        <source>Inpainter</source>
+        <translation>Inpainter</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">Forma</translation>
+    </message>
+</context><context>
+    <name>SelectTextMiniMenu</name>
+    <message>
+        <location filename="../ui/textedit_area.py" line="30" />
+        <source>Search selected text on Internet</source>
+        <translation>Pesquisar texto selecionado na Internet</translation>
+    </message>
+    <message>
+        <location filename="../ui/textedit_area.py" line="36" />
+        <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
+        <translation>Consultar texto selecionado no SalaDict, veja o guia de instalação no painel de configuração</translation>
+    </message>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished">Atalho</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
+        <source>Apply</source>
+        <translation type="unfinished">Aplicar</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">Tradução</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">Tradutor</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished">Salvamento automático</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextAdvancedFormatPanel</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="170" />
+        <source>Proportional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="171" />
+        <source>Distance</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="175" />
+        <source>Line Spacing Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="182" />
+        <source>Set Text Opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="184" />
+        <source>Opacity</source>
+        <translation type="unfinished">Opacidade</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
+        <source>Shadow</source>
+        <translation type="unfinished">Sombra</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextDetectConfigPanel</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="615" />
+        <source>Keep Existing Lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextGradientGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="91" />
+        <source>Gradient</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="96" />
+        <source>Start Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="100" />
+        <source>End Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="102" />
+        <source>Enable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="112" />
+        <source>Set Gradient Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="114" />
+        <source>Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextShadowGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="17" />
+        <source>Set X offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="28" />
+        <source>Set Y offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="40" />
+        <source>Set Shadow Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="42" />
+        <source>Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="51" />
+        <source>Set Shadow Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="53" />
+        <source>Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="72" />
+        <source>Offset</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextStyleLabel</name>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="87" />
+        <source>Click to set as Global format. Double click to edit name.</source>
+        <translation>Clique para definir como formato global. Clique duas vezes para editar o nome.</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="99" />
+        <source>Apply Text Style</source>
+        <translation>Aplicar Estilo de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="104" />
+        <source>Update from active style</source>
+        <translation>Atualizar do estilo ativo</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="121" />
+        <source>Delete Style</source>
+        <translation>Excluir Estilo</translation>
+    </message>
+</context><context>
+    <name>TextStylePresetPanel</name>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="277" />
+        <source>Style</source>
+        <translation type="unfinished">Estilo</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
+        <source>New Text Style</source>
+        <translation type="unfinished">Novo Estilo de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="286" />
+        <source>Remove All</source>
+        <translation type="unfinished">Remover Todos</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="300" />
+        <source>Remove all styles?</source>
+        <translation type="unfinished">Remover todos os estilos?</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="462" />
+        <source>Remove all</source>
+        <translation type="unfinished">Remover todos</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="464" />
+        <source>Import Text Styles</source>
+        <translation type="unfinished">Importar Estilos de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="465" />
+        <source>Export Text Styles</source>
+        <translation type="unfinished">Exportar Estilos de Texto</translation>
+    </message>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished">Aplicar</translation>
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TitleBar</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="443" />
+        <source>Edit</source>
+        <translation>Editar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="445" />
+        <source>Undo</source>
+        <translation>Desfazer</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="448" />
+        <source>Redo</source>
+        <translation>Refazer</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="451" />
+        <source>Search</source>
+        <translation>Pesquisar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="454" />
+        <source>Global Search</source>
+        <translation>Pesquisa Global</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="458" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="460" />
+        <source>Keyword substitution for machine translation</source>
+        <translation>Substituição de palavras-chave para tradução automática</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="462" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
+        <source>View</source>
+        <translation>Exibir</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="486" />
+        <source>Display Language</source>
+        <translation>Idioma de Exibição</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="500" />
+        <source>Drawing Board</source>
+        <translation>Prancheta de Desenho</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="502" />
+        <source>Text Editor</source>
+        <translation>Editor de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="504" />
+        <source>Import Text Styles</source>
+        <translation>Importar Estilos de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="505" />
+        <source>Export Text Styles</source>
+        <translation>Exportar Estilos de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
+        <source>Dark Mode</source>
+        <translation>Modo Escuro</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
+        <source>Go</source>
+        <translation>Ir</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="601" />
+        <source>Previous Page</source>
+        <translation>Página Anterior</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="602" />
+        <source>Next Page</source>
+        <translation>Próxima Página</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
+        <source>Enable Text Dection</source>
+        <translation>Ativar Detecção de Texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="764" />
+        <source>Enable OCR</source>
+        <translation>Ativar OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="765" />
+        <source>Enable Translation</source>
+        <translation>Ativar Tradução</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="766" />
+        <source>Enable Inpainting</source>
+        <translation>Ativar Inpaint</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>Executar</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
+        <source>Run without update textstyle</source>
+        <translation>Executar sem atualizar estilo de texto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="775" />
+        <source>Translate page</source>
+        <translation>Traduzir página</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">Abrir Pasta ...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">Abrir Projeto ... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">Salvar Projeto</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">Exportar como Documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">Importar de Documento</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TranslateThread</name>
+    <message>
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
+        <source>Failed to set translator </source>
+        <translation>Falha ao definir o tradutor </translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
+        <source>Translation Failed.</source>
+        <translation>Falha na tradução.</translation>
+    </message>
+</context><context>
+    <name>TranslationContextDialog</name>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TranslatorConfigPanel</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="435" />
+        <source>Keyword substitution for machine translation</source>
+        <translation>Substituição de palavras-chave para tradução automática</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
+        <source>Source</source>
+        <translation>Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="480" />
+        <source>Target</source>
+        <translation>Alvo</translation>
+    </message>
+</context><context>
+    <name>TranslatorSelectionWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1468" />
+        <source>Translate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1470" />
+        <source>Source</source>
+        <translation type="unfinished">Original</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1472" />
+        <source>Target</source>
+        <translation type="unfinished">Alvo</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">Desfazer</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">Refazer</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished">Estilo</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">Excluir</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">Tradução</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">Executar</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished">Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/ru_RU.ts
+++ b/translate/ru_RU.ts
@@ -2,1301 +2,8785 @@
 <!DOCTYPE TS>
 <TS version="2.1" language="ru_RU" sourcelanguage="en_US">
 <context>
+    <name>BatchQueueDialog</name>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="54" />
+        <source>Batch processing queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="58" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="64" />
+        <source>Add folder(s)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="66" />
+        <source>Select one or more folders to add to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="67" />
+        <source>Add folder (include subfolders)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="69" />
+        <source>Select one folder; add it and each immediate subfolder as separate queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="70" />
+        <source>Remove selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="72" />
+        <source>Clear all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="82" />
+        <source>Skip ignored pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="85" />
+        <source>If checked, pages marked as "Ignore in run" in each project are not processed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="87" />
+        <source>The first item's page selection (which pages to run) is applied to all queue items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="91" />
+        <source>Queue: 0 items. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="96" />
+        <source>Start queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="98" />
+        <source>Process queue items one by one (same as headless --exec_dirs).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="99" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="101" />
+        <source>Temporarily pause the current job.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="103" />
+        <source>Resume</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="105" />
+        <source>Resume after pause.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="107" />
+        <source>Cancel queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="109" />
+        <source>Stop current job and clear remaining queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="123" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="143" />
+        <source>Select folder to add</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="157" />
+        <source>Select folder (it and its subfolders will be added)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="184" />
+        <source>Batch queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="185" />
+        <source>Add at least one folder to the queue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="195" />
+        <source>Paused. Click Resume to continue.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
+        <source>Running…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="206" />
+        <source>Queue: {} item(s). Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="215" />
+        <source>Running… Use Pause / Cancel queue as needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="223" />
+        <source>Queue empty. Add folders and click Start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="231" />
+        <source>Running: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="237" />
+        <source>Queue finished. Add more folders or close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_queue_dialog.py" line="241" />
+        <source>Queue cancelled.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>BatchReportDialog</name>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="19" />
+        <source>Batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="23" />
+        <source>Status: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
+        <source>Total: —  Skipped: —  Completed: —</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="29" />
+        <source>Page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="30" />
+        <source>Reason</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="31" />
+        <source>Suggested action</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="44" />
+        <source>Status: No report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="56" />
+        <source>Status: {}  Finished: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Cancelled</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="57" />
+        <source>Completed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/batch_report_dialog.py" line="62" />
+        <source>Total: {}  Skipped: {}  Completed: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="542"/>
-        <source>Enable/disable ocr</source>
-        <translation>Включить/выключить OCR</translation>
+        <location filename="../ui/mainwindowbars.py" line="1566" />
+        <source>Text Detector</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="546"/>
-        <source>Enable/disable translation</source>
-        <translation>Включить/выключить перевод</translation>
+        <location filename="../ui/mainwindowbars.py" line="1567" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="550"/>
-        <source>translate page</source>
-        <translation>Перевести страницу</translation>
+        <location filename="../ui/mainwindowbars.py" line="1568" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Закраска</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="551"/>
-        <source>stop</source>
-        <translation>Стоп</translation>
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation type="unfinished">Начать перевод</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="552"/>
-        <source>translate current page</source>
-        <translation>Перевести текущую страницу</translation>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="553"/>
-        <source>stop translation</source>
-        <translation>Остановить перевод</translation>
+        <location filename="../ui/mainwindowbars.py" line="1596" />
+        <source>Drawing board</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="562"/>
-        <source>Enable/disable paint mode</source>
-        <translation>Включить/выключить режим рисования</translation>
+        <location filename="../ui/mainwindowbars.py" line="1600" />
+        <source>Text editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="566"/>
-        <source>Enable/disable text edit mode</source>
-        <translation>Включить/выключить режим редактирования</translation>
+        <location filename="../ui/mainwindowbars.py" line="1604" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="572"/>
-        <source>Original image transparency: </source>
-        <translation>Прозрачность оригинала: </translation>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
+        <source>Original image opacity</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="576"/>
-        <source>Lettering layer transparency: </source>
-        <translation>Прозрачность перевода: </translation>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
+        <source>Text layer opacity</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="659"/>
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
+        <source>Edit</source>
+        <translation type="unfinished">Редактирование</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1073" />
         <source>Copy</source>
         <translation>Копировать</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="660"/>
+        <location filename="../ui/canvas.py" line="1078" />
         <source>Paste</source>
         <translation>Вставить</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="661"/>
-        <source>Delete</source>
-        <translation>Удалить</translation>
+        <location filename="../ui/canvas.py" line="1083" />
+        <source>Copy translation</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="662"/>
+        <location filename="../ui/canvas.py" line="1087" />
+        <source>Paste translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1091" />
         <source>Copy source text</source>
         <translation>Скопировать исходный текст</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="663"/>
+        <location filename="../ui/canvas.py" line="1096" />
         <source>Paste source text</source>
         <translation>Вставить исходный текст</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="664"/>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
         <source>Delete and Recover removed text</source>
         <translation>Удаление или восстановление удаленного текста</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="667"/>
+        <location filename="../ui/canvas.py" line="1115" />
+        <source>Clear source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1119" />
+        <source>Clear translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1125" />
+        <source>Select all text boxes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1138" />
+        <source>Spell check source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1142" />
+        <source>Spell check translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1146" />
+        <source>Trim whitespace</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1150" />
+        <source>To uppercase</source>
+        <translation type="unfinished">Начинать с большой буквы</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1154" />
+        <source>To lowercase</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1158" />
+        <source>Toggle strikethrough</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1162" />
+        <source>Gradient type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1163" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1164" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1168" />
+        <source>Text on path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1169" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1170" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1171" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
+        <location filename="../ui/canvas.py" line="1191" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1181" />
+        <source>Create text box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1182" />
+        <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1187" />
+        <source>Merge selected blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1192" />
+        <source>Split selected region(s)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1196" />
+        <source>Move block(s) up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1201" />
+        <source>Move block(s) down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1206" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
+        <source>Image / Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1214" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1219" />
+        <source>Clear overlay image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
+        <source>Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1230" />
+        <source>Free Transform</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1236" />
+        <source>Reset warp</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1241" />
+        <source>Warp preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1242" />
+        <source>Arc Up</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1243" />
+        <source>Arc Down</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1244" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1245" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
+        <source>Order</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1254" />
+        <source>Bring to front</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1258" />
+        <source>Send to back</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
+        <source>Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1271" />
         <source>Apply font formatting</source>
         <translation>Применить форматирование шрифта</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="668"/>
+        <location filename="../ui/canvas.py" line="1275" />
         <source>Auto layout</source>
         <translation>Автоматическая компоновка</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="669"/>
+        <location filename="../ui/canvas.py" line="1279" />
+        <source>Fit to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1281" />
+        <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1285" />
+        <source>Auto fit font size to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1287" />
+        <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1291" />
+        <source>Auto fit font size (binary search)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1293" />
+        <source>Find largest font size that fits the bubble (slower, more accurate).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1297" />
+        <source>Balloon shape</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1298" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1299" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1300" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1301" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1302" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1303" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1304" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1305" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1306" />
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1310" />
+        <source>Resize to fit content</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1312" />
+        <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1316" />
+        <source>Center in bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1318" />
+        <source>Move the text box so its center aligns with the bubble center (no resize).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1322" />
         <source>Reset Angle</source>
         <translation>Сбросить угол</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="671"/>
-        <source>translate</source>
-        <translation>Перевести</translation>
+        <location filename="../ui/canvas.py" line="1326" />
+        <source>Squeeze</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="672"/>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
+        <location filename="../ui/canvas.py" line="1341" />
+        <location filename="../ui/canvas.py" line="1337" />
+        <source>Run</source>
+        <translation type="unfinished">Начать перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1338" />
+        <source>Detect text in region</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1342" />
+        <source>Detect text on page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1347" />
+        <source>Translate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1352" />
         <source>OCR</source>
         <translation>OCR (Распознать)</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="673"/>
+        <location filename="../ui/canvas.py" line="1357" />
         <source>OCR and translate</source>
         <translation>Распознать и перевести</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="674"/>
+        <location filename="../ui/canvas.py" line="1362" />
         <source>OCR, translate and inpaint</source>
         <translation>Распознать, перевести и закрасить</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/canvas.py" line="1367" />
+        <source>Inpaint</source>
+        <translation type="unfinished">Закраска</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1384" />
+        <source>Download image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1385" />
+        <source>With text (result)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1386" />
+        <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1387" />
+        <source>Inpainted only (no text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1388" />
+        <source>Save inpainted image only (text regions filled, no text overlay).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1389" />
+        <source>Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1390" />
+        <source>Save original image without translation or inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
+        <source>Configure menu...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
     <message>
-        <location filename="../ui/configpanel.py" line="282"/>
+        <location filename="../ui/configpanel.py" line="410" />
         <source>DL Module</source>
         <translation>Модули ИИ</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="283"/>
+        <location filename="../ui/configpanel.py" line="411" />
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="285"/>
+        <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>Обнаружение текста</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="312"/>
-        <location filename="../ui/configpanel.py" line="286"/>
+        <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="287"/>
+        <location filename="../ui/configpanel.py" line="415" />
         <source>Inpaint</source>
         <translation>Клининг</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="288"/>
+        <location filename="../ui/configpanel.py" line="416" />
         <source>Translator</source>
         <translation>Переводчик</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="289"/>
+        <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>Действия при запуске</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="290"/>
-        <source>Sources</source>
-        <translation>Источники</translation>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="291"/>
-        <source>Lettering</source>
-        <translation>Работа с текстом</translation>
+        <location filename="../ui/configpanel.py" line="419" />
+        <source>Typesetting</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="292"/>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="421" />
+        <source>Save</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="422" />
         <source>SalaDict</source>
         <translation>SalaDict</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="308"/>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
+        <source>Load models on demand</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="443" />
+        <source>Load models on demand to save memory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
+        <source>Default (use module default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Default device</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="454" />
+        <source>Preferred device for DL modules when set to Default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN to save memory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="460" />
+        <source>Release model caches after batch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="461" />
+        <source>After pipeline finishes (all pages), unload models and clear caches to free RAM. Like "Empty cache after RUN" but only after a full run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="466" />
+        <source>Skip already translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="467" />
+        <source>Do not call translator for pages where every block already has a translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="472" />
+        <source>Enable OCR cache</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="473" />
+        <source>Reuse OCR results for the same image/model/language in this session. Reduces redundant OCR runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="478" />
+        <source>Auto OCR by source language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="479" />
+        <source>Select OCR module by source language (e.g. Japanese → manga_ocr). Requires language mapping in pipeline.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="484" />
+        <source>Show module tier badge in selector tooltip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="485" />
+        <source>Show Stable/Beta/Experimental/External-heavy badge in detector/OCR/inpainter/translator dropdown tooltips.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="490" />
+        <source>Merge nearby blocks (collision)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="491" />
+        <source>Merge detection boxes that are close (collision-based). Use when OCR returns many small boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="502" />
+        <source>Merge gap ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="503" />
+        <source>Vertical expansion ratio for horizontal merge (e.g. 1.5 for typical merge).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="512" />
+        <source>Min blocks to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="513" />
+        <source>Only run merge when page has at least this many blocks (avoids merging normal bubble layouts; default 18).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="518" />
+        <source>Unload All Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
+        <location filename="../ui/configpanel.py" line="523" />
+        <source>Check / Download module files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="524" />
+        <source>Check and download required model files for all detectors, OCR, inpainters, and translators. Run this if a module fails to load.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="735" />
+        <location filename="../ui/configpanel.py" line="610" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>Unload models after idle (minutes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="532" />
+        <source>0 = disabled. Unload DL models after N minutes of no Run or canvas activity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="535" />
+        <source>Image upscaling (Section 6)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="537" />
+        <source>Initial upscale before detection/OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="538" />
+        <source>Upscale page before pipeline (improves small text). Results are scaled back to original size.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>Initial upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="547" />
+        <source>e.g. 2 = 2x before detection/OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="550" />
+        <source>Final upscale when saving result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="551" />
+        <source>Upscale result image when saving (e.g. 2x for nicer export).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>Final upscale factor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="560" />
+        <source>e.g. 2 = 2x when saving result.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="563" />
+        <source>Auto-scale pipeline params by image area</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="564" />
+        <source>Scale padding/gaps by image size so settings behave consistently across resolutions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="570" />
+        <source>Colorize final result (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="571" />
+        <source>Apply a light colorization to grayscale pages when saving the final result. Does not affect original or inpainted layers.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="578" />
+        <source>Soft (Twilight, manga-friendly)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="579" />
+        <source>Vibrant (Magma)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="580" />
+        <source>Cool (Ocean)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="584" />
+        <source>Colorization style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="585" />
+        <source>Choose the colorization palette: softer vs more vibrant or cool-toned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="597" />
+        <source>Colorization strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="598" />
+        <source>Blend between grayscale (0) and fully colorized (1). Recommended 0.5–0.8.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>OCR crop upscale min side (global)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="606" />
+        <source>If &gt;0, upscale small crops so longer side &gt;= this before OCR (e.g. 512). Per-OCR params override when set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>Inpaint: spill to disk after N blocks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="613" />
+        <source>When &gt;0, write intermediate result to temp file every N blocks to reduce peak RAM/VRAM on long pages (e.g. 8 or 12).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="617" />
         <source>Detector</source>
         <translation>Детектор</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="316"/>
+        <location filename="../ui/configpanel.py" line="626" />
         <source>Inpainter</source>
         <translation>Клинер</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="324"/>
+        <location filename="../ui/configpanel.py" line="634" />
+        <source>Reopen last project, confirm before run, recent list limit.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
         <source>Reopen last project on startup</source>
         <translation>Открывать последний проект при запуске</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="332"/>
+        <location filename="../ui/configpanel.py" line="639" />
+        <source>Show welcome screen when no project is open</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="640" />
+        <source>On startup, when no project is opened, show the welcome screen to open or create a project (manhua-translator / Komakun style).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="645" />
+        <source>Auto update from GitHub on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="646" />
+        <source>Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
+        <source>Dev mode (show all modules)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Recent projects limit (5–30)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="675" />
+        <source>Maximum number of recent projects in the list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Confirm before Run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="679" />
+        <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="683" />
+        <source>Manual mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="684" />
+        <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="689" />
+        <source>Skip ignored pages in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="690" />
+        <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="695" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="696" />
+        <source>After run: on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="697" />
+        <source>After run: on current page only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="701" />
+        <source>After Run: Region merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="702" />
+        <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="711" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="712" />
+        <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="723" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="724" />
+        <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="738" />
+        <source>Smooth scroll (ms)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="739" />
+        <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="749" />
+        <source>Motion blur on scroll</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="750" />
+        <source>Briefly blur content during scroll (can be costly on some systems).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="761" />
+        <source>Reduce motion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="762" />
+        <source>Shorter or no UI animations (accessibility / preference).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="772" />
+        <source>Path to cursor image (.png, .cur)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="775" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="784" />
+        <source>Use custom cursor</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="785" />
+        <source>Use a custom mouse cursor from file. Set path below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="793" />
+        <source>Custom cursor path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="794" />
+        <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="805" />
+        <source>UI language. Same as View → Display Language.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Config panel font scale (0.8–1.5)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="813" />
+        <source>Scale font size in this Config panel. Reopen Config to apply.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="819" />
+        <source>System default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>Logical DPI (restart to apply)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="820" />
+        <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="826" />
+        <source>Auto fit to box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="827" />
+        <source>Fixed size (use font size list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="830" />
+        <source>Text in box</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="831" />
+        <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="835" />
+        <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="839" />
         <source>decide by program</source>
         <translation>Решает программа</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="333"/>
+        <location filename="../ui/configpanel.py" line="840" />
         <source>use global setting</source>
         <translation>Используется глобальная настройка</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="335"/>
-        <source>font size</source>
-        <translation>Размер шрифта</translation>
+        <location filename="../ui/configpanel.py" line="850" />
+        <source>Font Size</source>
+        <translation type="unfinished">Размер шрифта</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="337"/>
-        <source>stroke size</source>
-        <translation>размер хода</translation>
+        <location filename="../ui/configpanel.py" line="854" />
+        <source>Stroke Size</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="340"/>
-        <source>font color</source>
-        <translation>Цвет шрифта</translation>
+        <location filename="../ui/configpanel.py" line="858" />
+        <source>Font Color</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="342"/>
-        <source>stroke color</source>
-        <translation>цвет обводки</translation>
+        <location filename="../ui/configpanel.py" line="861" />
+        <source>Stroke Color</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="345"/>
-        <source>effect</source>
-        <translation>Эффекты</translation>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Default stroke width</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="347"/>
-        <source>alignment</source>
-        <translation>Выравнивание</translation>
+        <location filename="../ui/configpanel.py" line="871" />
+        <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="350"/>
+        <location filename="../ui/configpanel.py" line="883" />
+        <source>Default box corner radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="884" />
+        <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Default stroke color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="892" />
+        <source>Global default when "use global setting" is selected for Stroke Color.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="895" />
+        <source>Effect</source>
+        <translation type="unfinished">Эффект</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="898" />
+        <source>Alignment</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="902" />
+        <source>Writing-mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Keep existing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Always use global setting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Font Family</source>
+        <translation type="unfinished">Семейство шрифтов</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="911" />
         <source>Auto layout</source>
         <translation>Автоматическая компоновка</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="351"/>
-        <source>Split translation into multi-lines according to the extracted balloon region. The font size will be adaptively resized if it is set to &quot;decide by program.&quot;</source>
-        <translation>Разделите перевод на несколько строк в соответствии с выделенной областью &quot;облачка&quot;. Размер шрифта будет адаптивно изменен, если установлено значение &quot;определять программой&quot;</translation>
+        <location filename="../ui/configpanel.py" line="912" />
+        <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="353"/>
+        <location filename="../ui/configpanel.py" line="917" />
+        <source>Constrain text box to bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="918" />
+        <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="923" />
+        <source>Center in bubble after auto layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="924" />
+        <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="935" />
+        <source>Center in bubble: skip if another box within (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="936" />
+        <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="940" />
+        <source>Check overflow after layout</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="941" />
+        <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="945" />
+        <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="949" />
+        <source>Box size check model ID (secondary)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="950" />
+        <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="954" />
+        <source>Optimal line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="955" />
+        <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="960" />
+        <source>Hyphenation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="961" />
+        <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="966" />
+        <source>Optimize line breaks (fewer lines)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="967" />
+        <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="980" />
+        <source>Short line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="981" />
+        <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="993" />
+        <source>Height overflow penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="994" />
+        <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1007" />
+        <source>Layout font size min (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1008" />
+        <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1018" />
+        <source>Layout font size max (pt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1019" />
+        <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1022" />
+        <source>Scale font to fit bubble</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1023" />
+        <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1027" />
+        <source>Binary search font size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1028" />
+        <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Round</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Elongated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1034" />
+        <source>Narrow</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Diamond</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Square</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Bevel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Pentagon</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1035" />
+        <source>Point</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1037" />
+        <source>Balloon shape (Diamond-Text)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1038" />
+        <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1044" />
+        <source>Aspect ratio only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1045" />
+        <source>Contour only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1046" />
+        <source>Model only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1047" />
+        <source>Model, then contour</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1048" />
+        <source>Model, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1049" />
+        <source>Contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1050" />
+        <source>Model, then contour, then aspect ratio</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1052" />
+        <source>Auto shape method</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1053" />
+        <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1057" />
+        <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1061" />
+        <source>Balloon shape model ID</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1062" />
+        <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1072" />
+        <source>Minimum line width (px)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1073" />
+        <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1084" />
+        <source>Max line width fraction (no bubble)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1085" />
+        <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1096" />
+        <source>1-word line penalty</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1097" />
+        <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1100" />
+        <source>Translation panel: preserve line breaks</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1101" />
+        <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1105" />
         <source>To uppercase</source>
         <translation>Начинать с большой буквы</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="358"/>
-        <source>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md&quot;&gt;Installation guide&lt;/a&gt;</source>
-        <translation>&lt;a href=&quot;https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md&quot;&gt;Инструкция установки&lt;/a&gt;</translation>
+        <location filename="../ui/configpanel.py" line="1108" />
+        <source>Independent text styles for each projects</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="362"/>
+        <location filename="../ui/configpanel.py" line="1111" />
+        <source>Show only custom fonts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1116" />
+        <source>Spell check / Auto-correct OCR result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1117" />
+        <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1122" />
+        <source>Result image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1128" />
+        <source>Quality</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1133" />
+        <source>WebP lossless</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1134" />
+        <source>Use lossless WebP when result format is WebP (ignores quality).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1138" />
+        <source>Intermediate image format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1142" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1143" />
+        <source>Choose which actions appear in the canvas right-click menu.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Right-click menu</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1145" />
+        <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Инструкция установки&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
         <source>Show mini menu when selecting text.</source>
         <translation>Показывать мини-меню при выделении текста.</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="368"/>
-        <source>shortcut</source>
-        <translation>Гор. Клавиша</translation>
+        <location filename="../ui/configpanel.py" line="1160" />
+        <source>Shortcut</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="371"/>
+        <location filename="../ui/configpanel.py" line="1163" />
         <source>Search Engines</source>
         <translation>Поисковые системы</translation>
     </message>
     <message>
-        <source>stroke</source>
-        <translation type="vanished">Толщина границ</translation>
+        <location filename="../ui/configpanel.py" line="1306" />
+        <source>Select cursor image</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>font &amp; stroke color</source>
-        <translation type="vanished">цвет шрифта и границ</translation>
+        <location filename="../ui/configpanel.py" line="1308" />
+        <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/configpanel.py" line="1395" />
+        <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1401" />
+        <source>Error: </source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ContextMenuConfigDialog</name>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
+        <source>Context Menu Options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="129" />
+        <source>Choose which actions appear in the canvas right-click menu. Checked = visible, unchecked = hidden. Pin items to the list below to show them at the top of the menu (drag to reorder).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
+        <source>Shown at top of menu (drag to reorder)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
+        <source>Clear all from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
+        <source>Pin to top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
+        <source>Restore defaults</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
+        <source>OK</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
+        <source>Remove from top</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="343"/>
-        <source>Mask Transparency</source>
-        <translation>Прозрачность маски</translation>
+        <location filename="../ui/drawingpanel.py" line="350" />
+        <source>Hand (H) – Pan canvas</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="355" />
+        <source>Inpaint brush (J) – Draw region to inpaint</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="363" />
+        <source>Rectangle (R) – Select region to inpaint or delete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="374" />
+        <source>Pen (B) – Draw or erase on canvas</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="383" />
+        <source>Text eraser (#1093) – Erase parts of selected text (depth effect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="412" />
+        <source>Mask Opacity</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ExportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="92"/>
+        <location filename="../ui/io_thread.py" line="118" />
         <source>Export as doc...</source>
         <translation>Экспорт в формате doc...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="98"/>
+        <location filename="../ui/io_thread.py" line="124" />
         <source>Overwrite </source>
         <translation>Перезаписать </translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ExportFormatDialog</name>
+    <message>
+        <location filename="../ui/export_dialog.py" line="33" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="38" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
+        <source>(none)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="42" />
+        <source>Output folder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="50" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="52" />
+        <source>Also create PDF from exported images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="53" />
+        <source>Build a single PDF file from the exported pages (requires img2pdf).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="57" />
+        <source>Export as ZIP</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="58" />
+        <source>Export pages to a temporary folder, then pack into a single ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="67" />
+        <source>ZIP file path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="71" />
+        <source>Choose ZIP file...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="77" />
+        <source>Clean cache after export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="78" />
+        <source>Remove mask and inpainted caches for this project after export (saves disk space).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="88" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="90" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="98" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="111" />
+        <source>Save ZIP as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/export_dialog.py" line="114" />
+        <source>ZIP archives (*.zip)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="377"/>
+        <location filename="../ui/text_panel.py" line="275" />
         <source>Font Family</source>
         <translation>Семейство шрифтов</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="381"/>
+        <location filename="../ui/text_panel.py" line="280" />
         <source>Font Size</source>
         <translation>Размер шрифта</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="383"/>
+        <location filename="../ui/text_panel.py" line="282" />
         <source>Change font size</source>
         <translation>Изменить размер шрифта</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="394"/>
+        <location filename="../ui/text_panel.py" line="292" />
         <source>Change line spacing</source>
         <translation>Изменить межстрочный интервал</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="400"/>
+        <location filename="../ui/text_panel.py" line="296" />
         <source>Change font color</source>
         <translation>Изменить цвет шрифта</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="416"/>
-        <source>Stroke</source>
-        <translation>Обводка</translation>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="425"/>
-        <source>Change stroke color</source>
-        <translation>Изменить цвет обводки</translation>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Text on path: None</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="432"/>
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Circular</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
+        <source>Arc</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Warp: None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Arch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Bulge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="334" />
+        <source>Flag</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="336" />
+        <source>Photoshop-like text warp (#1093).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="344" />
+        <source>Warp intensity.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="355" />
+        <source>Rounded text box corners. 0 = sharp (rectangle).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="361" />
         <source>Change stroke width</source>
         <translation>Изменить толщину обводки</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="449"/>
+        <location filename="../ui/text_panel.py" line="364" />
+        <source>Stroke</source>
+        <translation>Обводка</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="373" />
+        <source>Change stroke color</source>
+        <translation>Изменить цвет обводки</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="386" />
         <source>Change letter spacing</source>
         <translation>Изменить интервал между буквами</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="459"/>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation type="unfinished">Непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="405" />
+        <source>Text opacity (quick access)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
         <source>Global Font Format</source>
         <translation>Глобальный шрифт</translation>
     </message>
     <message>
-        <location filename="../ui/fontformatpanel.py" line="465"/>
-        <source>Effect</source>
-        <translation>Эффекты</translation>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Stroke width: </source>
-        <translation type="vanished">轮廓宽度: </translation>
+        <location filename="../ui/text_panel.py" line="424" />
+        <source>Apply current global font format to every text block on this page.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>line spacing: </source>
-        <translation type="vanished">行间距: </translation>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_panel.py" line="427" />
+        <source>Save current global font format as the default for new projects and sessions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="431" />
+        <source>Show the Global Font Format section (style presets) again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="436" />
+        <source>Show the Advanced Text Format section again.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
+        <source>Advanced Text Format</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Unfold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Fold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="462" />
+        <source>Source</source>
+        <translation type="unfinished">Оригинал</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="463" />
+        <source>Translation</source>
+        <translation type="unfinished">Перевод</translation>
+    </message>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="188"/>
+        <location filename="../ui/global_search_widget.py" line="192" />
         <source>Replace...</source>
         <translation>Заменить...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="194"/>
+        <location filename="../ui/global_search_widget.py" line="198" />
         <source>Replace all occurrences?</source>
         <translation>Заменить все совпадения?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
-        <location filename="../ui/global_search_widget.py" line="306"/>
+        <location filename="../ui/global_search_widget.py" line="308" />
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="309"/>
+        <location filename="../ui/global_search_widget.py" line="311" />
         <source>No results found. </source>
         <translation>Результаты не найдены. </translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="310"/>
+        <location filename="../ui/global_search_widget.py" line="312" />
         <source>Document changed. Press Enter to re-search.</source>
         <translation>Документ изменен. Нажмите Enter для повторного поиска.</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="311"/>
+        <location filename="../ui/global_search_widget.py" line="313" />
         <source>Found results: </source>
         <translation>Найденые результаты: </translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="317"/>
+        <location filename="../ui/global_search_widget.py" line="319" />
         <source>Match Case</source>
         <translation>Способ сопоставления</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="322"/>
+        <location filename="../ui/global_search_widget.py" line="324" />
         <source>Match Whole Word</source>
         <translation>Сопоставить целое слово</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="327"/>
+        <location filename="../ui/global_search_widget.py" line="329" />
         <source>Use Regular Expression</source>
         <translation>Использовать регулярное выражение</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="331"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Translation</source>
         <translation>Перевод</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="331"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>Source</source>
         <translation>Оригинал</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="331"/>
+        <location filename="../ui/global_search_widget.py" line="333" />
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="334"/>
+        <location filename="../ui/global_search_widget.py" line="336" />
         <source> in</source>
         <translation> в</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="337"/>
+        <location filename="../ui/global_search_widget.py" line="339" />
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="340"/>
+        <location filename="../ui/global_search_widget.py" line="342" />
         <source>Replace All</source>
         <translation>Заменить все</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="342"/>
+        <location filename="../ui/global_search_widget.py" line="344" />
         <source>Replace All and Re-render all pages</source>
         <translation>Заменить все и повторное отрендерить страницы</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="383"/>
+        <location filename="../ui/global_search_widget.py" line="385" />
         <source>Replace...</source>
         <translation>Заменить...</translation>
     </message>
     <message>
-        <location filename="../ui/global_search_widget.py" line="495"/>
-        <source>Replace all occurrences re-render all pages? It can&apos;t be undone.</source>
+        <location filename="../ui/global_search_widget.py" line="490" />
+        <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>Заменить все совпадения повторно отрендерив все страницы?Это будет нельзя отменить.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImgtransProgressMessageBox</name>
     <message>
-        <location filename="../ui/stylewidgets.py" line="120"/>
+        <location filename="../ui/custom_widget/message.py" line="183" />
         <source>Detecting: </source>
         <translation>Обнаружение: </translation>
     </message>
     <message>
-        <location filename="../ui/stylewidgets.py" line="121"/>
+        <location filename="../ui/custom_widget/message.py" line="184" />
         <source>OCR: </source>
         <translation>OCR: </translation>
     </message>
     <message>
-        <location filename="../ui/stylewidgets.py" line="122"/>
+        <location filename="../ui/custom_widget/message.py" line="185" />
         <source>Inpainting: </source>
         <translation>Клининг: </translation>
     </message>
     <message>
-        <location filename="../ui/stylewidgets.py" line="123"/>
+        <location filename="../ui/custom_widget/message.py" line="186" />
         <source>Translating: </source>
         <translation>Перевод: </translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="378"/>
+        <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
+        <source>OCR Failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
         <source>Translation Failed.</source>
         <translation>Перевод не удался.</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="1022" />
+        <source>Text Detection Failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1526" />
+        <source>Inpainting Failed.</source>
+        <translation type="unfinished">Клининг не удался.</translation>
+    </message>
+</context><context>
     <name>ImportDocThread</name>
     <message>
-        <location filename="../ui/io_thread.py" line="126"/>
+        <location filename="../ui/io_thread.py" line="154" />
         <source>Import doc...</source>
         <translation>Импорт doc файла...</translation>
     </message>
     <message>
-        <location filename="../ui/io_thread.py" line="133"/>
+        <location filename="../ui/io_thread.py" line="161" />
         <source>Import *.docx</source>
         <translation>Импорт *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
-        <location filename="../ui/dlconfig_parse_widgets.py" line="321"/>
+        <location filename="../ui/module_parse_widgets.py" line="533" />
         <source>Let the program decide whether it is necessary to use the selected inpaint method.</source>
         <translation>Позвольте программе решить, нужно ли использовать выбранный метод закрашивания.</translation>
     </message>
-</context>
-<context>
-    <name>InpaintPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="66"/>
-        <source>pen thickness </source>
-        <translation>толщина пера </translation>
+        <location filename="../ui/module_parse_widgets.py" line="538" />
+        <source>Inpaint tile size:</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="71"/>
+        <location filename="../ui/module_parse_widgets.py" line="542" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="544" />
+        <source>Off = best quality. Use 512–1024 only if you get out-of-memory errors; tiling can cause grey or blurry bubbles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="546" />
+        <source>Overlap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="550" />
+        <source>Overlap between tiles for seamless blending. Ignored when tile size is Off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="557" />
+        <source>Exclude certain labels from inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="559" />
+        <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="566" />
+        <source>Labels to exclude (comma-separated):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="568" />
+        <source>e.g. other, scene</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="572" />
+        <source>Comma-separated detector labels to exclude from inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="577" />
+        <source>Inpaint full image (no per-block crops)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="579" />
+        <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>InpaintPanel</name>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="76"/>
+        <location filename="../ui/drawingpanel.py" line="80" />
         <source>Shape</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="79"/>
+        <location filename="../ui/drawingpanel.py" line="83" />
         <source>Circle</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="80"/>
+        <location filename="../ui/drawingpanel.py" line="84" />
         <source>Rectangle</source>
         <translation>Квадрат</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="92" />
+        <source>Hardness</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="96" />
+        <source>Brush edge hardness: 100 = hard, 0 = soft/feathered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="103" />
+        <source>Inpainter</source>
+        <translation type="unfinished">Клинер</translation>
+    </message>
+</context><context>
     <name>InpaintThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="115"/>
+        <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>Клининг не удался.</translation>
     </message>
-</context>
-<context>
-    <name>InpainterStatusButton</name>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="88"/>
-        <source>Inpainter: </source>
-        <translation>Клинер: </translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="24"/>
+        <location filename="../ui/keywordsubwidget.py" line="25" />
         <source>Keyword</source>
         <translation>Ключ. Слово</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="25"/>
+        <location filename="../ui/keywordsubwidget.py" line="26" />
         <source>Substitution</source>
         <translation>Замена на</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="26"/>
+        <location filename="../ui/keywordsubwidget.py" line="27" />
         <source>Use regex</source>
         <translation>Использовать Рег.Выр</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="27"/>
+        <location filename="../ui/keywordsubwidget.py" line="28" />
         <source>Case sensitive</source>
         <translation>С учетом регистра</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="34"/>
+        <location filename="../ui/keywordsubwidget.py" line="35" />
         <source>New</source>
         <translation>Новый</translation>
     </message>
     <message>
-        <location filename="../ui/keywordsubwidget.py" line="36"/>
+        <location filename="../ui/keywordsubwidget.py" line="37" />
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="156"/>
+        <location filename="../ui/mainwindowbars.py" line="104" />
         <source>Global Search (Ctrl+G)</source>
         <translation>Глобальный поиск (Ctrl+G)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="166"/>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
         <translation>Открыть папку ...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="170"/>
+        <location filename="../ui/mainwindowbars.py" line="132" />
         <source>Open Project ... *.json</source>
         <translation>Открыть проект...*.json</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="173"/>
+        <location filename="../ui/mainwindowbars.py" line="135" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="139" />
+        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="143" />
+        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="146" />
         <source>Save Project</source>
         <translation>Сохранить проект</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="177"/>
+        <location filename="../ui/mainwindowbars.py" line="155" />
         <source>Export as Doc</source>
         <translation>Экспорт в документ</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="179"/>
+        <location filename="../ui/mainwindowbars.py" line="157" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="158" />
+        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="160" />
         <source>Import from Doc</source>
         <translation>Импорт из документа</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="182"/>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="165" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="170" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="173" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>Открыть последний</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="290"/>
+        <location filename="../ui/mainwindowbars.py" line="182" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="303" />
         <source>Select Directory</source>
         <translation>Выберите каталог</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="297"/>
+        <location filename="../ui/mainwindowbars.py" line="319" />
+        <source>Comic archives (*.cbz *.zip)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="352" />
+        <source>Comic RAR archives (*.cbr *.rar)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>Импорт *.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="174"/>
-        <source>Keyword substitution for OCR</source>
-        <translation>Подстановка ключевых слов для OCR</translation>
+        <location filename="../ui/mainwindow.py" line="465" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="178"/>
+        <location filename="../ui/mainwindow.py" line="469" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>Подстановка ключевых слов для машинного перевода</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="366"/>
-        <location filename="../ui/mainwindow.py" line="345"/>
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
         <source>Failed to load project </source>
         <translation>Не удалось загрузить проект </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="414"/>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
+        <source>Failed to load project from</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
         <source>Restart to apply changes? 
 </source>
         <translation>Перезапустить, чтобы применить изменения? 
 </translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="938"/>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1255" />
+        <source>README.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1262" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>BallonsTranslatorPro — community fork</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1263" />
+        <source>Deep learning–assisted comic/manga translation.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
+        <location filename="../ui/mainwindow.py" line="1355" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1356" />
+        <source>Checking for updates...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1747" />
+        <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1748" />
+        <source>Translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1842" />
+        <source>docs/TROUBLESHOOTING.md not found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1907" />
+        <source>Startup stages: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1909" />
+        <source>Startup health</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1912" />
+        <source>Copy diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1913" />
+        <source>Relaunch PyQt5</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1914" />
+        <source>Relaunch CPU-only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1915" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Diagnostics copied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1930" />
+        <source>Startup diagnostics copied to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Export startup report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1935" />
+        <source>Text files (*.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1941" />
+        <source>Startup report saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1943" />
+        <source>Failed to export startup report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1955" />
+        <source>Failed to open log folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>Model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1960" />
+        <source>No model download diagnostics available yet.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1963" />
+        <source>Flow: {0}
+Status: {1}
+Downloaded: {2}
+Failed: {3}
+Skipped: {4}
+Package IDs: {5}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1972" />
+        <source>Failed items: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2019" />
+        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
+        <translation type="unfinished">Итог: загружено {0}, ошибок {1}, пропущено {2}.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2025" />
+        <source>Open Manage Models</source>
+        <translation type="unfinished">Открыть «Управление моделями»</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2026" />
+        <source>Open Troubleshooting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2027" />
+        <source>Continue with available modules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
+        <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation type="unfinished">Загрузка пакета моделей завершена</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation type="unfinished">Некоторые пакеты моделей не удалось загрузить. Ошибки: {0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation type="unfinished">Загрузка пакета моделей частично завершена</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
+        <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2110" />
+        <source>No model packages selected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation type="unfinished">Активен режим только локальных данных при первом запуске. Используйте Инструменты → Управление моделями для импорта/загрузки моделей или отредактируйте config/config.json, чтобы включить пакеты, затем перезапустите.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation type="unfinished">Загрузка частично завершена.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation type="unfinished">Загрузка завершена. Значения по умолчанию обновлены.</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation type="unfinished">Пакеты моделей загружены. Применённые модули:
+</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>unsaved</source>
         <translation>не сохранено</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="938"/>
+        <location filename="../ui/mainwindow.py" line="3224" />
         <source>saved</source>
         <translation>сохранено</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="982"/>
+        <location filename="../ui/mainwindow.py" line="3258" />
         <source>Saving image...</source>
         <translation>Сохранение картинки...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1042"/>
+        <location filename="../ui/mainwindow.py" line="3297" />
+        <source>Confirmation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation type="unfinished">Начать перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
+        <source>Import Text Styles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3417" />
+        <source>Save Text Styles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
+        <source>Text file exported to </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3565" />
+        <source>Failed to export as TEXT file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
+        <source>Import *.md/*.txt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3604" />
+        <source>Translation imported and matched successfully.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3608" />
+        <source>Missing pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3611" />
+        <source>Unexpected pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3614" />
+        <source>Unmatched pages: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3625" />
+        <source>Failed to import translation from </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
         <source>Export to </source>
         <translation>Экспортировать как </translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MangaSourceDialog</name>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="486" />
+        <source>Manga / Comic source</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
+        <source>Search</source>
+        <translation type="unfinished">Поиск</translation>
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="528" />
+        <source>Manga source. MangaDex: translated chapters. MangaDex (raw): search by original language and download raw chapters to translate. GOMANGA and Manhwa Reader support search and download. Comick supports search and chapter list only. Local folder opens a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="531" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="537" />
+        <source>Enter manga title...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="543" />
+        <source>Translate search to original language (for raw sources)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="545" />
+        <source>When searching NaruRaw, ManhwaRaw, or 1kkk: translate your search term from English to Japanese/Korean/Chinese so raw titles are found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
+        <source>Paste MangaDex chapter URL or chapter UUID...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="556" />
+        <source>Load chapter</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="559" />
+        <source>Use browser (Playwright) for JS-heavy sites</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="561" />
+        <source>Enable for sites that load images with JavaScript or use Cloudflare. Requires: pip install playwright &amp;&amp; playwright install chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="565" />
+        <source>Run browser in background (hidden)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="567" />
+        <source>When checked, the browser runs without a visible window so it does not interfere with the menu. Uncheck to show the browser window (e.g. for debugging).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
+        <source>Install Chromium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="573" />
+        <source>Ensure Playwright and Chromium are installed. Run this if browser features fail.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="580" />
+        <source>Open a folder of images to use as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
+        <source>Open folder in BallonsTranslator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="591" />
+        <source>Results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="602" />
+        <source>Chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
+        <source>Language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="619" />
+        <source>Use data-saver (smaller images)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="620" />
+        <source>Faster and smaller files; lower resolution.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="628" />
+        <source>Delay between API requests (rate limiting).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="631" />
+        <source>Request delay:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="635" />
+        <source>Load chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="638" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="640" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="654" />
+        <source>Download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="660" />
+        <source>Choose folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="663" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="675" />
+        <source>Open in BallonsTranslator after download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="676" />
+        <source>When checked, the first chapter folder will open in BallonsTranslator automatically when download finishes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="681" />
+        <source>Download selected chapters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="761" />
+        <source>Raw language (chapters to load):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="783" />
+        <source>Paste chapter URL (raw manga, manhwa, manhua sites)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="785" />
+        <source>Paste chapter page URL (HTML with images)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
+        <source>Chapter from URL</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="803" />
+        <source>Download is not supported for Comick. Use MangaDex to download, or open chapter links in your browser.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="807" />
+        <source>Click the button to open a folder of images as a project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="811" />
+        <source>Paste a chapter page URL and click Load chapter. For JS-heavy sites enable "Use browser (Playwright)".</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="813" />
+        <source>Search by title, load chapters, then download. Enable "Use browser (Playwright)" if the site uses Cloudflare or lazy-loaded images.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="820" />
+        <source>Enter a chapter page URL.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
+        <source>Loading chapter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="827" />
+        <source>Enter a MangaDex chapter URL or UUID.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="836" />
+        <source>Enter a title to search.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="846" />
+        <source>Searching...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="862" />
+        <source>No results found.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="864" />
+        <source>Select a title, then click Load chapters.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="878" />
+        <source>Select a manga from the results first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="887" />
+        <source>Loading chapters...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="913" />
+        <source>Loaded 1 chapter. Check to download, then choose folder and click Download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="917" />
+        <source>Loaded {0} chapter(s). Check the ones to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="929" />
+        <source>Choose download folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="958" />
+        <source>Select a manga and load chapters first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="968" />
+        <source>Select at least one chapter to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="972" />
+        <source>Choose a valid download folder.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="976" />
+        <source>Downloading...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="993" />
+        <source>Downloaded {0} / {1}: {2}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="998" />
+        <source>Download complete: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1010" />
+        <source>Download complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1011" />
+        <source>Chapters saved to:
+{0}
+
+You can open a chapter folder in BallonsTranslator to translate.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1035" />
+        <source>Installing Chromium...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/manga_source_dialog.py" line="1065" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>MergeDialog</name>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="15" />
+        <source>Region merge tool settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="31" />
+        <source>Vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="32" />
+        <source>Horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="33" />
+        <source>Vertical then horizontal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="34" />
+        <source>Horizontal then vertical</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="35" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="38" />
+        <source>Prefer shorter label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="39" />
+        <source>Use first box's label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="40" />
+        <source>Combine labels (label1+label2)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="41" />
+        <source>Prefer non-default label</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="45" />
+        <source>Main settings</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="53" />
+        <source>Merge mode:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="57" />
+        <source>Text merge order (by label)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="63" />
+        <source>label1,label2,...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="65" />
+        <source>balloon,qipao,shuqing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="67" />
+        <source>changfangtiao,hengxie</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="69" />
+        <source>Left-to-right (LTR) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="70" />
+        <source>Right-to-left (RTL) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="71" />
+        <source>Top-to-bottom (TTB) labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="76" />
+        <source>Label merge rules</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="84" />
+        <source>Label merge strategy:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="86" />
+        <source>Enable exclude-from-merge labels (blacklist)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="91" />
+        <source>other</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="92" />
+        <source>e.g. label1,label2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="93" />
+        <source>Blacklist labels:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="97" />
+        <source>Require same label to merge</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="100" />
+        <source>Merge only within specific label groups</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="102" />
+        <source>One group per line, labels comma-separated
+ e.g.:
+balloon,balloon2
+qipao,qipao2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="116" />
+        <source>Geometry merge parameters</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
+        <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="129" />
+        <source>Min horizontal overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="139" />
+        <source>Min vertical overlap (%). Higher = boxes must align more (e.g. 98 = almost fully overlapped).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="141" />
+        <source>&lt;b&gt;Vertical merge (up-down)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="142" />
+        <source>Max vertical gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="143" />
+        <source>Min horizontal overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="144" />
+        <source>&lt;b&gt;Horizontal merge (left-right)&lt;/b&gt;</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="145" />
+        <source>Max horizontal gap (px):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="146" />
+        <source>Min vertical overlap ratio:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="147" />
+        <source>Strict (one box per bubble): set both gaps to 0 or negative (e.g. -10), overlap to 98–100%.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="155" />
+        <source>Advanced options</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="159" />
+        <source>Allow negative gap (overlapping boxes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="166" />
+        <source>Merge result type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="172" />
+        <source>Axis-aligned rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="173" />
+        <source>Rotated rectangle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="187" />
+        <source>Run on current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="188" />
+        <source>Run on all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/merge_dialog.py" line="189" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+</context><context>
+    <name>ModelDownloadProgressDialog</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="139" />
+        <source>Downloading model packages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="141" />
+        <source>Downloading model packages... This may take several minutes.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelManagerDialog</name>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="99" />
+        <source>Manage models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="115" />
+        <source>Check model files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="118" />
+        <source>Check all models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="119" />
+        <source>Check which models have their files downloaded, missing, or with hash mismatch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="122" />
+        <source>Check compatibility (slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="123" />
+        <source>Try loading each module to detect missing dependencies or incompatible environment. Can be slow.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="133" />
+        <source>Search module key/name/description…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
+        <source>All categories</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
+        <source>All statuses</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Category</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Module</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Status</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="148" />
+        <source>Details</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
+        <source>Download models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="159" />
+        <source>Select the models you want to download. Only modules with a predefined file list are listed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="163" />
+        <source>Select all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="165" />
+        <source>Deselect all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="167" />
+        <source>Import local model directory...</source>
+        <translation type="unfinished">Импортировать локальный каталог моделей...</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="168" />
+        <source>Copy model files from an existing local folder into this app's data/models directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="170" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="192" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="212" />
+        <source>Size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="215" />
+        <source>Dependencies: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="217" />
+        <source>Support tier: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
+        <source>Downloaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
+        <source>Missing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
+        <source>Hash mismatch</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
+        <source>No file list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
+        <source>Download on load</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="296" />
+        <source>Select local model directory</source>
+        <translation type="unfinished">Выбрать локальный каталог моделей</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="319" />
+        <source>Import complete.
+New files: {}
+Overwritten: {}
+Destination: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="321" />
+        <source>Some files failed to import (showing first 5):
+{}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
+        <source>Import local models</source>
+        <translation type="unfinished">Импорт локальных моделей</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <source>Incompatible</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
+        <source>Optional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
+        <source>Estimated size: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="456" />
+        <source>Target: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="462" />
+        <source>Key: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="474" />
+        <source>Target path(s): {0}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ModelPackageSelectorDialog</name>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="59" />
+        <source>Choose models to download</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="76" />
+        <source>Display language</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
+        <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="98" />
+        <source>Recommended presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="105" />
+        <source>Approx size: {size}. Use: {use}. Dependency hints: {deps}.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="128" />
+        <source>Advanced/custom mode (power users)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="130" />
+        <source>Manually select low-level packages instead of using a preset.</source>
+        <translation type="unfinished">Выберите низкоуровневые пакеты вручную вместо использования предустановки.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="136" />
+        <source>Manual package selection</source>
+        <translation type="unfinished">Ручной выбор пакетов</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="155" />
+        <source>Skip (Core only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="156" />
+        <source>Download only the Core package (recommended minimum).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="158" />
+        <source>Skip all downloads (local-only)</source>
+        <translation type="unfinished">Пропустить все загрузки (только локально)</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="159" />
+        <source>Do not download any model package now. Use only already-local modules/files.</source>
+        <translation type="unfinished">Не загружать сейчас ни один пакет моделей. Использовать только уже локальные модули/файлы.</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="161" />
+        <source>Download selected</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation type="unfinished">Базовый пакет не выбран</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleManager</name>
     <message>
-        <location filename="../ui/module_manager.py" line="748"/>
-        <source>Invalid</source>
-        <translation>Неверный</translation>
+        <location filename="../ui/module_manager.py" line="1825" />
+        <source>Translation Failed</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="1829" />
+        <source>Skip</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1830" />
+        <source>Terminate</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1894" />
+        <source>Detecting ({}): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1896" />
+        <source>Detecting: </source>
+        <translation type="unfinished">Обнаружение: </translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2066" />
+        <source>No translator module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2067" />
+        <source>Failed to set Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2094" />
+        <source>No inpainter module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2095" />
+        <source>Failed to set Inpainter.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2101" />
+        <source>Set Inpainter...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2115" />
+        <source>No text detector module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2116" />
+        <source>Failed to set Text Detector.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2183" />
+        <source>No OCR module available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2184" />
+        <source>Failed to set OCR.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2228" />
+        <source>Testing...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2233" />
+        <source>Success.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Open a project and select a page with text blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2257" />
+        <source>No source text on this page. Run OCR first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2277" />
+        <source>Prompt copied to clipboard. Paste it into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2291" />
+        <source>Clipboard is empty. Copy the response from your translation tool first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2309" />
+        <source>No source text on this page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2314" />
+        <source>Response has %d items but page has %d blocks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2337" />
+        <source>Response must be JSON object or array.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="2350" />
+        <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ModuleThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="57"/>
-        <source>Failed to set </source>
-        <translation>Не удалось установить </translation>
+        <location filename="../ui/module_manager.py" line="116" />
+        <source>No fallback available.</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_manager.py" line="117" />
+        <source>Open Tools → Manage models to check or import local model files.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>OCRConfigPanel</name>
     <message>
-        <location filename="../ui/dlconfig_parse_widgets.py" line="342"/>
-        <source>Keyword substitution for OCR results</source>
-        <translation>Подстановка ключевых слов для результатов OCR</translation>
+        <location filename="../ui/module_parse_widgets.py" line="830" />
+        <source>Delete and restore region where OCR return empty string.</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="832" />
+        <source>When enabled, text boxes whose OCR result is empty are removed from the page and the mask is restored. Disable this to keep all boxes even when OCR returns nothing or fails (e.g. to avoid boxes disappearing).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="837" />
+        <source>Font Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="838" />
+        <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">Оригинал</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">Перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>PageListView</name>
+    <message>
+        <location filename="../ui/mainwindow.py" line="88" />
+        <source>Reveal in File Explorer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="94" />
+        <source>Select all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="97" />
+        <source>Translate Selected Images</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="98" />
+        <source>Run detection on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="99" />
+        <source>Run OCR on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="100" />
+        <source>Run translation on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="101" />
+        <source>Run inpainting on selected pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="103" />
+        <source>Ignore in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="104" />
+        <source>Skip these pages in full run and batch (when "Skip ignored pages" is on).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="105" />
+        <source>Include in run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="106" />
+        <source>Do not skip these pages in full run and batch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="108" />
+        <source>Remove from Project</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
-        <location filename="../ui/page_search_widget.py" line="212"/>
+        <location filename="../ui/page_search_widget.py" line="207" />
         <source>Find</source>
         <translation>Найти</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="215"/>
+        <location filename="../ui/page_search_widget.py" line="210" />
         <source>No result</source>
         <translation>Нет результатов</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="221"/>
+        <location filename="../ui/page_search_widget.py" line="216" />
         <source>Previous Match (Shift+Enter)</source>
         <translation>Прошлое совпадение (Shift+Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="226"/>
+        <location filename="../ui/page_search_widget.py" line="221" />
         <source>Next Match (Enter)</source>
         <translation>Следующее совпадение (Enter)</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="230"/>
+        <location filename="../ui/page_search_widget.py" line="225" />
         <source>Match Case</source>
         <translation>Способ сопоставления</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="235"/>
+        <location filename="../ui/page_search_widget.py" line="230" />
         <source>Match Whole Word</source>
         <translation>Сопоставить целое слово</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="240"/>
+        <location filename="../ui/page_search_widget.py" line="235" />
         <source>Use Regular Expression</source>
         <translation>Использовать регулярное выражение</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="244"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Translation</source>
         <translation>Перевод</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="244"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>Source</source>
         <translation>Оригинал</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="244"/>
+        <location filename="../ui/page_search_widget.py" line="239" />
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="247"/>
+        <location filename="../ui/page_search_widget.py" line="242" />
         <source>Range</source>
         <translation>Диапазон</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="254"/>
-        <location filename="../ui/page_search_widget.py" line="250"/>
+        <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>Заменить</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="258"/>
+        <location filename="../ui/page_search_widget.py" line="253" />
         <source>Replace All</source>
         <translation>Заменить все</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="295"/>
+        <location filename="../ui/page_search_widget.py" line="290" />
         <source>Close (Escape)</source>
         <translation>Закрыть (Escape)</translation>
     </message>
+</context><context>
+    <name>ParamComboBox</name>
     <message>
-        <source>ReplaceBtn</source>
-        <translation type="vanished">Заменить(кнопка)</translation>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>ReplaceAllBtn</source>
-        <translation type="vanished">Заменить все(кнопка)</translation>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamWidget</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>PenConfigPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="120"/>
-        <source>pen thickness </source>
-        <translation>Толщина пера </translation>
-    </message>
-    <message>
-        <location filename="../ui/drawingpanel.py" line="123"/>
-        <source>alpha value</source>
-        <translation>Значение прозрачности</translation>
-    </message>
-    <message>
-        <location filename="../ui/drawingpanel.py" line="131"/>
+        <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
         <translation>Цвет</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="132"/>
+        <location filename="../ui/drawingpanel.py" line="153" />
         <source>Alpha</source>
         <translation>Прозрачность</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="140"/>
+        <location filename="../ui/drawingpanel.py" line="161" />
         <source>Thickness</source>
         <translation>Толщина</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="145"/>
+        <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="148"/>
+        <location filename="../ui/drawingpanel.py" line="169" />
         <source>Circle</source>
         <translation>Круг</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="149"/>
+        <location filename="../ui/drawingpanel.py" line="170" />
         <source>Rectangle</source>
         <translation>Квадрат</translation>
     </message>
-</context>
-<context>
-    <name>PresetListWidget</name>
-    <message>
-        <location filename="../ui/preset_widget.py" line="29"/>
-        <source>preset</source>
-        <translation>Пресеты</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="56"/>
-        <source>Delete</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="57"/>
-        <source>New preset</source>
-        <translation>Новый пресет</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="58"/>
-        <source>Load preset</source>
-        <translation>Загрузить пресет</translation>
-    </message>
-</context>
-<context>
-    <name>PresetPanel</name>
-    <message>
-        <location filename="../ui/preset_widget.py" line="107"/>
-        <source>Text Style Presets</source>
-        <translation>Пресеты стилей текста</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="109"/>
-        <source>New</source>
-        <translation>Новый</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="110"/>
-        <source>Create new preset: </source>
-        <translation>Создать новый пресет: </translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="112"/>
-        <source>Delete</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="114"/>
-        <source>Load</source>
-        <translation>Загрузить</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="115"/>
-        <source>Load preset as global format</source>
-        <translation>Загрузка пресета в глобальный формат</translation>
-    </message>
-    <message>
-        <location filename="../ui/preset_widget.py" line="117"/>
-        <source>Exit</source>
-        <translation>Выход</translation>
-    </message>
-</context>
-<context>
-    <name>ProgressMessageBox</name>
-    <message>
-        <source>Detecting: </source>
-        <translation type="vanished">Обнаружение: </translation>
-    </message>
-    <message>
-        <source>OCR: </source>
-        <translation type="vanished">OCR: </translation>
-    </message>
-    <message>
-        <source>Inpainting: </source>
-        <translation type="vanished">Клининг: </translation>
-    </message>
-    <message>
-        <source>Translating: </source>
-        <translation type="vanished">Перевод: </translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <location filename="../ui/drawingpanel.py" line="195"/>
+        <location filename="../ui/drawingpanel.py" line="214" />
         <source>Dilate</source>
         <translation>Точность</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="196"/>
-        <source>kernel size: </source>
-        <translation>Уровень точности: </translation>
+        <location filename="../ui/drawingpanel.py" line="217" />
+        <source>Expand mask boundary (enlarge selection).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="202"/>
-        <source>method 1</source>
-        <translation>метод 1</translation>
+        <location filename="../ui/drawingpanel.py" line="219" />
+        <source>Erode</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="202"/>
-        <source>method 2</source>
-        <translation>метод 2</translation>
+        <location filename="../ui/drawingpanel.py" line="222" />
+        <source>Shrink mask boundary (use after Dilate to fine-tune).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="203"/>
+        <location filename="../ui/drawingpanel.py" line="228" />
+        <source>Canny + flood</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="229" />
+        <source>Connected Canny</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="230" />
+        <source>Use existing mask</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="231" />
+        <source>SAM refine balloon (SAM2/SAM3)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Rectangle</source>
+        <translation type="unfinished">Квадрат</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="237" />
+        <source>Ellipse</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="238" />
+        <source>Selection shape (#35).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="240" />
         <source>Auto</source>
         <translation>Авто</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="204"/>
+        <location filename="../ui/drawingpanel.py" line="241" />
         <source>run inpainting automatically.</source>
         <translation>Запуск закраски автоматически.</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="206"/>
+        <location filename="../ui/drawingpanel.py" line="243" />
         <source>Inpaint</source>
         <translation>Закраска</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="207"/>
+        <location filename="../ui/drawingpanel.py" line="244" />
         <source>Space</source>
         <translation>Пробел</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="209"/>
+        <location filename="../ui/drawingpanel.py" line="246" />
+        <source>Fill</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="247" />
+        <source>Fill selection with detected background (no inpainter model).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="249" />
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="210"/>
+        <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="258" />
+        <source>Inpainter</source>
+        <translation type="unfinished">Клинер</translation>
+    </message>
+    <message>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation type="unfinished">Форма</translation>
+    </message>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
-        <location filename="../ui/textedit_area.py" line="24"/>
+        <location filename="../ui/textedit_area.py" line="30" />
         <source>Search selected text on Internet</source>
         <translation>Поиск выбранного текста в Интернете</translation>
     </message>
     <message>
-        <location filename="../ui/textedit_area.py" line="29"/>
+        <location filename="../ui/textedit_area.py" line="36" />
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>Просмотр выделенного текста в SalaDict, см. руководство по установке в configpanel</translation>
     </message>
-</context>
-<context>
-    <name>SourceDownloadProgressMessageBox</name>
+</context><context>
+    <name>SelectionWithConfigWidget</name>
     <message>
-        <location filename="../ui/stylewidgets.py" line="165"/>
-        <source>Downloading: </source>
-        <translation>Загрузка: </translation>
+        <location filename="../ui/mainwindowbars.py" line="1423" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
-    <name>SourceDownloadStatusButton</name>
+</context><context>
+    <name>ShortcutsDialog</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="92"/>
-        <source>Source url: </source>
-        <translation>Исходный URL: </translation>
-    </message>
-</context>
-<context>
-    <name>TextEffectPanel</name>
-    <message>
-        <location filename="../ui/text_graphical_effect.py" line="86"/>
-        <source>Effect</source>
-        <translation>Эффект</translation>
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="95"/>
-        <source>Opacity</source>
-        <translation>Непрозрачность</translation>
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <source>Filter:</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="96"/>
-        <source>Opacity: </source>
-        <translation>Значение непрозрачности: </translation>
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
+        <source>Search action or category...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="101"/>
-        <source>Shadow</source>
-        <translation>Тень</translation>
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
+        <source>All categories</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="104"/>
-        <source>Change shadow color</source>
-        <translation>Изменить цвет тени</translation>
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
+        <source>Category:</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="105"/>
-        <source>radius: </source>
-        <translation>Радиус: </translation>
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="108"/>
-        <source>strength: </source>
-        <translation>сила: </translation>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
+        <source>Category</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="111"/>
-        <source>x offset: </source>
-        <translation>X смещение: </translation>
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
+        <source>Action</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="114"/>
-        <source>y offset: </source>
-        <translation>Y смещение: </translation>
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
+        <source>Shortcut</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="118"/>
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
+        <source>Reset all to default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
         <source>Apply</source>
-        <translation>Применить</translation>
+        <translation type="unfinished">Применить</translation>
     </message>
     <message>
-        <location filename="../ui/text_graphical_effect.py" line="120"/>
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
         <source>Cancel</source>
-        <translation>Отмена</translation>
+        <translation type="unfinished">Отмена</translation>
     </message>
-</context>
-<context>
-    <name>ThreadBase</name>
     <message>
-        <location filename="../ui/io_thread.py" line="27"/>
-        <source>Execution error</source>
-        <translation>Ошибка выполнения</translation>
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
+        <source>Reset</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SpellCheckPanel</name>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="34" />
+        <source>Target:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="36" />
+        <source>Translation</source>
+        <translation type="unfinished">Перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="38" />
+        <source>Check current page</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="41" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="43" />
+        <source>Close spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="49" />
+        <source>Replace with suggestion</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
+        <source>Spell check</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="77" />
+        <source>Spell check requires pyenchant and a dictionary (e.g. en_US). Install: pip install pyenchant</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="87" />
+        <source>No text blocks on the current page. Open a project, select a page with text blocks, then run detection/OCR if needed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/spellcheck_panel.py" line="104" />
+        <source>(no suggestions)</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslateThread</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
+        <source>Translator '%s' is not available. Check Config → Translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="98" />
+        <source>Translator '%s' is not registered.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="107" />
+        <source>Could not start translator: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="156" />
+        <source>Translator returned %s lines; expected %s.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="163" />
+        <source>Translation failed (API error).</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>SubtitleFileTranslatorDialog</name>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
+        <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="203" />
+        <source>(no file)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="205" />
+        <source>Open…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="211" />
+        <source>Input</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="214" />
+        <source>Auto-detect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="215" />
+        <source>SubRip (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
+        <source>Timestamped text (.txt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
+        <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="222" />
+        <source>Format:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="231" />
+        <source>Source language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="232" />
+        <source>Target language:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="235" />
+        <source>Output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="238" />
+        <source>SRT (.srt)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="240" />
+        <source>Save as:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="243" />
+        <source>Series translation context</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
+        <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="255" />
+        <source>e.g. default, urban_immortal, or a subfolder path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="264" />
+        <source>Include recent pages from series store (recent_context.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
+        <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
+        <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="282" />
+        <source>e.g. 主角名 -&gt; Hero Name
+门派 -&gt; sect</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="288" />
+        <source>Optional subtitle / model hint (video-style)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="292" />
+        <source>Short notes or terms appended to the prompt (like the video translator glossary hint).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="298" />
+        <source>No cues loaded.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="307" />
+        <source>Translate and save as…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="327" />
+        <source>Open subtitle file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="329" />
+        <source>Subtitles (*.srt *.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="337" />
+        <source>Open file</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="343" />
+        <source>Parse error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="350" />
+        <source>{0} cue(s) loaded (detected format: {1}).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="360" />
+        <source>No cues</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="361" />
+        <source>No subtitle cues found. Try another format option or check the file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="373" />
+        <source>Translator</source>
+        <translation type="unfinished">Переводчик</translation>
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
+        <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="390" />
+        <source>Save translated subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="392" />
+        <source>SRT (*.srt);;Text (*.txt);;All files (*.*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="446" />
+        <source>Save</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="450" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="451" />
+        <source>Wrote translated file to:
+{0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="458" />
+        <source>Translation failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="465" />
+        <source>Translation is still running. Close anyway?</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextAdvancedFormatPanel</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="170" />
+        <source>Proportional</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="171" />
+        <source>Distance</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="175" />
+        <source>Line Spacing Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="182" />
+        <source>Set Text Opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="184" />
+        <source>Opacity</source>
+        <translation type="unfinished">Непрозрачность</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Normal</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Medium</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>SemiBold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="195" />
+        <source>Bold</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="197" />
+        <source>Font weight (100–900)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="199" />
+        <source>Font Weight</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="209" />
+        <source>Shadow</source>
+        <translation type="unfinished">Тень</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Multiply</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Overlay</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Darken</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="228" />
+        <source>Lighten</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="238" />
+        <source>Outline only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="239" />
+        <source>Draw stroke only, no fill (set stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="242" />
+        <source>Stroke outline outside only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="243" />
+        <source>Draw stroke only outside the glyphs (EasyScanlate-style; needs stroke width &gt; 0)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="247" />
+        <source>Foreground overlay image opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="249" />
+        <source>Overlay opacity</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="257" />
+        <source>Skew X</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="260" />
+        <source>Skew Y</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextDetectConfigPanel</name>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="615" />
+        <source>Keep Existing Lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="617" />
+        <source>Run second detector (dual detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="618" />
+        <source>Run a second text detector and merge results to catch more regions (e.g. one good at bubbles, one at captions).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="629" />
+        <source>Secondary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="631" />
+        <source>Outside bubbles only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="632" />
+        <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="638" />
+        <source>Run third detector</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="639" />
+        <source>Run a third text detector and merge results (e.g. primary + secondary + tertiary for maximum coverage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="650" />
+        <source>Tertiary:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="654" />
+        <source>OSB layout fallbacks (vertical stack + restore original)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="655" />
+        <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="662" />
+        <source>Allow box rotation for slanted text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="663" />
+        <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="671" />
+        <source>Min angle (degrees):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="683" />
+        <source>Secondary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="695" />
+        <source>Tertiary detector params:</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextGradientGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="91" />
+        <source>Gradient</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="96" />
+        <source>Start Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="100" />
+        <source>End Color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="102" />
+        <source>Enable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Linear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="105" />
+        <source>Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="112" />
+        <source>Set Gradient Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="114" />
+        <source>Size</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextShadowGroup</name>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="17" />
+        <source>Set X offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="28" />
+        <source>Set Y offset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="40" />
+        <source>Set Shadow Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="42" />
+        <source>Strength</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="51" />
+        <source>Set Shadow Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="53" />
+        <source>Radius</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="72" />
+        <source>Offset</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextStyleLabel</name>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="87" />
+        <source>Click to set as Global format. Double click to edit name.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="99" />
+        <source>Apply Text Style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="104" />
+        <source>Update from active style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="121" />
+        <source>Delete Style</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TextStylePresetPanel</name>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="277" />
+        <source>Style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
+        <source>New Text Style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="286" />
+        <source>Remove All</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="300" />
+        <source>Remove all styles?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="462" />
+        <source>Remove all</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="464" />
+        <source>Import Text Styles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/text_style_presets.py" line="465" />
+        <source>Export Text Styles</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ThemeCustomizerDialog</name>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="52" />
+        <source>Theme &amp; UI Customizer</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="58" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="60" />
+        <source>Dark mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="62" />
+        <source>Use dark theme (Eva Dark). Uncheck for light (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
+        <source>Accent color</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="69" />
+        <source>Used for buttons, focus, links (e.g. blue → purple):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="70" />
+        <source>Choose color...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="80" />
+        <source>App font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="82" />
+        <source>Font family:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="97" />
+        <source>Size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="100" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="102" />
+        <source>0 = use system default.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="107" />
+        <source>UI style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="109" />
+        <source>Advanced UI (rounder corners, gradients)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="111" />
+        <source>Uncheck for a simpler, flatter look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="118" />
+        <source>Apply</source>
+        <translation type="unfinished">Применить</translation>
+    </message>
+    <message>
+        <location filename="../ui/theme_customizer_dialog.py" line="120" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TitleBar</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="333"/>
+        <location filename="../ui/mainwindowbars.py" line="443" />
         <source>Edit</source>
         <translation>Редактирование</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="335"/>
+        <location filename="../ui/mainwindowbars.py" line="445" />
         <source>Undo</source>
         <translation>Отменить</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="338"/>
+        <location filename="../ui/mainwindowbars.py" line="448" />
         <source>Redo</source>
         <translation>Вернуть</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="341"/>
+        <location filename="../ui/mainwindowbars.py" line="451" />
         <source>Search</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="344"/>
+        <location filename="../ui/mainwindowbars.py" line="454" />
         <source>Global Search</source>
         <translation>Глобальный поиск</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="348"/>
+        <location filename="../ui/mainwindowbars.py" line="458" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="460" />
         <source>Keyword substitution for machine translation</source>
         <translation>Подстановка ключевых слов для машинного перевода</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="350"/>
-        <source>Keyword substitution for OCR results</source>
-        <translation>Подстановка ключевых слов для результатов OCR</translation>
+        <location filename="../ui/mainwindowbars.py" line="462" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="361"/>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>Просмотр</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="363"/>
+        <location filename="../ui/mainwindowbars.py" line="486" />
         <source>Display Language</source>
         <translation>Язык отображения</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="377"/>
+        <location filename="../ui/mainwindowbars.py" line="500" />
         <source>Drawing Board</source>
         <translation>Режим рисования</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="379"/>
+        <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>Текстовый редактор</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="381"/>
-        <source>Text Style Presets</source>
-        <translation>Пресеты стилей текста</translation>
+        <location filename="../ui/mainwindowbars.py" line="504" />
+        <source>Import Text Styles</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="382"/>
+        <location filename="../ui/mainwindowbars.py" line="505" />
+        <source>Export Text Styles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
         <source>Dark Mode</source>
         <translation>Темная тема</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="400"/>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="600" />
         <source>Go</source>
         <translation>Перейти</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="401"/>
+        <location filename="../ui/mainwindowbars.py" line="601" />
         <source>Previous Page</source>
         <translation>Пред. страница</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="403"/>
+        <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>След. Страница</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="414"/>
-        <location filename="../ui/mainwindowbars.py" line="413"/>
+        <location filename="../ui/mainwindowbars.py" line="603" />
+        <source>Previous Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="604" />
+        <source>Next Page (alternate)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="618" />
+        <source>Tools</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="623" />
+        <source>Re-run detection only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="625" />
+        <source>Re-run OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="627" />
+        <source>Export all pages</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="631" />
+        <source>Export all pages as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="634" />
+        <source>Check project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="643" />
+        <source>Manga / Comic source...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="646" />
+        <source>Batch queue...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="657" />
+        <source>Show model download diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="658" />
+        <source>Show last model download summary and failed items.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="660" />
+        <source>Copy startup diagnostics</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="661" />
+        <source>Copy startup and environment diagnostics to clipboard.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="663" />
+        <source>Export startup report...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="664" />
+        <source>Save startup diagnostics to a text file for support.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="666" />
+        <source>Open log folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="667" />
+        <source>Open logs directory in your file explorer.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="669" />
+        <source>Relaunch with PyQt5 (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="670" />
+        <source>Restart app using --qt-api pyqt5 for compatibility troubleshooting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="672" />
+        <source>Relaunch CPU-only (safe mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="673" />
+        <source>Restart app with CUDA_VISIBLE_DEVICES empty to disable GPU for this launch.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
+        <source>Release model caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="701" />
+        <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
+        <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
+        <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation type="unfinished">Источники</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
+        <source>Enable Text Dection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="764" />
+        <source>Enable OCR</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="765" />
+        <source>Enable Translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="766" />
+        <source>Enable Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="773" />
         <source>Run</source>
         <translation>Начать перевод</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="415"/>
+        <location filename="../ui/mainwindowbars.py" line="774" />
+        <source>Run without update textstyle</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="775" />
         <source>Translate page</source>
         <translation>Перевести страницу</translation>
     </message>
     <message>
-        <source>Drawing Board </source>
-        <translation type="vanished">Режим рисования </translation>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation type="unfinished">Открыть папку ...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation type="unfinished">Открыть проект...*.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation type="unfinished">Сохранить проект</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation type="unfinished">Экспорт в документ</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation type="unfinished">Импорт из документа</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslateThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="179"/>
+        <location filename="../ui/module_manager.py" line="261" />
+        <source>Failed to set translator. No fallback available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="283" />
         <source>Failed to set translator </source>
         <translation>Не удалось установить переводчик </translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="199"/>
-        <source> is required for </source>
-        <translation> требуется для </translation>
-    </message>
-    <message>
-        <location filename="../ui/module_manager.py" line="237"/>
-        <location filename="../ui/module_manager.py" line="204"/>
+        <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>Перевод не удался.</translation>
     </message>
+</context><context>
+    <name>TranslationContextDialog</name>
     <message>
-        <source>The selected language is not supported by </source>
-        <translation type="vanished">所选语言不被目标翻译器支持</translation>
+        <location filename="../ui/translation_context_dialog.py" line="54" />
+        <source>Translation context (project)</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>support list: </source>
-        <translation type="vanished">支持语言列表: </translation>
+        <location filename="../ui/translation_context_dialog.py" line="57" />
+        <source>Project translation context</source>
+        <translation type="unfinished" />
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="60" />
+        <source>Series context path (folder or ID, e.g. urban_immortal_cultivator):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="63" />
+        <source>Leave empty to use default (data/translation_context/default)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="68" />
+        <source>Project glossary (one line per entry: source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="71" />
+        <source>e.g.:
+丹田 -&gt; dantian
+真气 -&gt; true qi
+# lines starting with # are ignored</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/translation_context_dialog.py" line="79" />
+        <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <location filename="../ui/dlconfig_parse_widgets.py" line="281"/>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>Подстановка ключевых слов для машинного перевода</translation>
     </message>
     <message>
-        <location filename="../ui/dlconfig_parse_widgets.py" line="288"/>
-        <source>Source </source>
-        <translation>Источник </translation>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
+        <source>Keyword substitution for source text</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/dlconfig_parse_widgets.py" line="290"/>
-        <source>Target </source>
-        <translation>Цель </translation>
-    </message>
-</context>
-<context>
-    <name>TranslatorStatusButton</name>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="81"/>
-        <source>Translator: </source>
-        <translation>Переводчик: </translation>
+        <location filename="../ui/module_parse_widgets.py" line="441" />
+        <source>Translate each text block individually</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="82"/>
-        <source>Source: </source>
-        <translation>Источник: </translation>
+        <location filename="../ui/module_parse_widgets.py" line="442" />
+        <source>Translation context (project)...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="83"/>
-        <source>Target: </source>
-        <translation>Цель: </translation>
-    </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
-    <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation>Скопировать файлы моделей из существующей локальной папки в каталог data/models этого приложения.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="443" />
+        <source>Set series path and glossary for this project (cross-chapter consistency).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package</source>
-        <translation>Базовый пакет</translation>
+        <location filename="../ui/module_parse_widgets.py" line="448" />
+        <source>Continue batch on soft translation failure</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Core package not selected</source>
-        <translation>Базовый пакет не выбран</translation>
+        <location filename="../ui/module_parse_widgets.py" line="449" />
+        <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation>Не загружать сейчас ни один пакет моделей. Использовать только уже локальные модули/файлы.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="460" />
+        <source>Copy prompt</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation>Загрузка завершена. Значения по умолчанию обновлены.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="461" />
+        <source>Copy the translation prompt (JSON with source texts) to clipboard. Paste into your tool, then paste the response back and click Paste response.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Download partially complete.</source>
-        <translation>Загрузка частично завершена.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="465" />
+        <source>Paste response</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>Активен режим только локальных данных при первом запуске. Используйте Инструменты → Управление моделями для импорта/загрузки моделей или отредактируйте config/config.json, чтобы включить пакеты, затем перезапустите.</translation>
+        <location filename="../ui/module_parse_widgets.py" line="466" />
+        <source>Paste JSON from clipboard into the response box and apply to blocks. Run Translate to use it.</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Import local model directory...</source>
-        <translation>Импортировать локальный каталог моделей...</translation>
+        <location filename="../ui/module_parse_widgets.py" line="478" />
+        <source>Source</source>
+        <translation type="unfinished">Оригинал</translation>
     </message>
     <message>
-        <source>Import local models</source>
-        <translation>Импорт локальных моделей</translation>
+        <location filename="../ui/module_parse_widgets.py" line="480" />
+        <source>Target</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>TranslatorSelectionWidget</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1468" />
+        <source>Translate</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Manual package selection</source>
-        <translation>Ручной выбор пакетов</translation>
+        <location filename="../ui/mainwindowbars.py" line="1470" />
+        <source>Source</source>
+        <translation type="unfinished">Оригинал</translation>
     </message>
     <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation>Выберите низкоуровневые пакеты вручную вместо использования предустановки.</translation>
+        <location filename="../ui/mainwindowbars.py" line="1472" />
+        <source>Target</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download complete</source>
-        <translation>Загрузка пакета моделей завершена</translation>
+        <location filename="../ui/mainwindowbars.py" line="1486" />
+        <source>Open module settings</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoSubtitleEditorWindow</name>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="184" />
+        <source>Video Subtitle Editor</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model package download partially complete</source>
-        <translation>Загрузка пакета моделей частично завершена</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="211" />
+        <source>File</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>Пакеты моделей загружены. Применённые модули:
-</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="213" />
+        <source>Open video...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Open Manage Models</source>
-        <translation>Открыть «Управление моделями»</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="216" />
+        <source>Load subtitles...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Select local model directory</source>
-        <translation>Выбрать локальный каталог моделей</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="220" />
+        <source>Save SRT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation>Пропустить все загрузки (только локально)</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="223" />
+        <source>Export ASS...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>Некоторые пакеты моделей не удалось загрузить. Ошибки: {0}</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="226" />
+        <source>Export WebVTT...</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation>Итог: загружено {0}, ошибок {1}, пропущено {2}.</translation>
+        <location filename="../ui/video_subtitle_editor.py" line="230" />
+        <source>Render video (burn subtitles)...</source>
+        <translation type="unfinished" />
     </message>
-</context>
-</TS>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="234" />
+        <source>Undo</source>
+        <translation type="unfinished">Отменить</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="238" />
+        <source>Redo</source>
+        <translation type="unfinished">Вернуть</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="256" />
+        <source>Open a video to preview</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
+        <source>Play</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="281" />
+        <source>Timeline</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="285" />
+        <source>Subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Start</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>End</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="288" />
+        <source>Style</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="297" />
+        <source>Add segment</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="299" />
+        <source>Delete</source>
+        <translation type="unfinished">Удалить</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="301" />
+        <source>Split at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="312" />
+        <source>Trim &amp; crop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="315" />
+        <source>In:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="317" />
+        <source>0:00 (leave empty = start)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
+        <source>Set at playhead</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="323" />
+        <source>Out:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="325" />
+        <source>end (leave empty = end)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="331" />
+        <source>Clear In/Out</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="337" />
+        <source>Crop % (L,T,R,B):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="367" />
+        <source>Subtitle style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="374" />
+        <source>Open a video and optionally load subtitles (SRT/ASS/VTT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="384" />
+        <source>Open video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="385" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Error</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
+        <source>Could not open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="416" />
+        <source>Loaded: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <source>Failed to open video: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="423" />
+        <source>Load subtitles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="424" />
+        <source>Subtitle files (*.srt *.ass *.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <source>Failed to load subtitles: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="449" />
+        <source>Loaded %d segments from %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Anime</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <source>Documentary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="651" />
+        <source>Split segment at %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="653" />
+        <source>Playhead not inside a segment or segment too short to split.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <source>Pause</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <source>Open a video first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="714" />
+        <source>Save SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="715" />
+        <source>SRT files (*.srt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="721" />
+        <source>Saved SRT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="734" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="735" />
+        <source>ASS files (*.ass);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="744" />
+        <source>Exported ASS: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="751" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="752" />
+        <source>WebVTT files (*.vtt);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="761" />
+        <source>Exported WebVTT: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="768" />
+        <source>Render video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="769" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <source>Could not open video for rendering.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <source>Could not create output video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Rendering video...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="809" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="838" />
+        <source>Rendered: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Done</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="839" />
+        <source>Video saved to: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <source>Render failed: %s</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>VideoTranslatorDialog</name>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3167" />
+        <source>Video translator</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3195" />
+        <source>Video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3198" />
+        <source>Input video path</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
+        <source>Browse...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3202" />
+        <source>Input:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3206" />
+        <source>Output video path (default: input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3210" />
+        <source>Output:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3217" />
+        <source>Batch (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3222" />
+        <source>Add video files; when list is non-empty, Run processes all to the output directory below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3225" />
+        <source>Add files...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3227" />
+        <source>Add folder...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3229" />
+        <source>Remove</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3231" />
+        <source>Clear</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3240" />
+        <source>Output directory:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3242" />
+        <source>All batch outputs go here (e.g. input_translated.mp4)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3258" />
+        <source>Pipeline &amp; sampling</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3261" />
+        <source>Source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3264" />
+        <source>Hardcoded subtitles (OCR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3265" />
+        <source>Audio (speech-to-text / ASR)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3266" />
+        <source>Existing subtitles (file or embedded)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3271" />
+        <source>OCR = detect and read text on screen. ASR = transcribe from audio (faster-whisper). Existing = sidecar .srt/.ass/.vtt or embedded subtitle stream.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3275" />
+        <source>ASR model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3283" />
+        <source>Device:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3290" />
+        <source>Language (empty=auto):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3292" />
+        <source>ja, en, zh, ...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3296" />
+        <source>VAD filter (reduce hallucinations)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3299" />
+        <source>Filter non-speech segments to reduce ASR hallucinations (VideoCaptioner-style). Recommended on.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3301" />
+        <source>Smart sentence break (LLM)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3304" />
+        <source>Use LLM to merge/split ASR segments into natural sentences. Requires translator. VideoCaptioner-style 智能断句.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3306" />
+        <source>Merge cues until sentence punctuation (rule-based)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3309" />
+        <source>Merge short adjacent cues until sentence-ending punctuation (., ?, !, 。！？). Reduces half-sentence mistranslations and request count without extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3311" />
+        <source>Max merge duration (sec):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3318" />
+        <source>Separate vocals (reduce music noise)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3321" />
+        <source>Use demucs to separate vocals before ASR. Improves accuracy on noisy audio. Optional: pip install demucs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3323" />
+        <source>ASR-guided detect/inpaint (experimental)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3326" />
+        <source>Use ASR timings to drive vision: detect once at each subtitle segment start and reuse boxes until segment end, then inpaint only during active segments.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3328" />
+        <source>Midpoint refresh in ASR-guided mode</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3331" />
+        <source>Refresh text detection once around the middle of each active subtitle segment to handle moving subtitles.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3333" />
+        <source>Long-audio chunk size (sec, 0=off):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3338" />
+        <source>Off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
+        <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3353" />
+        <source>Chunking min duration (sec, 0=never):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3358" />
+        <source>Never</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
+        <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3379" />
+        <source>Save/resume ASR chunk checkpoint (temp JSON)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
+        <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3395" />
+        <source>Usage preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3398" />
+        <source>Custom (no change)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3399" />
+        <source>Don't miss text (quality)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3400" />
+        <source>Balanced (recommended)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3401" />
+        <source>Maximum speed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3402" />
+        <source>Anime / long series</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3403" />
+        <source>Documentary / captions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
+        <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3419" />
+        <source>Process every:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
+        <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
+At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3431" />
+        <source> frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3437" />
+        <source>Detection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3440" />
+        <source>OCR</source>
+        <translation type="unfinished">OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3443" />
+        <source>Translation</source>
+        <translation type="unfinished">Перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3446" />
+        <source>Inpainting</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3456" />
+        <source>Subtitle bar: solid box behind text (no inpaint)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
+        <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3476" />
+        <source>Subtitle region &amp; output</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3478" />
+        <source>Subtitle region:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3481" />
+        <source>Full frame</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3482" />
+        <source>Bottom 15%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3483" />
+        <source>Bottom 20%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3484" />
+        <source>Bottom 25%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3485" />
+        <source>Bottom 30%</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3491" />
+        <source>Only process text blocks in this area (e.g. Bottom 20%% = subtitle band). Speeds up and reduces false positives. Inspired by ROI in video-subtitle-extractor / subtitle-quality tools.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3493" />
+        <source>Output codec (FourCC):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3495" />
+        <source>mp4v</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3497" />
+        <source>OpenCV FourCC: mp4v (default), avc1 (H.264), XVID, etc. Leave default if playback has issues.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3501" />
+        <source>Burn-in style:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Anime (larger)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3503" />
+        <source>Documentary (smaller)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
+        <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3514" />
+        <source>Subtitle font:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3516" />
+        <source>Empty = Arial / default</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3518" />
+        <source>Optional path to a .ttf or .otf file for burn-in subtitles. Leave empty to use the default font (Arial/DejaVu).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3526" />
+        <source>Soft subtitles only (no burn-in; output video + SRT, very fast)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
+        <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3536" />
+        <source>Inpaint only (no burn-in; SRT/ASS/VTT only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3539" />
+        <source>Run full pipeline (detect, OCR, translate, inpaint) but do not draw subtitles on the video. Output: inpainted video + SRT/ASS/VTT files. Use so the video never has both hardcoded and soft subs at once.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3541" />
+        <source>Mux SRT into video (inpaint-only mode)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3544" />
+        <source>When 'Inpaint only' is on: add the SRT as a subtitle stream inside the output video file. Requires FFmpeg. If off, SRT is only a sidecar file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3552" />
+        <source>Scene &amp; smoothing</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3554" />
+        <source>Scene detection (pipeline only on scene changes)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3558" />
+        <source>Scene threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3565" />
+        <source>Temporal smoothing (blend with previous frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3569" />
+        <source>Blend weight:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3576" />
+        <source>Prefetch frames:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3580" />
+        <source>0 (off)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3581" />
+        <source>Decode next frames in a separate thread (2–3 recommended) so I/O doesn't block the pipeline. 0 = off. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3584" />
+        <source>Two-stage keyframes (skip pipeline when subtitle region unchanged)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3587" />
+        <source>Cheap content hash of the subtitle band; skip full pipeline when unchanged. Saves work when the same subtitle holds across many frames. OCR path only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3589" />
+        <source>Background writer (encode in separate thread)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3592" />
+        <source>Saved for compatibility. OCR path always runs decode and encode in separate threads so the pipeline is never throttled by I/O.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3594" />
+        <source>Two-pass OCR burn-in (faster when translation is slow)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3597" />
+        <source>Pass 1 runs detect/OCR/inpaint while collecting translations asynchronously; pass 2 burns timed subtitles. Increases throughput on slow translators. OCR hardcoded burn-in mode only.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3600" />
+        <source>Forced refresh (frames):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3604" />
+        <source>0 = off. If enabled, never skip two-stage indefinitely: force a full pipeline run at least every N frames.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3608" />
+        <source>New-line diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3613" />
+        <source>Used with two-stage keyframes. If the subtitle band pixel-diff indicates a new line, we run the pipeline even when the hash matches. Higher = fewer forced runs.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3617" />
+        <source>Adaptive detector ROI (crop around last subs)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3620" />
+        <source>When enabled and ROI is known from the last pipeline run, the detector runs on a cropped region to speed it up.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3622" />
+        <source>Auto-catch subtitle appearance on skipped frames</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3625" />
+        <source>When sample_every_frames skips a frame, monitor subtitle-band pixel changes and force a full pipeline run if a new subtitle likely appeared.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3628" />
+        <source>Detector ROI padding:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3635" />
+        <source>Adaptive ROI start (seconds):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3640" />
+        <source>Delay adaptive ROI until this time in the video. Useful to ignore early corner watermarks/registration text.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3643" />
+        <source>Auto-catch diff threshold:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3648" />
+        <source>0 (auto)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3649" />
+        <source>0 = auto from sample_every_frames/fps. Higher values trigger fewer catch-up runs; lower values trigger more often.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3653" />
+        <source>Overlap inpaint with OCR/translation</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3656" />
+        <source>Run inpainting in parallel with OCR/translation within the same pipeline tick (only when safe). May increase GPU contention.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3658" />
+        <source>OCR temporal stability (reduce OCR jitter)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3661" />
+        <source>Vote over recent frames for the same subtitle region before translation. Helps stop per-frame character flicker.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3663" />
+        <source>OCR temporal window:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3669" />
+        <source>OCR temporal min votes:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3675" />
+        <source>OCR temporal geo quantization:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3680" />
+        <source>Region matching tolerance in pixels across frames. Higher = more stable matching; too high can over-merge nearby subtitle regions.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3685" />
+        <source>FFmpeg &amp; export</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3687" />
+        <source>Use FFmpeg (libx264, better compatibility)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3691" />
+        <source>FFmpeg path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3693" />
+        <source>Empty = use PATH</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3695" />
+        <source>If FFmpeg is not on PATH, set full path to ffmpeg.exe.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3703" />
+        <source>CRF (0–51):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3707" />
+        <source>Lower = better quality (18 = high; 23 = medium). Ignored when Target bitrate is set.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3710" />
+        <source>Encoding preset:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3718" />
+        <source>Faster presets = quicker encoding, slightly larger file. veryfast/faster = good speed/quality trade-off.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3721" />
+        <source>Hardware encoder:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3724" />
+        <source>None (libx264)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3725" />
+        <source>NVIDIA (NVENC)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3726" />
+        <source>Intel (QSV)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3727" />
+        <source>Auto (NVENC or QSV if available)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3733" />
+        <source>Use GPU encoder for faster encoding. Requires FFmpeg built with NVENC (NVIDIA) or QSV (Intel). Auto picks first available.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3736" />
+        <source>Target bitrate (kbps, 0=CRF only):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3740" />
+        <source>0 (CRF)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3741" />
+        <source>0 = use source video bitrate when detectable (same as original), else use CRF. Set a value (e.g. 9600) to override. Only when FFmpeg is enabled.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3744" />
+        <source>Skip detection (fixed region only)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3746" />
+        <source>Use one block for subtitle region; no text detection. Set region above (e.g. Bottom 20%%).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3749" />
+        <source>Detect-only mode (skip inpainting)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3751" />
+        <source>Run detection/OCR/translation normally, but do not run inpainting. Useful when you only want subtitle burn-in and no background cleanup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3754" />
+        <source>Bottom-band native mode (skip-detect)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3757" />
+        <source>When Skip detection is on, use native bottom-band behavior for OCR/inpaint handling instead of fixed-block shortcuts.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3759" />
+        <source>Export SRT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
+        <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3769" />
+        <source>Export ASS</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
+        <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3779" />
+        <source>Export WebVTT</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3782" />
+        <source>Write WebVTT subtitle file (same timing as SRT).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
+        <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3799" />
+        <source>Context (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3801" />
+        <source>Glossary / script hint:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3803" />
+        <source>Terminology, names, script excerpt or correction hints…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3805" />
+        <source>Optional. Sent to the LLM for OCR/ASR correction and translation (e.g. terms, names, script excerpt). VideoCaptioner-style.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3809" />
+        <source>LLM per-line quality fix (empty/echo rescue)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3812" />
+        <source>When enabled, retries problematic lines (empty or source-echo) with focused prompts. Improves quality but may add extra LLM calls.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3815" />
+        <source>LLM translation chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3819" />
+        <source>Off (one request)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
+        <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3829" />
+        <source>Parallel workers:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
+        <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3843" />
+        <source>Qwen3.5-4B: allow OCR-correction and reflection passes</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3846" />
+        <source>When enabled, do not skip Qwen3.5-4B LM Studio auxiliary passes (OCR correction/reflection). Can improve quality but may trigger verbose-thinking JSON failures and extra latency.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3848" />
+        <source>Lock/ignore watermark-like lines by regex</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3851" />
+        <source>Do not translate lines matching the regex below (keeps source text). Useful for备案号/watermarks.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3853" />
+        <source>Watermark lock regex:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3856" />
+        <source>Python regex. Example: 备案号[:：]?\s*\d{8,}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3860" />
+        <source>Series context path:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3862" />
+        <source>Folder or series ID (e.g. my_anime); leave empty to use translator's config</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3863" />
+        <source>Optional. Same as project series context: loads glossary and recent context from data/translation_context/&lt;id&gt;/ or the given folder. Improves consistency across videos.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3875" />
+        <source>Flow fixer (optional)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3877" />
+        <source>Use flow fixer (smooth subtitle flow after translation)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3879" />
+        <source>After translation, a second pass can improve flow. Local = free (Ollama/LM Studio). OpenAI = use ChatGPT credits (gpt-4o-mini is cheap). See docs/FLOW_FIXER_SETUP.md for model list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3882" />
+        <source>Flow fixer:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3885" />
+        <source>None</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3886" />
+        <source>Local server (Ollama or LM Studio)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3887" />
+        <source>OpenRouter (second model)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3888" />
+        <source>OpenAI / ChatGPT (use credits)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3896" />
+        <source>Server URL:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3898" />
+        <source>http://localhost:1234/v1</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3900" />
+        <source>LM Studio: http://localhost:1234/v1  —  Ollama: http://localhost:11434/v1. If you get invalid JSON or wrong revision count, see docs/FLOW_FIXER_SETUP.md (context size, max tokens, stop sequences).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3903" />
+        <source>Model (local):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3905" />
+        <source>Type model name (required)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3907" />
+        <source>Required: type the exact model name. LM Studio: use the name shown for the loaded model (e.g. llama-3.2-3b, Qwen2.5-3B-Instruct). Ollama: e.g. qwen2.5:3b, phi3:mini. Flow fixer is only used when this is non-empty; see docs/FLOW_FIXER_SETUP.md.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3910" />
+        <source>OpenRouter API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3912" />
+        <source>Same as translator or paste key</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3915" />
+        <source>OpenRouter API key for the flow-fixer model. Can be the same key as your main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3918" />
+        <source>OpenRouter model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3920" />
+        <source>google/gemma-3n-e2b-it:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3922" />
+        <source>Small/free model for flow only. Examples: google/gemma-3n-e2b-it:free, qwen/qwen3-4b:free</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3925" />
+        <source>OpenAI API key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3927" />
+        <source>sk-... (platform.openai.com API key)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3930" />
+        <source>OpenAI API key (ChatGPT credits). Get one at platform.openai.com → API keys. Use gpt-4o-mini or gpt-3.5-turbo for cheap flow passes.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3933" />
+        <source>OpenAI model:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3935" />
+        <source>gpt-4o-mini</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3937" />
+        <source>Cheap and good: gpt-4o-mini (default). Even cheaper: gpt-3.5-turbo. Uses your ChatGPT/OpenAI credits.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3940" />
+        <source>Max tokens:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3946" />
+        <source>Context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3950" />
+        <source>How many previous subtitle lines to send for flow (1–50). Higher = more context; may trigger summarization when long. Default 20.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3953" />
+        <source>Enable reasoning/thinking (if supported)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3955" />
+        <source>Uses model reasoning controls for flow-fixer requests. If unsupported by a model/provider, it automatically retries without reasoning params.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3958" />
+        <source>Reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3965" />
+        <source>Use flow fixer model for OCR/ASR correction and reflection</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3967" />
+        <source>When enabled, Correct OCR with LLM, Correct ASR with LLM, and Reflect translation use the same model as the flow fixer (local/OpenRouter/OpenAI) instead of the main translator.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3970" />
+        <source>Strict flow fixer: always review single-line updates</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3973" />
+        <source>If enabled, flow fixer API is called even when there is no previous context and only one new line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3975" />
+        <source>Post-run global subtitle flow review</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
+        <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3986" />
+        <source>Allow post-review via main translator when flow fixer is off</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
+        <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="3999" />
+        <source>Apply post-run review on cancel (partial output)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4003" />
+        <source>Post-review chunk size:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4009" />
+        <source>Post-review context lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4016" />
+        <source>Post-review / main-LLM flow pass: enable reasoning</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
+        <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4029" />
+        <source>Post-review reasoning effort:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
+        <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
+        <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4057" />
+        <source>Apply Anime preset</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4058" />
+        <source>Same as selecting 'Anime / long series' in the Usage preset dropdown above.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4067" />
+        <source>Live preview (current frame)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4075" />
+        <source>Frame and subtitles will appear here during OCR run</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4078" />
+        <source>Full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4079" />
+        <source>Show current frame in full screen. Press Esc to close.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4086" />
+        <source>Current frame translation:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4087" />
+        <source>View history…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4088" />
+        <source>Open a list of previous source text and translations so you can read how they flow together.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4090" />
+        <source>A/B compare models…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4091" />
+        <source>Compare two translator models on sampled subtitle lines from this run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4103" />
+        <source>Detected / translated lines appear here during run.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4124" />
+        <source>Edit subtitles...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4125" />
+        <source>Open Video Subtitle Editor to cut, edit captions, and export.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4128" />
+        <source>Run</source>
+        <translation type="unfinished">Начать перевод</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4130" />
+        <source>Cancel</source>
+        <translation type="unfinished">Отмена</translation>
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
+        <source>Close</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4166" />
+        <source>Series context folder</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4435" />
+        <source>Select input video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4437" />
+        <source>Video files (*.mp4 *.avi *.mkv *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4448" />
+        <source>Select output video</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4450" />
+        <source>Video files (*.mp4 *.avi);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4457" />
+        <source>Add video files</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4458" />
+        <source>Video files (*.mp4 *.mkv *.avi *.mov *.webm);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4465" />
+        <source>Add folder with videos</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4481" />
+        <source>Batch output directory</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4489" />
+        <source>Select ffmpeg executable</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4491" />
+        <source>Executables (ffmpeg.exe);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4499" />
+        <source>Select subtitle font</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4501" />
+        <source>Fonts (*.ttf *.otf);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4512" />
+        <source>For batch, select a valid output directory.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4523" />
+        <source>No valid files in batch list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4537" />
+        <source>Please select a valid input video file.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4546" />
+        <source>Output directory does not exist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4552" />
+        <source>Running pipeline...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
+        <source>Batch done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4625" />
+        <source>File {} / {}: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4726" />
+        <source>No text on this frame.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4742" />
+        <source>Preview — full screen</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4776" />
+        <source>Translation history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4784" />
+        <source>No history yet. Run the pipeline to see source and translations as they are detected.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4788" />
+        <source>Frame %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4792" />
+        <source>Source: %s</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4866" />
+        <source>A/B compare translator models</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4870" />
+        <source>Model A:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4872" />
+        <source>e.g. qwen/qwen3.5-4b-instruct</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4874" />
+        <source>Model B:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4876" />
+        <source>e.g. mextrans-7b</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4878" />
+        <source>Sample lines:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4883" />
+        <source>Test source:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4886" />
+        <source>Current run history</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4887" />
+        <source>Preset: Chinese subtitle terms</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4888" />
+        <source>Preset: Japanese anime lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4889" />
+        <source>Preset: Korean dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4890" />
+        <source>Preset: English dialogue lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4891" />
+        <source>Custom pasted lines</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4895" />
+        <source>Custom lines (one per line):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4897" />
+        <source>Paste your own terms/lines here, one per line.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4903" />
+        <source>Click Run compare to generate side-by-side output.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4906" />
+        <source>Run compare</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4907" />
+        <source>Use Model A</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4908" />
+        <source>Use Model B</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4914" />
+        <source>Save custom list</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4923" />
+        <source>Saved custom A/B list.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4930" />
+        <source>A/B compare: set model first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4940" />
+        <source>A/B compare: set winner model to {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4953" />
+        <source>Please set both Model A and Model B.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4959" />
+        <source>No current run history yet. Choose a preset test source or run a translation first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4974" />
+        <source>Custom list is empty. Paste lines first or choose another source.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="4990" />
+        <source>Could not initialize translator module for A/B compare.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5029" />
+        <source>A/B compare running...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5067" />
+        <source>A/B compare done. Saved: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
+        <source>A/B compare done.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
+        <source>Pass 1/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
+        <source>Pass 2/2</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5104" />
+        <source>File {} / {}: {} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5112" />
+        <source>File {} / {}: frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5116" />
+        <source>{} frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5118" />
+        <source>Frame {} / {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5125" />
+        <source>Done. Output: {}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/video_translator_dialog.py" line="5131" />
+        <source>Error: {}</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>WelcomeWidget</name>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="155" />
+        <source>BallonsTranslator Pro</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="160" />
+        <source>Open a project folder or choose a recent one to start.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="168" />
+        <source>Get started</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="172" />
+        <source>Open folder…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="173" />
+        <source>Open a folder containing images (creates or loads project).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="179" />
+        <source>Open project…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="180" />
+        <source>Open an existing project (.json).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="186" />
+        <source>Open images…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="187" />
+        <source>Select image files to open as a new project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="193" />
+        <source>Open ACBF/CBZ…</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="194" />
+        <source>Open a comic archive (.cbz/.zip).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="205" />
+        <source>Recent projects</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="215" />
+        <source>No recent projects.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="232" />
+        <source>Open project</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/welcome_widget.py" line="234" />
+        <source>Project files (*.json);;All files (*)</source>
+        <translation type="unfinished" />
+    </message>
+</context></TS>

--- a/translate/zh_CN.ts
+++ b/translate/zh_CN.ts
@@ -1,16 +1,6 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
 <TS version="2.1" language="zh_CN" sourcelanguage="en">
-<context>
-    <name />
-    <message>
-        <source>Mask Transparency</source>
-        <translation type="obsolete">掩膜透明度</translation>
-    </message>
-    <message>
-        <source>Mask Opacity</source>
-        <translation type="vanished">掩膜不透明度</translation>
-    </message>
-</context>
 <context>
     <name>BatchQueueDialog</name>
     <message>
@@ -144,8 +134,8 @@
         <translation>已暂停。点击“继续”以恢复。</translation>
     </message>
     <message>
-        <location filename="../ui/batch_queue_dialog.py" line="201" />
         <location filename="../ui/batch_queue_dialog.py" line="233" />
+        <location filename="../ui/batch_queue_dialog.py" line="201" />
         <source>Running…</source>
         <translation>运行中…</translation>
     </message>
@@ -179,8 +169,7 @@
         <source>Queue cancelled.</source>
         <translation>队列已取消。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>BatchReportDialog</name>
     <message>
         <location filename="../ui/batch_report_dialog.py" line="19" />
@@ -193,8 +182,8 @@
         <translation>状态：—</translation>
     </message>
     <message>
-        <location filename="../ui/batch_report_dialog.py" line="25" />
         <location filename="../ui/batch_report_dialog.py" line="45" />
+        <location filename="../ui/batch_report_dialog.py" line="25" />
         <source>Total: —  Skipped: —  Completed: —</source>
         <translation>总数：—  跳过：—  完成：—</translation>
     </message>
@@ -238,629 +227,582 @@
         <source>Total: {}  Skipped: {}  Completed: {}</source>
         <translation>总数：{}  跳过：{}  完成：{}</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>BottomBar</name>
     <message>
-        <source>Enable/disable ocr</source>
-        <translation type="obsolete">启用/禁用OCR</translation>
-    </message>
-    <message>
-        <source>Enable/disable translation</source>
-        <translation type="obsolete">启用/禁用机翻</translation>
-    </message>
-    <message>
-        <source>translate page</source>
-        <translation type="obsolete">翻译本页</translation>
-    </message>
-    <message>
-        <source>stop</source>
-        <translation type="obsolete">停止</translation>
-    </message>
-    <message>
-        <source>translate current page</source>
-        <translation type="obsolete">翻译本页</translation>
-    </message>
-    <message>
-        <source>stop translation</source>
-        <translation type="obsolete">停止翻译</translation>
-    </message>
-    <message>
-        <source>Enable/disable paint mode</source>
-        <translation type="vanished">启用/禁用画板</translation>
-    </message>
-    <message>
-        <source>Enable/disable text edit mode</source>
-        <translation type="vanished">启用/禁用文本编辑</translation>
-    </message>
-    <message>
-        <source>Original image transparency: </source>
-        <translation type="obsolete">原图透明度: </translation>
-    </message>
-    <message>
-        <source>Lettering layer transparency: </source>
-        <translation type="obsolete">嵌字层透明度</translation>
-    </message>
-    <message>
-        <source>Original image transparency</source>
-        <translation type="obsolete">原图透明度</translation>
-    </message>
-    <message>
-        <source>Lettering layer transparency</source>
-        <translation type="obsolete">嵌字层透明度</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1579" />
-        <source>Original image opacity</source>
-        <translation>原图不透明度</translation>
-    </message>
-    <message>
-        <source>Lettering layer opacity</source>
-        <translation type="obsolete">嵌字层不透明度</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1583" />
-        <source>Text layer opacity</source>
-        <translation>嵌字层不透明度</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1535" />
+        <location filename="../ui/mainwindowbars.py" line="1566" />
         <source>Text Detector</source>
         <translation>文本检测</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1536" />
+        <location filename="../ui/mainwindowbars.py" line="1567" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1537" />
+        <location filename="../ui/mainwindowbars.py" line="1568" />
         <source>Inpaint</source>
         <translation>图像修复</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1545" />
+        <location filename="../ui/mainwindowbars.py" line="1571" />
+        <source>Run</source>
+        <translation>运行</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1576" />
         <source>Run pipeline (same as Pipeline → Run).</source>
         <translation>运行流程（同 流程 → 运行）。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1565" />
+        <location filename="../ui/mainwindowbars.py" line="1596" />
         <source>Drawing board</source>
         <translation>画板</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1569" />
+        <location filename="../ui/mainwindowbars.py" line="1600" />
         <source>Text editor</source>
         <translation>文本编辑</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1573" />
+        <location filename="../ui/mainwindowbars.py" line="1604" />
         <source>Spell check panel</source>
         <translation>拼写检查面板</translation>
     </message>
     <message>
-        <source>Open module settings</source>
-        <translation type="vanished">打开模块设置</translation>
+        <location filename="../ui/mainwindowbars.py" line="1610" />
+        <source>Original image opacity</source>
+        <translation>原图不透明度</translation>
     </message>
     <message>
-        <source>Translate</source>
-        <translation type="vanished">翻译</translation>
+        <location filename="../ui/mainwindowbars.py" line="1614" />
+        <source>Text layer opacity</source>
+        <translation>嵌字层不透明度</translation>
     </message>
-    <message>
-        <source>Source</source>
-        <translation type="vanished">源语言</translation>
-    </message>
-    <message>
-        <source>Target</source>
-        <translation type="vanished">目标语言</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1540" />
-        <source>Run</source>
-        <translation>运行</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>Canvas</name>
     <message>
-        <location filename="../ui/canvas.py" line="1100" />
-        <source>Delete</source>
-        <translation>删除</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1264" />
-        <source>Apply font formatting</source>
-        <translation>应用字体格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1268" />
-        <source>Auto layout</source>
-        <translation>自动排版</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1070" />
-        <source>Copy</source>
-        <translation>复制</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1075" />
-        <source>Paste</source>
-        <translation>粘贴</translation>
-    </message>
-    <message>
-        <source>translate</source>
-        <translation type="vanished">翻译</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1342" />
-        <source>OCR</source>
-        <translation>OCR</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1346" />
-        <source>OCR and translate</source>
-        <translation>OCR并翻译</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1350" />
-        <source>OCR, translate and inpaint</source>
-        <translation>OCR，翻译并抹字</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1105" />
-        <source>Delete and Recover removed text</source>
-        <translation>删除并恢复被抹除文字</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1315" />
-        <source>Reset Angle</source>
-        <translation>角度复位</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1088" />
-        <source>Copy source text</source>
-        <translation>复制原文</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1093" />
-        <source>Paste source text</source>
-        <translation>粘贴原文</translation>
-    </message>
-    <message>
-        <source>inpaint</source>
-        <translation type="vanished">抹字</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1319" />
-        <source>Squeeze</source>
-        <translation>收缩</translation>
-    </message>
-    <message>
-        <location filename="../ui/canvas.py" line="1069" />
-        <location filename="../ui/canvas.py" line="1074" />
-        <location filename="../ui/canvas.py" line="1079" />
-        <location filename="../ui/canvas.py" line="1083" />
-        <location filename="../ui/canvas.py" line="1087" />
-        <location filename="../ui/canvas.py" line="1092" />
-        <location filename="../ui/canvas.py" line="1099" />
-        <location filename="../ui/canvas.py" line="1104" />
-        <location filename="../ui/canvas.py" line="1111" />
-        <location filename="../ui/canvas.py" line="1115" />
-        <location filename="../ui/canvas.py" line="1121" />
+        <location filename="../ui/canvas.py" line="1124" />
+        <location filename="../ui/canvas.py" line="1118" />
+        <location filename="../ui/canvas.py" line="1114" />
+        <location filename="../ui/canvas.py" line="1107" />
+        <location filename="../ui/canvas.py" line="1102" />
+        <location filename="../ui/canvas.py" line="1095" />
+        <location filename="../ui/canvas.py" line="1090" />
+        <location filename="../ui/canvas.py" line="1086" />
+        <location filename="../ui/canvas.py" line="1082" />
+        <location filename="../ui/canvas.py" line="1077" />
+        <location filename="../ui/canvas.py" line="1072" />
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1080" />
+        <location filename="../ui/canvas.py" line="1073" />
+        <source>Copy</source>
+        <translation>复制</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1078" />
+        <source>Paste</source>
+        <translation>粘贴</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1083" />
         <source>Copy translation</source>
         <translation>复制译文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1084" />
+        <location filename="../ui/canvas.py" line="1087" />
         <source>Paste translation</source>
         <translation>粘贴译文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1112" />
+        <location filename="../ui/canvas.py" line="1091" />
+        <source>Copy source text</source>
+        <translation>复制原文</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1096" />
+        <source>Paste source text</source>
+        <translation>粘贴原文</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1103" />
+        <source>Delete</source>
+        <translation>删除</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1108" />
+        <source>Delete and Recover removed text</source>
+        <translation>删除并恢复被抹除文字</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1115" />
         <source>Clear source text</source>
         <translation>清空原文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1116" />
+        <location filename="../ui/canvas.py" line="1119" />
         <source>Clear translation</source>
         <translation>清空译文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1122" />
+        <location filename="../ui/canvas.py" line="1125" />
         <source>Select all text boxes</source>
         <translation>全选文本框</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1134" />
-        <location filename="../ui/canvas.py" line="1138" />
-        <location filename="../ui/canvas.py" line="1142" />
-        <location filename="../ui/canvas.py" line="1146" />
-        <location filename="../ui/canvas.py" line="1150" />
-        <location filename="../ui/canvas.py" line="1154" />
-        <location filename="../ui/canvas.py" line="1158" />
-        <location filename="../ui/canvas.py" line="1164" />
+        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1157" />
+        <location filename="../ui/canvas.py" line="1153" />
+        <location filename="../ui/canvas.py" line="1149" />
+        <location filename="../ui/canvas.py" line="1145" />
+        <location filename="../ui/canvas.py" line="1141" />
+        <location filename="../ui/canvas.py" line="1137" />
         <source>Text</source>
         <translation>文本</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1135" />
+        <location filename="../ui/canvas.py" line="1138" />
         <source>Spell check source text</source>
         <translation>拼写检查原文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1139" />
+        <location filename="../ui/canvas.py" line="1142" />
         <source>Spell check translation</source>
         <translation>拼写检查译文</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1143" />
+        <location filename="../ui/canvas.py" line="1146" />
         <source>Trim whitespace</source>
         <translation>修剪空白</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1147" />
+        <location filename="../ui/canvas.py" line="1150" />
         <source>To uppercase</source>
         <translation>转为大写</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1151" />
+        <location filename="../ui/canvas.py" line="1154" />
         <source>To lowercase</source>
         <translation>转为小写</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1155" />
+        <location filename="../ui/canvas.py" line="1158" />
         <source>Toggle strikethrough</source>
         <translation>切换删除线</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1159" />
+        <location filename="../ui/canvas.py" line="1162" />
         <source>Gradient type</source>
         <translation>渐变类型</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1160" />
+        <location filename="../ui/canvas.py" line="1163" />
         <source>Linear</source>
         <translation>线性</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1161" />
+        <location filename="../ui/canvas.py" line="1164" />
         <source>Radial</source>
         <translation>径向</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1165" />
+        <location filename="../ui/canvas.py" line="1168" />
         <source>Text on path</source>
         <translation>路径文字</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1166" />
+        <location filename="../ui/canvas.py" line="1169" />
         <source>None</source>
         <translation>无</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1167" />
+        <location filename="../ui/canvas.py" line="1170" />
         <source>Circular</source>
         <translation>圆</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1168" />
+        <location filename="../ui/canvas.py" line="1171" />
         <source>Arc</source>
         <translation>弧</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1176" />
-        <location filename="../ui/canvas.py" line="1182" />
-        <location filename="../ui/canvas.py" line="1187" />
+        <location filename="../ui/canvas.py" line="1200" />
+        <location filename="../ui/canvas.py" line="1195" />
         <location filename="../ui/canvas.py" line="1191" />
-        <location filename="../ui/canvas.py" line="1196" />
+        <location filename="../ui/canvas.py" line="1186" />
+        <location filename="../ui/canvas.py" line="1180" />
         <source>Block</source>
         <translation>块</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1177" />
+        <location filename="../ui/canvas.py" line="1181" />
         <source>Create text box</source>
         <translation>创建文本框</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1178" />
+        <location filename="../ui/canvas.py" line="1182" />
         <source>Add a new text box at the right-click position (default size). Or right-click and drag to set size.</source>
         <translation>在右键位置添加新文本框（默认大小）。或右键拖动以设置大小。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1183" />
+        <location filename="../ui/canvas.py" line="1187" />
         <source>Merge selected blocks</source>
         <translation>合并选中块</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1188" />
+        <location filename="../ui/canvas.py" line="1192" />
         <source>Split selected region(s)</source>
         <translation>拆分选中区域</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1192" />
+        <location filename="../ui/canvas.py" line="1196" />
         <source>Move block(s) up</source>
         <translation>块上移</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1197" />
+        <location filename="../ui/canvas.py" line="1201" />
         <source>Move block(s) down</source>
         <translation>块下移</translation>
     </message>
     <message>
+        <location filename="../ui/canvas.py" line="1205" />
+        <source>Add selected to triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
         <location filename="../ui/canvas.py" line="1206" />
-        <location filename="../ui/canvas.py" line="1211" />
+        <source>Mark selected as reviewed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1218" />
+        <location filename="../ui/canvas.py" line="1213" />
         <source>Image / Overlay</source>
         <translation>图像 / 叠加</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1207" />
+        <location filename="../ui/canvas.py" line="1214" />
         <source>Import Image</source>
         <translation>导入图片</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1212" />
+        <location filename="../ui/canvas.py" line="1219" />
         <source>Clear overlay image</source>
         <translation>清除叠加图</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1222" />
-        <location filename="../ui/canvas.py" line="1228" />
-        <location filename="../ui/canvas.py" line="1233" />
+        <location filename="../ui/canvas.py" line="1240" />
+        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1229" />
         <source>Transform</source>
         <translation>变换</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1223" />
+        <location filename="../ui/canvas.py" line="1230" />
         <source>Free Transform</source>
         <translation>自由变换</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1229" />
+        <location filename="../ui/canvas.py" line="1236" />
         <source>Reset warp</source>
         <translation>重置变形</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1234" />
+        <location filename="../ui/canvas.py" line="1241" />
         <source>Warp preset</source>
         <translation>变形预设</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1235" />
+        <location filename="../ui/canvas.py" line="1242" />
         <source>Arc Up</source>
         <translation>上弧</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1236" />
+        <location filename="../ui/canvas.py" line="1243" />
         <source>Arc Down</source>
         <translation>下弧</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1237" />
+        <location filename="../ui/canvas.py" line="1244" />
         <source>Arch</source>
         <translation>拱形</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1238" />
+        <location filename="../ui/canvas.py" line="1245" />
         <source>Flag</source>
         <translation>旗帜</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1246" />
-        <location filename="../ui/canvas.py" line="1250" />
+        <location filename="../ui/canvas.py" line="1257" />
+        <location filename="../ui/canvas.py" line="1253" />
         <source>Order</source>
         <translation>顺序</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1247" />
+        <location filename="../ui/canvas.py" line="1254" />
         <source>Bring to front</source>
         <translation>置于顶层</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1251" />
+        <location filename="../ui/canvas.py" line="1258" />
         <source>Send to back</source>
         <translation>置于底层</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1263" />
-        <location filename="../ui/canvas.py" line="1267" />
-        <location filename="../ui/canvas.py" line="1271" />
-        <location filename="../ui/canvas.py" line="1277" />
-        <location filename="../ui/canvas.py" line="1283" />
-        <location filename="../ui/canvas.py" line="1289" />
-        <location filename="../ui/canvas.py" line="1302" />
-        <location filename="../ui/canvas.py" line="1308" />
-        <location filename="../ui/canvas.py" line="1314" />
-        <location filename="../ui/canvas.py" line="1318" />
+        <location filename="../ui/canvas.py" line="1325" />
+        <location filename="../ui/canvas.py" line="1321" />
+        <location filename="../ui/canvas.py" line="1315" />
+        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1270" />
         <source>Format</source>
         <translation>格式</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1272" />
+        <location filename="../ui/canvas.py" line="1271" />
+        <source>Apply font formatting</source>
+        <translation>应用字体格式</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1275" />
+        <source>Auto layout</source>
+        <translation>自动排版</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1279" />
         <source>Fit to bubble</source>
         <translation>适合气泡</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1274" />
+        <location filename="../ui/canvas.py" line="1281" />
         <source>Run layout so text fits inside the bubble (constrain + line breaks).</source>
         <translation>运行布局，使文本适合气泡内（约束+换行符）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1278" />
+        <location filename="../ui/canvas.py" line="1285" />
         <source>Auto fit font size to box</source>
         <translation>字号自动适应框</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1280" />
+        <location filename="../ui/canvas.py" line="1287" />
         <source>Scale font size so text fits the selected text box(es). Use after changing font.</source>
         <translation>缩放字号使文字适应所选文本框。更改字体后使用。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1284" />
+        <location filename="../ui/canvas.py" line="1291" />
         <source>Auto fit font size (binary search)</source>
         <translation>自动调整字体大小（二分查找）</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1286" />
+        <location filename="../ui/canvas.py" line="1293" />
         <source>Find largest font size that fits the bubble (slower, more accurate).</source>
         <translation>找到适合气泡的最大字体大小（更慢，更准确）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1290" />
+        <location filename="../ui/canvas.py" line="1297" />
         <source>Balloon shape</source>
         <translation>气球形状</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1291" />
+        <location filename="../ui/canvas.py" line="1298" />
         <source>Round</source>
         <translation>圆形的</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1292" />
+        <location filename="../ui/canvas.py" line="1299" />
         <source>Elongated</source>
         <translation>拉长型</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1293" />
+        <location filename="../ui/canvas.py" line="1300" />
         <source>Narrow</source>
         <translation>狭窄的</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1294" />
+        <location filename="../ui/canvas.py" line="1301" />
         <source>Diamond</source>
         <translation>钻石</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1295" />
+        <location filename="../ui/canvas.py" line="1302" />
         <source>Square</source>
         <translation>正方形</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1296" />
+        <location filename="../ui/canvas.py" line="1303" />
         <source>Bevel</source>
         <translation>斜角</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1297" />
+        <location filename="../ui/canvas.py" line="1304" />
         <source>Pentagon</source>
         <translation>五角大楼</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1298" />
+        <location filename="../ui/canvas.py" line="1305" />
         <source>Point</source>
         <translation>观点</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1299" />
+        <location filename="../ui/canvas.py" line="1306" />
         <source>Auto</source>
         <translation>汽车</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1303" />
+        <location filename="../ui/canvas.py" line="1310" />
         <source>Resize to fit content</source>
         <translation>调整大小以适合内容</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1305" />
+        <location filename="../ui/canvas.py" line="1312" />
         <source>Resize the text box so all text is visible (e.g. when the box is too small and clips content).</source>
         <translation>调整文本框的大小，使所有文本都可见（例如，当文本框太小并剪辑内容时）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1309" />
+        <location filename="../ui/canvas.py" line="1316" />
         <source>Center in bubble</source>
         <translation>气泡中心</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1311" />
+        <location filename="../ui/canvas.py" line="1318" />
         <source>Move the text box so its center aligns with the bubble center (no resize).</source>
         <translation>移动文本框，使其中心与气泡中心对齐（不调整大小）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1329" />
-        <location filename="../ui/canvas.py" line="1333" />
-        <location filename="../ui/canvas.py" line="1337" />
+        <location filename="../ui/canvas.py" line="1322" />
+        <source>Reset Angle</source>
+        <translation>角度复位</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1326" />
+        <source>Squeeze</source>
+        <translation>收缩</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1356" />
+        <location filename="../ui/canvas.py" line="1351" />
+        <location filename="../ui/canvas.py" line="1346" />
         <location filename="../ui/canvas.py" line="1341" />
-        <location filename="../ui/canvas.py" line="1345" />
-        <location filename="../ui/canvas.py" line="1349" />
-        <location filename="../ui/canvas.py" line="1353" />
+        <location filename="../ui/canvas.py" line="1337" />
         <source>Run</source>
         <translation>运行</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1330" />
+        <location filename="../ui/canvas.py" line="1338" />
         <source>Detect text in region</source>
         <translation>检测区域内文字</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1334" />
+        <location filename="../ui/canvas.py" line="1342" />
         <source>Detect text on page</source>
         <translation>检测本页文字</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1338" />
+        <location filename="../ui/canvas.py" line="1347" />
         <source>Translate</source>
         <translation>翻译</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1354" />
+        <location filename="../ui/canvas.py" line="1352" />
+        <source>OCR</source>
+        <translation>OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1357" />
+        <source>OCR and translate</source>
+        <translation>OCR并翻译</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1362" />
+        <source>OCR, translate and inpaint</source>
+        <translation>OCR，翻译并抹字</translation>
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1367" />
         <source>Inpaint</source>
         <translation>图像修复</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1360" />
+        <location filename="../ui/canvas.py" line="1384" />
         <source>Download image</source>
         <translation>下载图片</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1361" />
+        <location filename="../ui/canvas.py" line="1385" />
         <source>With text (result)</source>
         <translation>带文字（结果）</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1362" />
+        <location filename="../ui/canvas.py" line="1386" />
         <source>Save current page as image with translated text rendered (inpainted + text layer).</source>
         <translation>将当前页面保存为带有渲染翻译文本的图像（修复+文本层）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1363" />
+        <location filename="../ui/canvas.py" line="1387" />
         <source>Inpainted only (no text)</source>
         <translation>仅修复（无文字）</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1364" />
+        <location filename="../ui/canvas.py" line="1388" />
         <source>Save inpainted image only (text regions filled, no text overlay).</source>
         <translation>仅保存修复的图像（填充文本区域，无文本覆盖）。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1365" />
+        <location filename="../ui/canvas.py" line="1389" />
         <source>Original</source>
         <translation>原来的</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1366" />
+        <location filename="../ui/canvas.py" line="1390" />
         <source>Save original image without translation or inpainting.</source>
         <translation>保存原始图像，无需翻译或修复。</translation>
     </message>
     <message>
-        <location filename="../ui/canvas.py" line="1392" />
+        <location filename="../ui/canvas.py" line="1397" />
+        <source>Pin quick actions</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/canvas.py" line="1426" />
         <source>Configure menu...</source>
         <translation>配置菜单...</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ColorPickerLabel</name>
+    <message>
+        <location filename="../ui/custom_widget/label.py" line="64" />
+        <source>Apply Color</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ConfigPanel</name>
+    <message>
+        <location filename="../ui/configpanel.py" line="410" />
+        <source>DL Module</source>
+        <translation>自动化模组</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="411" />
+        <source>General</source>
+        <translation>常规</translation>
+    </message>
     <message>
         <location filename="../ui/configpanel.py" line="413" />
         <source>Text Detection</source>
         <translation>文本检测</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="414" />
         <location filename="../ui/configpanel.py" line="622" />
+        <location filename="../ui/configpanel.py" line="414" />
         <source>OCR</source>
         <translation>OCR</translation>
     </message>
@@ -875,123 +817,24 @@
         <translation>翻译器</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="427" />
-        <source>Image upscaling</source>
-        <translation>图像放大</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="617" />
-        <source>Detector</source>
-        <translation>检测器</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="626" />
-        <source>Inpainter</source>
-        <translation>修复工具</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="410" />
-        <source>DL Module</source>
-        <translation>自动化模组</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="411" />
-        <source>General</source>
-        <translation>常规</translation>
-    </message>
-    <message>
         <location filename="../ui/configpanel.py" line="417" />
         <source>Startup</source>
         <translation>启动</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="635" />
-        <source>Reopen last project on startup</source>
-        <translation>启动时打开上次项目</translation>
+        <location filename="../ui/configpanel.py" line="418" />
+        <source>Display</source>
+        <translation>显示</translation>
     </message>
     <message>
-        <source>Lettering</source>
-        <translation type="obsolete">嵌字</translation>
+        <location filename="../ui/configpanel.py" line="419" />
+        <source>Typesetting</source>
+        <translation>嵌字</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="826" />
-        <source>decide by program</source>
-        <translation>由程序决定</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="827" />
-        <source>use global setting</source>
-        <translation>使用全局设置</translation>
-    </message>
-    <message>
-        <source>font size</source>
-        <translation type="obsolete">字体大小</translation>
-    </message>
-    <message>
-        <source>stroke</source>
-        <translation type="obsolete">轮廓</translation>
-    </message>
-    <message>
-        <source>font &amp; stroke color</source>
-        <translation type="obsolete">字体与轮廓颜色</translation>
-    </message>
-    <message>
-        <source>alignment</source>
-        <translation type="obsolete">对齐方式</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="898" />
-        <source>Auto layout</source>
-        <translation>横排自动排版</translation>
-    </message>
-    <message>
-        <source>Split translation into multi-lines according to the extracted balloon region. The font size will be adaptively resized if it is set to "decide by program."</source>
-        <translation type="obsolete">自动断句并分行.</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1092" />
-        <source>To uppercase</source>
-        <translation>小写转大写</translation>
-    </message>
-    <message>
-        <source>effect</source>
-        <translation type="obsolete">特效</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="422" />
-        <source>SalaDict</source>
-        <translation>沙拉查词</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1137" />
-        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
-        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict_chs.md"&gt;安装说明&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1141" />
-        <source>Show mini menu when selecting text.</source>
-        <translation>选择文本时显示迷你菜单</translation>
-    </message>
-    <message>
-        <source>shortcut</source>
-        <translation type="obsolete">快捷键</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1150" />
-        <source>Search Engines</source>
-        <translation>搜索引擎</translation>
-    </message>
-    <message>
-        <source>stroke size</source>
-        <translation type="obsolete">轮廓大小</translation>
-    </message>
-    <message>
-        <source>font color</source>
-        <translation type="obsolete">字体颜色</translation>
-    </message>
-    <message>
-        <source>stroke color</source>
-        <translation type="obsolete">轮廓颜色</translation>
+        <location filename="../ui/configpanel.py" line="420" />
+        <source>OCR result</source>
+        <translation>OCR 结果</translation>
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="421" />
@@ -999,67 +842,24 @@
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="653" />
-        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
-        <translation>用于测试和调试。启用后：(1) 检测器/OCR/转换器下拉列表显示所有模块，包括尚未下载或不兼容的模块。 (2) Console/py.exe窗口显示更多日志输出（DEBUG和第三方INFO）。禁用时：仅列出即用型模块，并且控制台显示 INFO 及以上内容。</translation>
+        <location filename="../ui/configpanel.py" line="422" />
+        <source>SalaDict</source>
+        <translation>沙拉查词</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="837" />
-        <source>Font Size</source>
-        <translation>大小</translation>
+        <location filename="../ui/configpanel.py" line="423" />
+        <source>Canvas</source>
+        <translation>画布</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="841" />
-        <source>Stroke Size</source>
-        <translation>轮廓大小</translation>
+        <location filename="../ui/configpanel.py" line="424" />
+        <source>Integrations</source>
+        <translation>集成</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="845" />
-        <source>Font Color</source>
-        <translation>字体颜色</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="848" />
-        <source>Stroke Color</source>
-        <translation>轮廓颜色</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="882" />
-        <source>Effect</source>
-        <translation>特效</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="885" />
-        <source>Alignment</source>
-        <translation>对齐方式</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1109" />
-        <source>Result image format</source>
-        <translation>结果图格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1115" />
-        <source>Quality</source>
-        <translation>质量</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1147" />
-        <source>Shortcut</source>
-        <translation>快捷键</translation>
-    </message>
-    <message>
-        <source>Split translation into multi-lines according to the extracted balloon region.</source>
-        <translation type="vanished">自动断句并分行</translation>
-    </message>
-    <message>
-        <source>Adjust font size adaptively if it is set to "decide by program."</source>
-        <translation type="obsolete">自动排版时调整字体大小</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="889" />
-        <source>Writing-mode</source>
-        <translation>书写方向</translation>
+        <location filename="../ui/configpanel.py" line="427" />
+        <source>Image upscaling</source>
+        <translation>图像放大</translation>
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="443" />
@@ -1072,53 +872,8 @@
         <translation>按需加载模型以节省内存</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="456" />
-        <source>Empty cache after RUN</source>
-        <translation>RUN后清空缓存</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="456" />
-        <source>Empty cache after RUN to save memory.</source>
-        <translation>RUN后清空缓存以节省内存</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="518" />
-        <source>Unload All Models</source>
-        <translation>清空已载入的模型</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="892" />
-        <source>Keep existing</source>
-        <translation>保留已有格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="892" />
-        <source>Always use global setting</source>
-        <translation>总是使用全局设置</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="892" />
-        <source>Font Family</source>
-        <translation>字体</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="419" />
-        <source>Typesetting</source>
-        <translation>嵌字</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1095" />
-        <source>Independent text styles for each projects</source>
-        <translation>在每个项目下建立独立的字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="1098" />
-        <source>Show only custom fonts</source>
-        <translation>只显示 fonts 文件夹下的字体</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="449" />
         <location filename="../ui/configpanel.py" line="452" />
+        <location filename="../ui/configpanel.py" line="449" />
         <source>Default (use module default)</source>
         <translation>默认（使用模块默认）</translation>
     </message>
@@ -1131,6 +886,16 @@
         <location filename="../ui/configpanel.py" line="454" />
         <source>Preferred device for DL modules when set to Default.</source>
         <translation>设为默认时，DL 模块优先使用的设备。</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN</source>
+        <translation>RUN后清空缓存</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="456" />
+        <source>Empty cache after RUN to save memory.</source>
+        <translation>RUN后清空缓存以节省内存</translation>
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="460" />
@@ -1213,9 +978,14 @@
         <translation>仅当页面至少有这么多块时才执行合并（避免合并正常气泡布局；默认 18）。</translation>
     </message>
     <message>
+        <location filename="../ui/configpanel.py" line="518" />
+        <source>Unload All Models</source>
+        <translation>清空已载入的模型</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1400" />
+        <location filename="../ui/configpanel.py" line="1394" />
         <location filename="../ui/configpanel.py" line="523" />
-        <location filename="../ui/configpanel.py" line="1375" />
-        <location filename="../ui/configpanel.py" line="1381" />
         <source>Check / Download module files</source>
         <translation>检查/下载模块文件</translation>
     </message>
@@ -1225,10 +995,10 @@
         <translation>检查并下载所有检测器、OCR、修复、翻译所需模型文件。模块加载失败时可运行此项。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="530" />
-        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="735" />
         <location filename="../ui/configpanel.py" line="610" />
-        <location filename="../ui/configpanel.py" line="722" />
+        <location filename="../ui/configpanel.py" line="603" />
+        <location filename="../ui/configpanel.py" line="530" />
         <source>Off</source>
         <translation>关</translation>
     </message>
@@ -1363,29 +1133,24 @@
         <translation>当 &gt;0 时，每 N 块将中间结果写入临时文件，以降低长页峰值内存/显存（如 8 或 12）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="418" />
-        <source>Display</source>
-        <translation>显示</translation>
+        <location filename="../ui/configpanel.py" line="617" />
+        <source>Detector</source>
+        <translation>检测器</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="420" />
-        <source>OCR result</source>
-        <translation>OCR 结果</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="423" />
-        <source>Canvas</source>
-        <translation>画布</translation>
-    </message>
-    <message>
-        <location filename="../ui/configpanel.py" line="424" />
-        <source>Integrations</source>
-        <translation>集成</translation>
+        <location filename="../ui/configpanel.py" line="626" />
+        <source>Inpainter</source>
+        <translation>修复工具</translation>
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="634" />
         <source>Reopen last project, confirm before run, recent list limit.</source>
         <translation>启动时打开上次项目、运行前确认、最近列表数量。</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="635" />
+        <source>Reopen last project on startup</source>
+        <translation>启动时打开上次项目</translation>
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="639" />
@@ -1409,624 +1174,754 @@
     </message>
     <message>
         <location filename="../ui/configpanel.py" line="651" />
+        <source>Show model download result popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="652" />
+        <source>When enabled, show the model package download summary dialog after startup downloads. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="657" />
+        <source>Show startup health popup on startup</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="658" />
+        <source>When enabled, show startup stages/diagnostics popup on launch. Disable to suppress this popup.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="664" />
         <source>Dev mode (show all modules)</source>
         <translation>开发模式（显示全部模块）</translation>
     </message>
     <message>
-        <source>Show all modules including experimental or deprecated ones in module lists.</source>
-        <translation type="vanished">在模块列表中显示所有模块，包括实验性或已弃用的。</translation>
+        <location filename="../ui/configpanel.py" line="665" />
+        <source>For testing and debugging. When enabled: (1) Detector / OCR / translator dropdowns show all modules, including not-yet-downloaded or incompatible. (2) Console/py.exe window shows more log output (DEBUG and third-party INFO). When disabled: only ready-to-use modules are listed and console shows INFO and above.</source>
+        <translation>用于测试和调试。启用后：(1) 检测器/OCR/转换器下拉列表显示所有模块，包括尚未下载或不兼容的模块。 (2) Console/py.exe窗口显示更多日志输出（DEBUG和第三方INFO）。禁用时：仅列出即用型模块，并且控制台显示 INFO 及以上内容。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="662" />
+        <location filename="../ui/configpanel.py" line="675" />
         <source>Recent projects limit (5–30)</source>
         <translation>最近项目数量上限（5–30）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="662" />
+        <location filename="../ui/configpanel.py" line="675" />
         <source>Maximum number of recent projects in the list.</source>
         <translation>最近项目列表中显示的最大数量。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="666" />
+        <location filename="../ui/configpanel.py" line="679" />
         <source>Confirm before Run</source>
         <translation>运行前确认</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="666" />
+        <location filename="../ui/configpanel.py" line="679" />
         <source>Show Run / Continue / Cancel dialog when clicking Run.</source>
         <translation>点击运行时显示“运行 / 继续 / 取消”对话框。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="670" />
+        <location filename="../ui/configpanel.py" line="683" />
         <source>Manual mode</source>
         <translation>手动模式</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="671" />
+        <location filename="../ui/configpanel.py" line="684" />
         <source>When on, Run processes the current page only (comic-translate style). Useful for step-by-step workflow.</source>
         <translation>开启后，运行仅处理当前页（漫画翻译风格）。适合逐步工作流。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="676" />
+        <location filename="../ui/configpanel.py" line="689" />
         <source>Skip ignored pages in run</source>
         <translation>运行时跳过已忽略页面</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="677" />
+        <location filename="../ui/configpanel.py" line="690" />
         <source>When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.</source>
         <translation>启用后，完整运行和批处理队列会跳过页面列表上下文菜单中标记为“运行时忽略”的页面。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="682" />
+        <location filename="../ui/configpanel.py" line="695" />
         <source>Never</source>
         <translation>从不</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="683" />
+        <location filename="../ui/configpanel.py" line="696" />
         <source>After run: on all pages</source>
         <translation>运行后：全部页面</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="684" />
+        <location filename="../ui/configpanel.py" line="697" />
         <source>After run: on current page only</source>
         <translation>运行后：仅当前页</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="688" />
+        <location filename="../ui/configpanel.py" line="701" />
         <source>After Run: Region merge</source>
         <translation>运行后：区域合并</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="689" />
+        <location filename="../ui/configpanel.py" line="702" />
         <source>Automatically run the Region merge tool after a pipeline run. Uses settings from Tools → Region merge tool.</source>
         <translation>流水线运行结束后自动执行区域合并工具，使用“工具 → 区域合并工具”中的设置。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="698" />
+        <location filename="../ui/configpanel.py" line="711" />
         <source>Dark mode</source>
         <translation>深色模式</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="699" />
+        <location filename="../ui/configpanel.py" line="712" />
         <source>Use dark theme. Restart or toggle View → Dark Mode to apply fully.</source>
         <translation>使用深色主题。重启或切换“视图 → 深色模式”可完全生效。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="710" />
+        <location filename="../ui/configpanel.py" line="723" />
         <source>Bubbly UI</source>
         <translation>Bubbly 界面</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="711" />
+        <location filename="../ui/configpanel.py" line="724" />
         <source>Rounder corners, gradients, softer look. Same as View → Bubbly UI.</source>
         <translation>圆角更大、渐变更明显、观感更柔和。等同于“视图 → Bubbly UI”。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="725" />
+        <location filename="../ui/configpanel.py" line="738" />
         <source>Smooth scroll (ms)</source>
         <translation>平滑滚动（毫秒）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="726" />
+        <location filename="../ui/configpanel.py" line="739" />
         <source>Animate scroll position on wheel for an enhanced feel. 0 = off. 80–200 = subtle. Applies to config and dialogs.</source>
         <translation>滚轮滚动时启用平滑动画。0=关闭，80–200 为轻度效果。应用于配置面板和对话框。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="736" />
+        <location filename="../ui/configpanel.py" line="749" />
         <source>Motion blur on scroll</source>
         <translation>滚动动态模糊</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="737" />
+        <location filename="../ui/configpanel.py" line="750" />
         <source>Briefly blur content during scroll (can be costly on some systems).</source>
         <translation>滚动时短暂模糊内容（部分系统开销较大）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="748" />
+        <location filename="../ui/configpanel.py" line="761" />
         <source>Reduce motion</source>
         <translation>减少动画</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="749" />
+        <location filename="../ui/configpanel.py" line="762" />
         <source>Shorter or no UI animations (accessibility / preference).</source>
         <translation>缩短或禁用界面动画（无障碍/偏好）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="759" />
+        <location filename="../ui/configpanel.py" line="772" />
         <source>Path to cursor image (.png, .cur)</source>
         <translation>光标图片路径（.png, .cur）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="762" />
+        <location filename="../ui/configpanel.py" line="775" />
         <source>Browse...</source>
         <translation>浏览...</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="771" />
+        <location filename="../ui/configpanel.py" line="784" />
         <source>Use custom cursor</source>
         <translation>使用自定义光标</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="772" />
+        <location filename="../ui/configpanel.py" line="785" />
         <source>Use a custom mouse cursor from file. Set path below.</source>
         <translation>使用文件中的自定义鼠标光标，请在下方设置路径。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="780" />
+        <location filename="../ui/configpanel.py" line="793" />
         <source>Custom cursor path</source>
         <translation>自定义光标路径</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="781" />
+        <location filename="../ui/configpanel.py" line="794" />
         <source>PNG or CUR file. Applied when "Use custom cursor" is on.</source>
         <translation>PNG 或 CUR 文件。在“使用自定义光标”开启时生效。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="792" />
+        <location filename="../ui/configpanel.py" line="805" />
         <source>Display language</source>
         <translation>界面语言</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="792" />
+        <location filename="../ui/configpanel.py" line="805" />
         <source>UI language. Same as View → Display Language.</source>
         <translation>界面语言。等同于“视图 → 界面语言”。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="800" />
+        <location filename="../ui/configpanel.py" line="813" />
         <source>Config panel font scale (0.8–1.5)</source>
         <translation>配置面板字体缩放（0.8–1.5）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="800" />
+        <location filename="../ui/configpanel.py" line="813" />
         <source>Scale font size in this Config panel. Reopen Config to apply.</source>
         <translation>调整本配置面板的字体大小。需重新打开配置面板后生效。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="806" />
+        <location filename="../ui/configpanel.py" line="819" />
         <source>System default</source>
         <translation>系统默认</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="807" />
+        <location filename="../ui/configpanel.py" line="820" />
         <source>Logical DPI (restart to apply)</source>
         <translation>逻辑 DPI（重启生效）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="807" />
+        <location filename="../ui/configpanel.py" line="820" />
         <source>0 = use system. Use 96 or 72 if font scaling is wrong.</source>
         <translation>0=使用系统值。若字体缩放异常，可尝试 96 或 72。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="813" />
+        <location filename="../ui/configpanel.py" line="826" />
         <source>Auto fit to box</source>
         <translation>自动适应框</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="814" />
+        <location filename="../ui/configpanel.py" line="827" />
         <source>Fixed size (use font size list)</source>
         <translation>固定大小（使用字号列表）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="817" />
+        <location filename="../ui/configpanel.py" line="830" />
         <source>Text in box</source>
         <translation>框内文字</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="818" />
+        <location filename="../ui/configpanel.py" line="831" />
         <source>How text is fitted in each text box. Auto fit scales font size so text fits the box while keeping line structure (see issue #1077). Fixed size uses the font size list below.</source>
         <translation>文字在文本框中的适配方式。自动适应会缩放字号使文字贴合框并保持行结构（见 #1077）。固定大小使用下方字号列表。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="822" />
+        <location filename="../ui/configpanel.py" line="835" />
         <source>Auto fit: program decides font size so text fits the balloon. Fixed: use the font size list.</source>
         <translation>自动适应：程序根据气泡决定字号。固定：使用字号列表。</translation>
     </message>
     <message>
+        <location filename="../ui/configpanel.py" line="839" />
+        <source>decide by program</source>
+        <translation>由程序决定</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="840" />
+        <source>use global setting</source>
+        <translation>使用全局设置</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="850" />
+        <source>Font Size</source>
+        <translation>大小</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="854" />
+        <source>Stroke Size</source>
+        <translation>轮廓大小</translation>
+    </message>
+    <message>
         <location filename="../ui/configpanel.py" line="858" />
+        <source>Font Color</source>
+        <translation>字体颜色</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="861" />
+        <source>Stroke Color</source>
+        <translation>轮廓颜色</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="871" />
         <source>Default stroke width</source>
         <translation>默认描边宽度</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="858" />
+        <location filename="../ui/configpanel.py" line="871" />
         <source>Global default when "use global setting" is selected for Stroke Size. 0 = no stroke.</source>
         <translation>描边大小选“使用全局设置”时的全局默认。0 = 无描边。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="870" />
+        <location filename="../ui/configpanel.py" line="883" />
         <source>Default box corner radius</source>
         <translation>默认文本框圆角</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="871" />
+        <location filename="../ui/configpanel.py" line="884" />
         <source>0 = square/rectangle. &gt;0 = rounded rectangle; for circle-like boxes use a large value (radius ≈ half of box size). Applies to newly created text boxes.</source>
         <translation>0 = 正方形/矩形。 &gt;0 = 圆角矩形；对于圆形盒子，请使用较大的值（半径 ≈ 盒子尺寸的一半）。适用于新创建的文本框。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="879" />
-        <location filename="../ui/configpanel.py" line="1407" />
+        <location filename="../ui/configpanel.py" line="1426" />
+        <location filename="../ui/configpanel.py" line="892" />
         <source>Default stroke color</source>
         <translation>默认描边颜色</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="879" />
+        <location filename="../ui/configpanel.py" line="892" />
         <source>Global default when "use global setting" is selected for Stroke Color.</source>
         <translation>描边颜色选“使用全局设置”时的全局默认。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="899" />
+        <location filename="../ui/configpanel.py" line="895" />
+        <source>Effect</source>
+        <translation>特效</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="898" />
+        <source>Alignment</source>
+        <translation>对齐方式</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="902" />
+        <source>Writing-mode</source>
+        <translation>书写方向</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Keep existing</source>
+        <translation>保留已有格式</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Always use global setting</source>
+        <translation>总是使用全局设置</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="905" />
+        <source>Font Family</source>
+        <translation>字体</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="911" />
+        <source>Auto layout</source>
+        <translation>横排自动排版</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="912" />
         <source>When on: scale font size to fit the speech bubble and wrap lines to the balloon shape. When off: use global font size and still wrap to the balloon (text may overflow if too long). Works with "Text in box" = Auto fit to box.</source>
         <translation>启用时：缩放字体大小以适合对话气泡，并将换行线适应气球形状。关闭时：使用全局字体大小并仍然换行到气球（如果文本太长，文本可能会溢出）。与“框中的文本”一起使用=自动适应框。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="904" />
+        <location filename="../ui/configpanel.py" line="917" />
         <source>Constrain text box to bubble</source>
         <translation>将文本框限制为气泡</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="905" />
+        <location filename="../ui/configpanel.py" line="918" />
         <source>Keep the text box size within the detected bubble and do not move it. When on, the box will not grow past the bubble or shift position after layout.</source>
         <translation>将文本框大小保持在检测到的气泡内，并且不要移动它。启用此选项后，框将不会超出气泡或在布局后移动位置。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="910" />
+        <location filename="../ui/configpanel.py" line="923" />
         <source>Center in bubble after auto layout</source>
         <translation>自动布局后气泡居中</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="911" />
+        <location filename="../ui/configpanel.py" line="924" />
         <source>After auto layout, move each text box so its center aligns with the bubble center. Skips boxes that are close to another (combined/overlapping bubbles).</source>
         <translation>自动布局后，移动每个文本框，使其中心与气泡中心对齐。跳过靠近另一个的框（组合/重叠的气泡）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="922" />
+        <location filename="../ui/configpanel.py" line="935" />
         <source>Center in bubble: skip if another box within (px)</source>
         <translation>气泡中心：如果 (px) 内有另一个框，则跳过</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="923" />
+        <location filename="../ui/configpanel.py" line="936" />
         <source>Do not center a box if another text box is within this many pixels (avoids pulling multiple boxes to the same spot in combined bubbles).</source>
         <translation>如果另一个文本框位于这么多像素内，请勿将框居中（避免将多个框拉到组合气泡中的同一位置）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="927" />
+        <location filename="../ui/configpanel.py" line="940" />
         <source>Check overflow after layout</source>
         <translation>布局后检查溢出</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="928" />
+        <location filename="../ui/configpanel.py" line="941" />
         <source>After layout, check if the text box or lines extend outside the bubble. Shrink box to bubble and/or scale font down to fix (no model).</source>
         <translation>布局后，检​​查文本框或线条是否延伸到气泡之外。缩小框以气泡和/或缩小字体以修复（无模型）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="932" />
+        <location filename="../ui/configpanel.py" line="945" />
         <source>Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.</source>
         <translation>使用“内置”进行零样本 CLIP 或 Hugging Face 模型 ID。留空以跳过。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="936" />
+        <location filename="../ui/configpanel.py" line="949" />
         <source>Box size check model ID (secondary)</source>
         <translation>盒子尺寸检查型号ID（次要）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="937" />
+        <location filename="../ui/configpanel.py" line="950" />
         <source>Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.</source>
         <translation>内置：使用“内置”（零镜头 CLIP）。自定义：带有标签too_large、too_small、ok 的图像分类模型。空 = 仅几何检查。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="941" />
+        <location filename="../ui/configpanel.py" line="954" />
         <source>Optimal line breaks</source>
         <translation>最佳换行符</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="942" />
+        <location filename="../ui/configpanel.py" line="955" />
         <source>Use dynamic programming to choose better line breaks (non-CJK). Reduces awkward mid-word wraps.</source>
         <translation>使用动态规划来选择更好的换行符（非 CJK）。减少尴尬的单词中间换行。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="947" />
+        <location filename="../ui/configpanel.py" line="960" />
         <source>Hyphenation</source>
         <translation>连字符</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="948" />
+        <location filename="../ui/configpanel.py" line="961" />
         <source>Allow hyphenation when breaking long words (non-CJK). Works with Optimal line breaks.</source>
         <translation>断开长单词（非 CJK）时允许使用连字符。适用于最佳换行符。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="953" />
+        <location filename="../ui/configpanel.py" line="966" />
         <source>Optimize line breaks (fewer lines)</source>
         <translation>优化换行符（更少的行数）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="954" />
+        <location filename="../ui/configpanel.py" line="967" />
         <source>Try slightly larger font / fewer lines so text fits with fewer breaks. Experimental.</source>
         <translation>尝试稍大的字体/更少的行，这样文本就可以减少中断。实验性的。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="967" />
+        <location filename="../ui/configpanel.py" line="980" />
         <source>Short line penalty</source>
         <translation>短线罚则</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="968" />
+        <location filename="../ui/configpanel.py" line="981" />
         <source>Penalty per very short non-final line in auto layout (higher = avoid 1–2 word stub lines).</source>
         <translation>自动布局中每条非常短的非最终行的惩罚（较高 = 避免 1-2 个字短线）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="980" />
+        <location filename="../ui/configpanel.py" line="993" />
         <source>Height overflow penalty</source>
         <translation>高度溢出惩罚</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="981" />
+        <location filename="../ui/configpanel.py" line="994" />
         <source>When a layout would exceed bubble height, this penalty is applied. Lower (e.g. 400–500) = fewer lines, larger font, allow some overflow. Higher (e.g. 1000+) = strict fit, more lines, smaller font.</source>
         <translation>当布局超过气泡高度时，将应用此惩罚。较低（例如 400–500）= 更少的行，更大的字体，允许一些溢出。更高（例如 1000+）= 严格配合、更多线条、更小的字体。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="994" />
+        <location filename="../ui/configpanel.py" line="1007" />
         <source>Layout font size min (pt)</source>
         <translation>布局最小字体大小（pt）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="995" />
+        <location filename="../ui/configpanel.py" line="1008" />
         <source>Minimum font size (points) for auto layout. Text will not be scaled below this.</source>
         <translation>自动布局的最小字体大小（点）。文本的缩放比例不会低于此值。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1005" />
+        <location filename="../ui/configpanel.py" line="1018" />
         <source>Layout font size max (pt)</source>
         <translation>布局字体大小最大 (pt)</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1006" />
+        <location filename="../ui/configpanel.py" line="1019" />
         <source>Maximum font size (points) for auto layout. Prevents text from growing too large.</source>
         <translation>自动布局的最大字体大小（点）。防止文本变得太大。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1009" />
+        <location filename="../ui/configpanel.py" line="1022" />
         <source>Scale font to fit bubble</source>
         <translation>缩放字体以适合气泡</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1010" />
+        <location filename="../ui/configpanel.py" line="1023" />
         <source>When on, scale laid-out text to fit inside the bubble (ratio-based); when off, only apply line-break scaling. Font size is always clamped to min/max above.</source>
         <translation>启用后，缩放布局文本以适合气泡内部（基于比例）；关闭时，仅应用换行缩放。字体大小始终固定为上面的最小/最大。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1014" />
+        <location filename="../ui/configpanel.py" line="1027" />
         <source>Binary search font size</source>
         <translation>二分查找字体大小</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1015" />
+        <location filename="../ui/configpanel.py" line="1028" />
         <source>Find the largest font size that fits the bubble by trying multiple sizes (more accurate, slower). Only when "Scale font to fit bubble" is on and non-CJK.</source>
         <translation>通过尝试多种尺寸找到适合气泡的最大字体尺寸（更准确，更慢）。仅当“缩放字体以适合气泡”打开且非 CJK 时。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1021" />
+        <location filename="../ui/configpanel.py" line="1034" />
         <source>Auto</source>
         <translation>汽车</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1021" />
+        <location filename="../ui/configpanel.py" line="1034" />
         <source>Round</source>
         <translation>圆形的</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1021" />
+        <location filename="../ui/configpanel.py" line="1034" />
         <source>Elongated</source>
         <translation>拉长型</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1021" />
+        <location filename="../ui/configpanel.py" line="1034" />
         <source>Narrow</source>
         <translation>狭窄的</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1022" />
+        <location filename="../ui/configpanel.py" line="1035" />
         <source>Diamond</source>
         <translation>钻石</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1022" />
+        <location filename="../ui/configpanel.py" line="1035" />
         <source>Square</source>
         <translation>正方形</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1022" />
+        <location filename="../ui/configpanel.py" line="1035" />
         <source>Bevel</source>
         <translation>斜角</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1022" />
+        <location filename="../ui/configpanel.py" line="1035" />
         <source>Pentagon</source>
         <translation>五角大楼</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1022" />
+        <location filename="../ui/configpanel.py" line="1035" />
         <source>Point</source>
         <translation>观点</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1024" />
+        <location filename="../ui/configpanel.py" line="1037" />
         <source>Balloon shape (Diamond-Text)</source>
         <translation>气球形状（菱形文本）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1025" />
+        <location filename="../ui/configpanel.py" line="1038" />
         <source>Hint for bubble shape: Auto detects from aspect ratio; other options set insets and line-length scoring (e.g. round/square/bevel = more uniform line lengths).</source>
         <translation>气泡形状提示：根据长宽比自动检测；其他选项设置插图和线长评分（例如圆形/方形/斜角=更统一的线长）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1031" />
+        <location filename="../ui/configpanel.py" line="1044" />
         <source>Aspect ratio only</source>
         <translation>仅纵横比</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1032" />
+        <location filename="../ui/configpanel.py" line="1045" />
         <source>Contour only</source>
         <translation>仅轮廓</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1033" />
+        <location filename="../ui/configpanel.py" line="1046" />
         <source>Model only</source>
         <translation>仅型号</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1034" />
+        <location filename="../ui/configpanel.py" line="1047" />
         <source>Model, then contour</source>
         <translation>模型，然后轮廓</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1035" />
+        <location filename="../ui/configpanel.py" line="1048" />
         <source>Model, then aspect ratio</source>
         <translation>模型，然后是长宽比</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1036" />
+        <location filename="../ui/configpanel.py" line="1049" />
         <source>Contour, then aspect ratio</source>
         <translation>轮廓，然后纵横比</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1037" />
+        <location filename="../ui/configpanel.py" line="1050" />
         <source>Model, then contour, then aspect ratio</source>
         <translation>模型，然后轮廓，然后纵横比</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1039" />
+        <location filename="../ui/configpanel.py" line="1052" />
         <source>Auto shape method</source>
         <translation>自动形状法</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1040" />
+        <location filename="../ui/configpanel.py" line="1053" />
         <source>When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).</source>
         <translation>当气球形状为自动时，使用哪种方法。轮廓 = 基于掩模 (OpenCV)。模型 = HF 图像分类（在下面设置模型 ID）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1044" />
+        <location filename="../ui/configpanel.py" line="1057" />
         <source>Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny</source>
         <translation>默认值：prithivMLmods/几何形状分类 (92.9M)。打火机：0-ma/vit-geometric-shapes-tiny</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1048" />
+        <location filename="../ui/configpanel.py" line="1061" />
         <source>Balloon shape model ID</source>
         <translation>气球形状型号ID</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1049" />
+        <location filename="../ui/configpanel.py" line="1062" />
         <source>Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.</source>
         <translation>默认为 prithivMLmods/Geometric-Shapes-Classification（SigLIP2-base，92.9M 参数，8 个形状，~99% 准确度）。使用 0-ma/vit-geometric-shapes-tiny 来获得更轻的 5.5M 模型。当模型显示为方形时，宽气泡被迫变成椭圆形。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1059" />
+        <location filename="../ui/configpanel.py" line="1072" />
         <source>Minimum line width (px)</source>
         <translation>最小线宽（像素）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1060" />
+        <location filename="../ui/configpanel.py" line="1073" />
         <source>Layout never uses a narrower line width; avoids short text (e.g. "pluck!") breaking into 2–3 character lines.</source>
         <translation>布局从不使用较窄的线宽；避免短文本（例如“pluck！”）分成 2-3 个字符行。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1071" />
+        <location filename="../ui/configpanel.py" line="1084" />
         <source>Max line width fraction (no bubble)</source>
         <translation>最大线宽分数（无气泡）</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1072" />
+        <location filename="../ui/configpanel.py" line="1085" />
         <source>For text boxes outside bubbles: max line width = box width × this. Lower values give more, shorter lines (e.g. 0.78).</source>
         <translation>对于气泡外的文本框：最大线宽 = 框宽 × this。值越低，线条越多、越短（例如 0.78）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1083" />
+        <location filename="../ui/configpanel.py" line="1096" />
         <source>1-word line penalty</source>
         <translation>1字行罚分</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1084" />
+        <location filename="../ui/configpanel.py" line="1097" />
         <source>Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).</source>
         <translation>在布局评分中，对单独一行上的单个单词进行处罚（较高=强烈避免，例如单独使用“the”）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1087" />
+        <location filename="../ui/configpanel.py" line="1100" />
         <source>Translation panel: preserve line breaks</source>
         <translation>翻译面板：保留换行符</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1088" />
+        <location filename="../ui/configpanel.py" line="1101" />
         <source>When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).</source>
         <translation>启用后，翻译面板不会按宽度换行，因此换行符与画布气泡匹配（渲染奇偶校验）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1103" />
+        <location filename="../ui/configpanel.py" line="1105" />
+        <source>To uppercase</source>
+        <translation>小写转大写</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1108" />
+        <source>Independent text styles for each projects</source>
+        <translation>在每个项目下建立独立的字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1111" />
+        <source>Show only custom fonts</source>
+        <translation>只显示 fonts 文件夹下的字体</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1116" />
         <source>Spell check / Auto-correct OCR result</source>
         <translation>拼写检查 / 自动纠正 OCR 结果</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1104" />
+        <location filename="../ui/configpanel.py" line="1117" />
         <source>After OCR runs, correct misspelled words using a spell checker when there is a single suggestion (e.g. "teh" → "the"). Requires pyenchant and a system dictionary (e.g. en_US). Enable this in General to auto-correct OCR text.</source>
         <translation>OCR 运行后，当拼写检查器有单一建议时自动纠正拼写（如 "teh" → "the"）。需要 pyenchant 和系统词典（如 en_US）。在常规中启用以自动纠正 OCR 文本。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1120" />
+        <location filename="../ui/configpanel.py" line="1122" />
+        <source>Result image format</source>
+        <translation>结果图格式</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1128" />
+        <source>Quality</source>
+        <translation>质量</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1133" />
         <source>WebP lossless</source>
         <translation>WebP 无损</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1121" />
+        <location filename="../ui/configpanel.py" line="1134" />
         <source>Use lossless WebP when result format is WebP (ignores quality).</source>
         <translation>结果格式为 WebP 时使用无损 WebP（忽略质量）。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1125" />
+        <location filename="../ui/configpanel.py" line="1138" />
         <source>Intermediate image format</source>
         <translation>中间图像格式</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1129" />
+        <location filename="../ui/configpanel.py" line="1142" />
         <source>Context menu options...</source>
         <translation>右键菜单选项...</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1130" />
+        <location filename="../ui/configpanel.py" line="1143" />
         <source>Choose which actions appear in the canvas right-click menu.</source>
         <translation>选择画布右键菜单中显示的操作。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1132" />
+        <location filename="../ui/configpanel.py" line="1145" />
         <source>Right-click menu</source>
         <translation>右键菜单</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1132" />
+        <location filename="../ui/configpanel.py" line="1145" />
         <source>Same as View → Context menu options. Show or hide actions in the canvas context menu by category.</source>
         <translation>同“视图 → 右键菜单选项”。按类别显示或隐藏画布右键菜单动作。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1287" />
+        <location filename="../ui/configpanel.py" line="1150" />
+        <source>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict.md"&gt;Installation guide&lt;/a&gt;</source>
+        <translation>&lt;a href="https://github.com/dmMaze/BallonsTranslator/tree/master/doc/saladict_chs.md"&gt;安装说明&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1154" />
+        <source>Show mini menu when selecting text.</source>
+        <translation>选择文本时显示迷你菜单</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1160" />
+        <source>Shortcut</source>
+        <translation>快捷键</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1163" />
+        <source>Search Engines</source>
+        <translation>搜索引擎</translation>
+    </message>
+    <message>
+        <location filename="../ui/configpanel.py" line="1306" />
         <source>Select cursor image</source>
         <translation>选择光标图像</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1289" />
+        <location filename="../ui/configpanel.py" line="1308" />
         <source>Cursor images (*.png *.cur *.ico);;All files (*)</source>
         <translation>光标图像 (*.png *.cur *.ico);;所有文件 (*)</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1376" />
+        <location filename="../ui/configpanel.py" line="1395" />
         <source>Finished. If any module reported missing files, check the console/log and save them to the specified paths, then restart or switch module.</source>
         <translation>完成的。如果有模块报告丢失文件，请检查控制台/日志并将其保存到指定路径，然后重新启动或切换模块。</translation>
     </message>
     <message>
-        <location filename="../ui/configpanel.py" line="1382" />
+        <location filename="../ui/configpanel.py" line="1401" />
         <source>Error: </source>
         <translation>错误：</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ContextMenuConfigDialog</name>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="116" />
+        <location filename="../ui/context_menu_config_dialog.py" line="117" />
         <source>Context Menu Options</source>
         <translation>上下文菜单选项</translation>
     </message>
@@ -2036,42 +1931,83 @@
         <translation>选择画布右键菜单中显示的操作。选中=可见，未选中=隐藏。将项目固定到下面的列表，以将它们显示在菜单顶部（拖动以重新排序）。</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="137" />
+        <location filename="../ui/context_menu_config_dialog.py" line="138" />
         <source>Shown at top of menu (drag to reorder)</source>
         <translation>显示在菜单顶部（拖动即可重新排序）</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="147" />
+        <location filename="../ui/context_menu_config_dialog.py" line="148" />
         <source>Clear all from top</source>
         <translation>从顶部清除所有内容</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="170" />
+        <location filename="../ui/context_menu_config_dialog.py" line="154" />
+        <source>Quick profiles:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="155" />
+        <source>Editing-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="158" />
+        <source>Pipeline-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="161" />
+        <source>Layout-focused</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="185" />
         <source>Pin to top</source>
         <translation>固定到顶部</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="184" />
+        <location filename="../ui/context_menu_config_dialog.py" line="197" />
+        <source>Run macros (JSON list)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="212" />
         <source>Restore defaults</source>
         <translation>恢复默认设置</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="186" />
+        <location filename="../ui/context_menu_config_dialog.py" line="214" />
         <source>OK</source>
         <translation>好的</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="189" />
+        <location filename="../ui/context_menu_config_dialog.py" line="217" />
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../ui/context_menu_config_dialog.py" line="223" />
+        <location filename="../ui/context_menu_config_dialog.py" line="262" />
         <source>Remove from top</source>
         <translation>从顶部移除</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/context_menu_config_dialog.py" line="291" />
+        <source>Invalid run macros JSON</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>DangoSwitch</name>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="155" />
+        <source>On</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/dango_switch.py" line="163" />
+        <source>Off</source>
+        <translation type="unfinished">离开</translation>
+    </message>
+</context><context>
     <name>DrawingPanel</name>
     <message>
         <location filename="../ui/drawingpanel.py" line="350" />
@@ -2103,8 +2039,7 @@
         <source>Mask Opacity</source>
         <translation>蒙版不透明度</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportDocThread</name>
     <message>
         <location filename="../ui/io_thread.py" line="118" />
@@ -2116,8 +2051,7 @@
         <source>Overwrite </source>
         <translation>覆盖</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ExportFormatDialog</name>
     <message>
         <location filename="../ui/export_dialog.py" line="33" />
@@ -2130,9 +2064,9 @@
         <translation>选择文件夹...</translation>
     </message>
     <message>
-        <location filename="../ui/export_dialog.py" line="39" />
-        <location filename="../ui/export_dialog.py" line="68" />
         <location filename="../ui/export_dialog.py" line="108" />
+        <location filename="../ui/export_dialog.py" line="68" />
+        <location filename="../ui/export_dialog.py" line="39" />
         <source>(none)</source>
         <translation>（没有任何）</translation>
     </message>
@@ -2211,8 +2145,7 @@
         <source>ZIP archives (*.zip)</source>
         <translation>ZIP 档案 (*.zip)</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>FontFormatPanel</name>
     <message>
         <location filename="../ui/text_panel.py" line="275" />
@@ -2225,42 +2158,9 @@
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="296" />
-        <source>Change font color</source>
-        <translation>改变文字颜色</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="373" />
-        <source>Change stroke color</source>
-        <translation>改变文字轮廓颜色</translation>
-    </message>
-    <message>
-        <source>Stroke width: </source>
-        <translation type="obsolete">轮廓宽度: </translation>
-    </message>
-    <message>
-        <source>line spacing: </source>
-        <translation type="obsolete">行间距: </translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="414" />
-        <source>Global Font Format</source>
-        <translation>全局字体格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="364" />
-        <source>Stroke</source>
-        <translation>轮廓</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="361" />
-        <source>Change stroke width</source>
-        <translation>修改轮廓宽度</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="386" />
-        <source>Change letter spacing</source>
-        <translation>修改字符间距</translation>
+        <location filename="../ui/text_panel.py" line="282" />
+        <source>Change font size</source>
+        <translation>改变字体大小</translation>
     </message>
     <message>
         <location filename="../ui/text_panel.py" line="292" />
@@ -2268,38 +2168,14 @@
         <translation>修改行距</translation>
     </message>
     <message>
-        <source>Effect</source>
-        <translation type="obsolete">特效</translation>
+        <location filename="../ui/text_panel.py" line="296" />
+        <source>Change font color</source>
+        <translation>改变文字颜色</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="282" />
-        <source>Change font size</source>
-        <translation>改变字体大小</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="461" />
-        <source>Unfold</source>
-        <translation>展开</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="461" />
-        <source>Fold</source>
-        <translation>折叠</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="462" />
-        <source>Source</source>
-        <translation>原文</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="463" />
-        <source>Translation</source>
-        <translation>译文</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="441" />
-        <source>Advanced Text Format</source>
-        <translation>进阶字体格式</translation>
+        <location filename="../ui/text_panel.py" line="313" />
+        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
+        <translation>自动适应块：排版时缩放字号使文字适应边界框。</translation>
     </message>
     <message>
         <location filename="../ui/text_panel.py" line="318" />
@@ -2312,10 +2188,20 @@
         <translation>圆形</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="318" />
         <location filename="../ui/text_panel.py" line="334" />
+        <location filename="../ui/text_panel.py" line="318" />
         <source>Arc</source>
         <translation>弧形</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="319" />
+        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
+        <translation>沿圆或弧绘制文字（如气泡、拟声词）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="327" />
+        <source>Arc span in degrees (for Arc text on path).</source>
+        <translation>弧角度数（用于路径弧形文字）。</translation>
     </message>
     <message>
         <location filename="../ui/text_panel.py" line="334" />
@@ -2338,46 +2224,6 @@
         <translation>旗帜</translation>
     </message>
     <message>
-        <location filename="../ui/text_panel.py" line="400" />
-        <source>Opacity</source>
-        <translation>不透明度</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="423" />
-        <source>Apply to all blocks</source>
-        <translation>应用到全部块</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="426" />
-        <source>Save as default</source>
-        <translation>保存为默认</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="430" />
-        <source>Show Global Font Format</source>
-        <translation>显示全局字体格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="435" />
-        <source>Show Advanced Font Format</source>
-        <translation>显示高级字体格式</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="313" />
-        <source>Auto fit font size to block: scale font so text fits the bounding box when layout runs.</source>
-        <translation>自动适应块：排版时缩放字号使文字适应边界框。</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="319" />
-        <source>Draw text along a circle or arc (e.g. for balloons, SFX).</source>
-        <translation>沿圆或弧绘制文字（如气泡、拟声词）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_panel.py" line="327" />
-        <source>Arc span in degrees (for Arc text on path).</source>
-        <translation>弧角度数（用于路径弧形文字）。</translation>
-    </message>
-    <message>
         <location filename="../ui/text_panel.py" line="336" />
         <source>Photoshop-like text warp (#1093).</source>
         <translation>类 Photoshop 文字变形（#1093）。</translation>
@@ -2393,9 +2239,44 @@
         <translation>文本框圆角。0 = 直角（矩形）。</translation>
     </message>
     <message>
+        <location filename="../ui/text_panel.py" line="361" />
+        <source>Change stroke width</source>
+        <translation>修改轮廓宽度</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="364" />
+        <source>Stroke</source>
+        <translation>轮廓</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="373" />
+        <source>Change stroke color</source>
+        <translation>改变文字轮廓颜色</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="386" />
+        <source>Change letter spacing</source>
+        <translation>修改字符间距</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="400" />
+        <source>Opacity</source>
+        <translation>不透明度</translation>
+    </message>
+    <message>
         <location filename="../ui/text_panel.py" line="405" />
         <source>Text opacity (quick access)</source>
         <translation>文字不透明度（快捷）</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="414" />
+        <source>Global Font Format</source>
+        <translation>全局字体格式</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="423" />
+        <source>Apply to all blocks</source>
+        <translation>应用到全部块</translation>
     </message>
     <message>
         <location filename="../ui/text_panel.py" line="424" />
@@ -2403,9 +2284,19 @@
         <translation>将当前全局字体格式应用到本页所有文本框。</translation>
     </message>
     <message>
+        <location filename="../ui/text_panel.py" line="426" />
+        <source>Save as default</source>
+        <translation>保存为默认</translation>
+    </message>
+    <message>
         <location filename="../ui/text_panel.py" line="427" />
         <source>Save current global font format as the default for new projects and sessions.</source>
         <translation>将当前全局字体格式保存为新项目与新会话的默认。</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="430" />
+        <source>Show Global Font Format</source>
+        <translation>显示全局字体格式</translation>
     </message>
     <message>
         <location filename="../ui/text_panel.py" line="431" />
@@ -2413,12 +2304,41 @@
         <translation>再次显示全局字体格式区域（样式预设）。</translation>
     </message>
     <message>
+        <location filename="../ui/text_panel.py" line="435" />
+        <source>Show Advanced Font Format</source>
+        <translation>显示高级字体格式</translation>
+    </message>
+    <message>
         <location filename="../ui/text_panel.py" line="436" />
         <source>Show the Advanced Text Format section again.</source>
         <translation>再次显示高级文本格式区域。</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/text_panel.py" line="441" />
+        <source>Advanced Text Format</source>
+        <translation>进阶字体格式</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Unfold</source>
+        <translation>展开</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="461" />
+        <source>Fold</source>
+        <translation>折叠</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="462" />
+        <source>Source</source>
+        <translation>原文</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_panel.py" line="463" />
+        <source>Translation</source>
+        <translation>译文</translation>
+    </message>
+</context><context>
     <name>GlobalReplaceThead</name>
     <message>
         <location filename="../ui/global_search_widget.py" line="192" />
@@ -2430,8 +2350,7 @@
         <source>Replace all occurrences?</source>
         <translation>替换所有结果?</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>GlobalSearchWidget</name>
     <message>
         <location filename="../ui/global_search_widget.py" line="308" />
@@ -2513,43 +2432,61 @@
         <source>Replace all occurrences re-render all pages? It can't be undone.</source>
         <translation>全部替换并重新渲染所有页? 无法撤销. </translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImgtransProgressMessageBox</name>
     <message>
+        <location filename="../ui/custom_widget/message.py" line="183" />
         <source>Detecting: </source>
         <translation type="obsolete">检测: </translation>
     </message>
     <message>
+        <location filename="../ui/custom_widget/message.py" line="184" />
         <source>OCR: </source>
         <translation type="obsolete">OCR: </translation>
     </message>
     <message>
+        <location filename="../ui/custom_widget/message.py" line="185" />
         <source>Inpainting: </source>
         <translation type="obsolete">修复: </translation>
     </message>
     <message>
+        <location filename="../ui/custom_widget/message.py" line="186" />
         <source>Translating: </source>
         <translation type="obsolete">翻译: </translation>
     </message>
-</context>
-<context>
-    <name>ImgtransThread</name>
     <message>
-        <location filename="../ui/module_manager.py" line="766" />
-        <location filename="../ui/module_manager.py" line="769" />
-        <location filename="../ui/module_manager.py" line="1434" />
-        <location filename="../ui/module_manager.py" line="1439" />
-        <location filename="../ui/module_manager.py" line="1573" />
-        <location filename="../ui/module_manager.py" line="1578" />
-        <source>Translation Failed.</source>
-        <translation>翻译失败。</translation>
+        <location filename="../ui/custom_widget/message.py" line="248" />
+        <location filename="../ui/custom_widget/message.py" line="195" />
+        <source>Stop</source>
+        <translation type="unfinished" />
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="759" />
+        <location filename="../ui/custom_widget/message.py" line="199" />
+        <source>Force stop</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/message.py" line="222" />
+        <source>trying to stop...</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
+    <name>ImgtransThread</name>
+    <message>
         <location filename="../ui/module_manager.py" line="1262" />
+        <location filename="../ui/module_manager.py" line="759" />
         <source>OCR Failed.</source>
         <translation>OCR失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_manager.py" line="1578" />
+        <location filename="../ui/module_manager.py" line="1573" />
+        <location filename="../ui/module_manager.py" line="1439" />
+        <location filename="../ui/module_manager.py" line="1434" />
+        <location filename="../ui/module_manager.py" line="769" />
+        <location filename="../ui/module_manager.py" line="766" />
+        <source>Translation Failed.</source>
+        <translation>翻译失败。</translation>
     </message>
     <message>
         <location filename="../ui/module_manager.py" line="1022" />
@@ -2561,8 +2498,7 @@
         <source>Inpainting Failed.</source>
         <translation>修复失败</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ImportDocThread</name>
     <message>
         <location filename="../ui/io_thread.py" line="154" />
@@ -2574,8 +2510,7 @@
         <source>Import *.docx</source>
         <translation>导入*.docx</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintConfigPanel</name>
     <message>
         <location filename="../ui/module_parse_widgets.py" line="533" />
@@ -2613,7 +2548,7 @@
         <translation>从修复中排除某些标签</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="560" />
+        <location filename="../ui/module_parse_widgets.py" line="559" />
         <source>When enabled, text blocks whose detector label is in the list below will not be inpainted (e.g. leave scene text as-is). Labels are case-insensitive. Requires a detector that sets block labels (e.g. YSG YOLO).</source>
         <translation>启用后，探测器标签位于下面列表中的文本块将不会被修复（例如，按原样保留场景文本）。标签不区分大小写。需要一个设置块标签的检测器（例如 YSG YOLO）。</translation>
     </message>
@@ -2638,21 +2573,16 @@
         <translation>修复完整图像（无按块裁剪）</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="580" />
+        <location filename="../ui/module_parse_widgets.py" line="579" />
         <source>Process the whole image at once instead of cropping per text block. Uses more VRAM and can be slower, but avoids crop/mask issues that cause bad results with some inpainting models (e.g. Lama). Try this if inpainting looks wrong.</source>
         <translation>立即处理整个图像，而不是裁剪每个文本块。使用更多 VRAM 并且速度可能会更慢，但可以避免裁剪/遮罩问题，这些问题会导致某些修复模型（例如 Lama）出现不良结果。如果修复看起来不对，请尝试此操作。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintPanel</name>
     <message>
         <location filename="../ui/drawingpanel.py" line="75" />
         <source>Thickness</source>
         <translation>大小</translation>
-    </message>
-    <message>
-        <source>pen thickness </source>
-        <translation type="obsolete">画笔大小 </translation>
     </message>
     <message>
         <location filename="../ui/drawingpanel.py" line="80" />
@@ -2684,23 +2614,14 @@
         <source>Inpainter</source>
         <translation>修复工具</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>InpaintThread</name>
     <message>
         <location filename="../ui/module_manager.py" line="197" />
         <source>Inpainting Failed.</source>
         <translation>修复失败.</translation>
     </message>
-</context>
-<context>
-    <name>InpainterStatusButton</name>
-    <message>
-        <source>Inpainter: </source>
-        <translation type="obsolete">修复工具: </translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>KeywordSubWidget</name>
     <message>
         <location filename="../ui/keywordsubwidget.py" line="25" />
@@ -2732,9 +2653,18 @@
         <source>Delete</source>
         <translation>删除</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>LeftBar</name>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="104" />
+        <source>Global Search (Ctrl+G)</source>
+        <translation>全局查找 (Ctrl+G)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="125" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation>运行流程（同 流程 → 运行）。</translation>
+    </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="128" />
         <source>Open Folder ...</source>
@@ -2751,9 +2681,19 @@
         <translation>打开图片...</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindowbars.py" line="138" />
+        <source>Open ACBF/CBZ ...</source>
+        <translation>打开 ACBF/CBZ...</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindowbars.py" line="139" />
         <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
         <translation>打开漫画书档案 (.cbz/.zip)；解压到文件夹并作为项目打开。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="142" />
+        <source>Open CBR ...</source>
+        <translation>打开 CBR...</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="143" />
@@ -2786,6 +2726,31 @@
         <translation>导入word文档</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindowbars.py" line="163" />
+        <source>Export source text as TXT</source>
+        <translation>原文导出为 TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="165" />
+        <source>Export translation as TXT</source>
+        <translation>译文导出为 TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="168" />
+        <source>Export source text as markdown</source>
+        <translation>原文导出为 Markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="170" />
+        <source>Export translation as markdown</source>
+        <translation>译文导出为 Markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="173" />
+        <source>Import translation from TXT/markdown</source>
+        <translation>从 TXT/Markdown 导入译文</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindowbars.py" line="176" />
         <source>Open Recent</source>
         <translation>打开最近</translation>
@@ -2806,347 +2771,225 @@
         <translation>漫画档案 (*.cbz *.zip)</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindowbars.py" line="337" />
+        <source>Open ACBF/CBZ</source>
+        <translation>打开 ACBF/CBZ</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="377" />
+        <location filename="../ui/mainwindowbars.py" line="338" />
+        <source>Failed to extract archive: {}</source>
+        <translation>解压失败：{}</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindowbars.py" line="352" />
         <source>Comic RAR archives (*.cbr *.rar)</source>
         <translation>漫画 RAR 档案 (*.cbr *.rar)</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="376" />
+        <location filename="../ui/mainwindowbars.py" line="370" />
+        <source>Open CBR</source>
+        <translation>打开 CBR</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="382" />
         <source>Import *.docx</source>
         <translation>导入*.docx</translation>
     </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="104" />
-        <source>Global Search (Ctrl+G)</source>
-        <translation>全局查找 (Ctrl+G)</translation>
-    </message>
-    <message>
-        <source>Export soure text as TXT</source>
-        <translation type="obsolete">原文导出为 TXT</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="165" />
-        <source>Export translation as TXT</source>
-        <translation>译文导出为 TXT</translation>
-    </message>
-    <message>
-        <source>Export soure text as markdown</source>
-        <translation type="obsolete">原文导出为 Markdown</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="170" />
-        <source>Export translation as markdown</source>
-        <translation>译文导出为 Markdown</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="173" />
-        <source>Import translation from TXT/markdown</source>
-        <translation>从 TXT/Markdown 导入译文</translation>
-    </message>
-    <message>
-        <source>RUN</source>
-        <translation type="vanished">运行</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="163" />
-        <source>Export source text as TXT</source>
-        <translation>原文导出为 TXT</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="168" />
-        <source>Export source text as markdown</source>
-        <translation>原文导出为 Markdown</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="125" />
-        <source>Run pipeline (same as Pipeline → Run).</source>
-        <translation>运行流程（同 流程 → 运行）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="138" />
-        <source>Open ACBF/CBZ ...</source>
-        <translation>打开 ACBF/CBZ...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="142" />
-        <source>Open CBR ...</source>
-        <translation>打开 CBR...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="337" />
-        <source>Open ACBF/CBZ</source>
-        <translation>打开 ACBF/CBZ</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="338" />
-        <location filename="../ui/mainwindowbars.py" line="377" />
-        <source>Failed to extract archive: {}</source>
-        <translation>解压失败：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="370" />
-        <location filename="../ui/mainwindowbars.py" line="376" />
-        <source>Open CBR</source>
-        <translation>打开 CBR</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>MainWindow</name>
     <message>
-        <location filename="../ui/mainwindow.py" line="817" />
-        <source>Failed to load project </source>
-        <translation>项目加载失败 </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3208" />
-        <source>unsaved</source>
-        <translation>未保存</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3208" />
-        <source>saved</source>
-        <translation>已保存</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3242" />
-        <source>Saving image...</source>
-        <translation>保存中...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3725" />
-        <source>Ignored in run (right-click → Include in run to process)</source>
-        <translation>在运行中忽略（右键单击→包含在运行中进行处理）</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3737" />
-        <source>Are you sure you want to remove "{}" from the project?</source>
-        <translation>您确定要从项目中删除“{}”吗？</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3739" />
-        <source>Are you sure you want to remove {} images from the project?</source>
-        <translation>您确定要从项目中删除 {} 个图像吗？</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3741" />
-        <source>Confirm Removal</source>
-        <translation>确认删除</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3801" />
-        <source>Export to </source>
-        <translation>导出至 </translation>
-    </message>
-    <message>
-        <source>Keyword substitution for OCR</source>
-        <translation type="obsolete">替换OCR文本中的关键词</translation>
+        <location filename="../ui/mainwindow.py" line="465" />
+        <source>Keyword substitution for source text</source>
+        <translation>替换原文关键词</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.py" line="469" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>替换机翻前文本关键字</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="473" />
         <source>Keyword substitution for machine translation</source>
         <translation>替换机翻结果中的关键词</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1014" />
+        <location filename="../ui/mainwindow.py" line="728" />
+        <source>Run pipeline (same as Pipeline → Run).</source>
+        <translation>运行管道（与管道→运行相同）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="730" />
+        <source>Manual mode: runs current page only.</source>
+        <translation>手动模式：仅运行当前页面。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="821" />
+        <source>Failed to load project </source>
+        <translation>项目加载失败 </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="898" />
+        <source>Failed to import images</source>
+        <translation>导入图片失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="913" />
+        <source>Failed to load project from</source>
+        <translation>无法从所选路径加载项目：</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="979" />
+        <source>Confirm exit</source>
+        <translation>确认退出</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="980" />
+        <source>Are you sure you want to quit?</source>
+        <translation>您确定要退出吗？</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="1020" />
         <source>Restart to apply changes? 
 </source>
         <translation>重启程序以应用更改?\n</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="3384" />
-        <source>Import Text Styles</source>
-        <translation>导入字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3397" />
-        <source>Failed to load from {p}</source>
-        <translation>无法导入{p}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3401" />
-        <source>Save Text Styles</source>
-        <translation>导出字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3418" />
-        <source>Failed save to {savep}</source>
-        <translation>无法保存到{savep}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="909" />
-        <source>Failed to load project from</source>
-        <translation>无法从所选路径加载项目：</translation>
-    </message>
-    <message>
-        <source>Are you sure to run image translation again?
-All existing translation results will be cleared!</source>
-        <translation type="vanished">确定要重新运行吗？现有翻译结果将被清空！</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="461" />
-        <source>Keyword substitution for source text</source>
-        <translation>替换原文关键词</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="724" />
-        <source>Run pipeline (same as Pipeline → Run).</source>
-        <translation>运行管道（与管道→运行相同）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="726" />
-        <source>Manual mode: runs current page only.</source>
-        <translation>手动模式：仅运行当前页面。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="894" />
-        <source>Failed to import images</source>
-        <translation>导入图片失败</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="973" />
-        <source>Confirm exit</source>
-        <translation>确认退出</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="974" />
-        <source>Are you sure you want to quit?</source>
-        <translation>您确定要退出吗？</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="1243" />
+        <location filename="../ui/mainwindow.py" line="1255" />
         <source>Documentation</source>
         <translation>文档</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1243" />
+        <location filename="../ui/mainwindow.py" line="1255" />
         <source>README.md not found.</source>
         <translation>未找到 README.md。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1250" />
+        <location filename="../ui/mainwindow.py" line="1262" />
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1251" />
+        <location filename="../ui/mainwindow.py" line="1263" />
         <source>BallonsTranslatorPro — community fork</source>
         <translation>BallonsTranslatorPro — 社区分叉</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1251" />
+        <location filename="../ui/mainwindow.py" line="1263" />
         <source>Deep learning–assisted comic/manga translation.</source>
         <translation>深度学习辅助漫画翻译。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1343" />
+        <location filename="../ui/mainwindow.py" line="1369" />
+        <location filename="../ui/mainwindow.py" line="1367" />
         <location filename="../ui/mainwindow.py" line="1355" />
-        <location filename="../ui/mainwindow.py" line="1357" />
         <source>Update from GitHub</source>
         <translation>从 GitHub 更新</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1344" />
+        <location filename="../ui/mainwindow.py" line="1356" />
         <source>Checking for updates...</source>
         <translation>正在检查更新...</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1735" />
+        <location filename="../ui/mainwindow.py" line="1747" />
         <source>Open a project first (File → Open Folder / Open Project) to set project translation context.</source>
         <translation>首先打开一个项目（文件 → 打开文件夹/打开项目）以设置项目翻译上下文。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1736" />
+        <location filename="../ui/mainwindow.py" line="1748" />
         <source>Translation context</source>
         <translation>翻译上下文</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1830" />
+        <location filename="../ui/mainwindow.py" line="1842" />
         <source>Troubleshooting</source>
         <translation>故障排除</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1830" />
+        <location filename="../ui/mainwindow.py" line="1842" />
         <source>docs/TROUBLESHOOTING.md not found.</source>
         <translation>未找到 docs/TROUBLESHOOTING.md。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1893" />
+        <location filename="../ui/mainwindow.py" line="1907" />
         <source>Startup stages: {0}</source>
         <translation>启动阶段：{0}</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1895" />
+        <location filename="../ui/mainwindow.py" line="1909" />
         <source>Startup health</source>
         <translation>启动健康</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1898" />
+        <location filename="../ui/mainwindow.py" line="1912" />
         <source>Copy diagnostics</source>
         <translation>复制诊断</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1899" />
+        <location filename="../ui/mainwindow.py" line="1913" />
         <source>Relaunch PyQt5</source>
         <translation>重新启动 PyQt5</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1900" />
+        <location filename="../ui/mainwindow.py" line="1914" />
         <source>Relaunch CPU-only</source>
         <translation>仅重新启动 CPU</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1901" />
+        <location filename="../ui/mainwindow.py" line="1915" />
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1916" />
+        <location filename="../ui/mainwindow.py" line="1930" />
         <source>Diagnostics copied</source>
         <translation>已复制诊断信息</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1916" />
+        <location filename="../ui/mainwindow.py" line="1930" />
         <source>Startup diagnostics copied to clipboard.</source>
         <translation>启动诊断已复制到剪贴板。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1921" />
+        <location filename="../ui/mainwindow.py" line="1935" />
         <source>Export startup report</source>
         <translation>导出启动报告</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1921" />
+        <location filename="../ui/mainwindow.py" line="1935" />
         <source>Text files (*.txt)</source>
         <translation>文本文件 (*.txt)</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1927" />
+        <location filename="../ui/mainwindow.py" line="1941" />
         <source>Startup report saved</source>
         <translation>启动报告已保存</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1929" />
+        <location filename="../ui/mainwindow.py" line="1943" />
         <source>Failed to export startup report.</source>
         <translation>导出启动报告失败。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1941" />
+        <location filename="../ui/mainwindow.py" line="1955" />
         <source>Failed to open log folder.</source>
         <translation>无法打开日志文件夹。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1946" />
-        <location filename="../ui/mainwindow.py" line="1959" />
+        <location filename="../ui/mainwindow.py" line="1973" />
+        <location filename="../ui/mainwindow.py" line="1960" />
         <source>Model download diagnostics</source>
         <translation>模型下载诊断</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1946" />
+        <location filename="../ui/mainwindow.py" line="1960" />
         <source>No model download diagnostics available yet.</source>
         <translation>尚无可用的模型下载诊断。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1949" />
+        <location filename="../ui/mainwindow.py" line="1963" />
         <source>Flow: {0}
 Status: {1}
 Downloaded: {2}
@@ -3161,447 +3004,652 @@ Package IDs: {5}</source>
 包 ID：{5}</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="1958" />
+        <location filename="../ui/mainwindow.py" line="1972" />
         <source>Failed items: {0}</source>
         <translation>失败的项目：{0}</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2003" />
+        <location filename="../ui/mainwindow.py" line="2019" />
         <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
         <translation>摘要：已下载 {0}，失败 {1}，跳过 {2}。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2009" />
+        <location filename="../ui/mainwindow.py" line="2025" />
         <source>Open Manage Models</source>
         <translation>开放管理模型</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2010" />
+        <location filename="../ui/mainwindow.py" line="2026" />
         <source>Open Troubleshooting</source>
         <translation>打开故障排除</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2011" />
+        <location filename="../ui/mainwindow.py" line="2027" />
         <source>Continue with available modules</source>
         <translation>继续使用可用模块</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2060" />
-        <source>Model package download complete</source>
-        <translation>模型包下载完成</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2066" />
-        <location filename="../ui/mainwindow.py" line="2115" />
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation>某些模型包失败。失败的项目：{0}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2066" />
-        <location filename="../ui/mainwindow.py" line="2115" />
-        <source>Unknown</source>
-        <translation>未知</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2068" />
-        <source>Model package download partially complete</source>
-        <translation>模型包下载部分完成</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2095" />
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation>首次运行仅限本地模式处于活动状态。使用工具 → 管理模型导入/下载模型，或编辑 config/config.json 以启用包并重新启动。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2117" />
-        <source>Download partially complete.</source>
-        <translation>下载部分完成。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2125" />
-        <source>Download complete. Defaults updated.</source>
-        <translation>下载完成。默认值已更新。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2126" />
-        <source>Model packages have been downloaded. Applied modules:
-</source>
-        <translation>模型包已下载。应用模块：</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2423" />
-        <location filename="../ui/mainwindow.py" line="2433" />
-        <location filename="../ui/mainwindow.py" line="2442" />
-        <location filename="../ui/mainwindow.py" line="2446" />
-        <location filename="../ui/mainwindow.py" line="2472" />
-        <location filename="../ui/mainwindow.py" line="2527" />
-        <location filename="../ui/mainwindow.py" line="3449" />
-        <location filename="../ui/mainwindow.py" line="3518" />
-        <location filename="../ui/mainwindow.py" line="3536" />
-        <location filename="../ui/mainwindow.py" line="3554" />
-        <source>Export</source>
-        <translation>出口</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2423" />
-        <location filename="../ui/mainwindow.py" line="2433" />
-        <location filename="../ui/mainwindow.py" line="2535" />
-        <location filename="../ui/mainwindow.py" line="3554" />
-        <source>Open a project first.</source>
-        <translation>首先打开一个项目。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2425" />
-        <source>Select output folder</source>
-        <translation>选择输出文件夹</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2442" />
-        <source>Choose a path for the ZIP file.</source>
-        <translation>选择 ZIP 文件的路径。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2446" />
-        <source>Select an output folder.</source>
-        <translation>选择输出文件夹。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2468" />
-        <source>Exported as ZIP: {}</source>
-        <translation>导出为 ZIP：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2471" />
-        <location filename="../ui/mainwindow.py" line="2525" />
-        <source>Cache cleaned.</source>
-        <translation>缓存已清理。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2506" />
-        <source>Exported {0} page(s) to {1}.</source>
-        <translation>已将 {0} 个页面导出到 {1}。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2515" />
-        <source>PDF saved: {}</source>
-        <translation>已保存 PDF：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2517" />
-        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
-        <translation>已跳过 PDF 导出。安装img2pdf：pip install img2pdf</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2520" />
-        <source>PDF export failed: {}</source>
-        <translation>PDF 导出失败：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2522" />
-        <source>Missing result for {0} page(s). Run pipeline first.</source>
-        <translation>缺少 {0} 页的结果。首先运行管道。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2530" />
-        <source>Batch export failed</source>
-        <translation>批量导出失败</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2535" />
-        <location filename="../ui/mainwindow.py" line="2591" />
-        <source>Check project</source>
-        <translation>检查项目</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2541" />
-        <source>Project JSON not found: {}</source>
-        <translation>未找到项目 JSON：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2549" />
-        <source>No pages in project JSON.</source>
-        <translation>项目 JSON 中没有页面。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2551" />
-        <source>Invalid project JSON: {}</source>
-        <translation>项目 JSON 无效：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2555" />
-        <source>Missing image: {}</source>
-        <translation>缺少图像：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2579" />
-        <source>Page "{}": {} overlapping block pair(s): {}</source>
-        <translation>页面“{}”：{} 个重叠块对：{}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2584" />
-        <source>Duplicate/overlapping blocks:</source>
-        <translation>重复/重叠块：</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2588" />
-        <source>No issues found.</source>
-        <translation>没有发现问题。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2687" />
-        <source>Unsaved changes</source>
-        <translation>未保存的更改</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2688" />
-        <source>Save project before closing?</source>
-        <translation>关闭前保存项目吗？</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3281" />
-        <source>Confirmation</source>
-        <translation>确认</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3282" />
-        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
-        <translation>“运行”将清除以前的结果，“继续”将尝试从以前的进度运行</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3284" />
-        <source>Run</source>
-        <translation>跑步</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3285" />
-        <source>Continue</source>
-        <translation>继续</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3286" />
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3449" />
-        <source>Open a project and select a page first.</source>
-        <translation>打开一个项目并首先选择一个页面。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3481" />
-        <location filename="../ui/mainwindow.py" line="3504" />
-        <location filename="../ui/mainwindow.py" line="3515" />
-        <source>original</source>
-        <translation>原来的</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3484" />
-        <location filename="../ui/mainwindow.py" line="3512" />
-        <source>inpainted</source>
-        <translation>修复的</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3488" />
-        <location filename="../ui/mainwindow.py" line="3496" />
-        <location filename="../ui/mainwindow.py" line="3509" />
-        <source>result</source>
-        <translation>结果</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3501" />
-        <source>inpainted (no text yet)</source>
-        <translation>已修复（还没有文字）</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3518" />
-        <source>No image available for current page.</source>
-        <translation>当前页面没有可用的图像。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3522" />
-        <source>Export current page as</source>
-        <translation>将当前页面导出为</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3533" />
-        <source>Saved to {}</source>
-        <translation>保存到 {}</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3539" />
-        <source>Export failed</source>
-        <translation>导出失败</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3547" />
-        <source>Text file exported to </source>
-        <translation>文本文件已导出到</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3549" />
-        <source>Failed to export as TEXT file</source>
-        <translation>文本文件导出失败</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3558" />
-        <source>Export translation to LPtxt</source>
-        <translation>将翻译导出到 LPtxt</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3559" />
-        <source>Include font and size info in the LPtxt output?</source>
-        <translation>在 LPtxt 输出中包含字体和大小信息？</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3568" />
-        <source>LPtxt exported to: </source>
-        <translation>LPtxt 导出到：</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3570" />
-        <source>Failed to export LPtxt</source>
-        <translation>导出 LPtxt 失败</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3576" />
-        <source>Import *.md/*.txt</source>
-        <translation>导入*.md/*.txt</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3588" />
-        <source>Translation imported and matched successfully.</source>
-        <translation>译文已导入且匹配成功</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3590" />
-        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
-        <translation>导入文件当前项目没能完全匹配，请确保导入文件格式和导出文件一致</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3592" />
-        <source>Missing pages: </source>
-        <translation>缺失页: </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3595" />
-        <source>Unexpected pages: </source>
-        <translation>额外页: </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3598" />
-        <source>Unmatched pages: </source>
-        <translation>未匹配页: </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3609" />
-        <source>Failed to import translation from </source>
-        <translation>从目标文件导入失败 </translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3977" />
-        <location filename="../ui/mainwindow.py" line="3998" />
-        <source>Spell check</source>
-        <translation>拼写检查</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="3978" />
-        <location filename="../ui/mainwindow.py" line="3999" />
-        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
-        <translation>拼写检查需要 pyenchant。安装它和系统字典（例如 en_US）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4250" />
-        <source>Images</source>
-        <translation>图片</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4250" />
-        <source>All files</source>
-        <translation>所有文件</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4251" />
-        <source>Import Image</source>
-        <translation>导入图像</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4259" />
-        <source>Could not create overlays folder.</source>
-        <translation>无法创建覆盖文件夹。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4268" />
-        <source>Could not copy image: </source>
-        <translation>无法复制图像：</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4423" />
-        <source>Canvas: Normal</source>
-        <translation>画布：普通</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4424" />
-        <source>Canvas: Original</source>
-        <translation>画布：原版</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4425" />
-        <source>Canvas: Debug (boxes/masks)</source>
-        <translation>画布：调试（框/遮罩）</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4426" />
-        <source>Canvas: Translated</source>
-        <translation>画布：翻译</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4437" />
-        <source>Canvas: Fit to width</source>
-        <translation>画布：适合宽度</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="4438" />
-        <source>Zoom canvas so image width fits the view.</source>
-        <translation>缩放画布，使图像宽度适合视图。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="465" />
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>替换机翻前文本关键字</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2108" />
-        <source>Download complete.</source>
-        <translation>下载完成。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2111" />
-        <source>Model packages have been downloaded. You can use the pipeline now.</source>
-        <translation>模型包已下载完成，现在可以使用流程了。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="2057" />
-        <location filename="../ui/mainwindow.py" line="2105" />
+        <location filename="../ui/mainwindow.py" line="2121" />
+        <location filename="../ui/mainwindow.py" line="2073" />
         <source>If the connectivity check is slow or fails, set DISABLE_MODEL_SOURCE_CHECK=True and retry. See docs/TROUBLESHOOTING.md.</source>
         <translation>若网络检查过慢或失败，可设置 DISABLE_MODEL_SOURCE_CHECK=True 后重试。详见 docs/TROUBLESHOOTING.md。</translation>
     </message>
     <message>
         <location filename="../ui/mainwindow.py" line="2076" />
+        <source>Model package download complete</source>
+        <translation>模型包下载完成</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Some model packages failed. Failed items: {0}</source>
+        <translation>某些模型包失败。失败的项目：{0}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2131" />
+        <location filename="../ui/mainwindow.py" line="2082" />
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2084" />
+        <source>Model package download partially complete</source>
+        <translation>模型包下载部分完成</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2147" />
+        <location filename="../ui/mainwindow.py" line="2092" />
         <source>Model download failed. You can retry from Tools → Retry model downloads.</source>
         <translation>模型下载失败。可从 工具 → 重试下载模型 再次尝试。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindow.py" line="2094" />
+        <location filename="../ui/mainwindow.py" line="2110" />
         <source>No model packages selected.</source>
         <translation>未选择任何模型包。</translation>
     </message>
     <message>
-        <source>Use Tools → Manage models to download individual models, or restart the app to choose packages again.</source>
-        <translation type="vanished">请通过 工具 → 管理模型 下载所需模型，或重启程序重新选择模型包。</translation>
+        <location filename="../ui/mainwindow.py" line="2111" />
+        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
+        <translation>首次运行仅限本地模式处于活动状态。使用工具 → 管理模型导入/下载模型，或编辑 config/config.json 以启用包并重新启动。</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2124" />
+        <source>Download complete.</source>
+        <translation>下载完成。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2127" />
+        <source>Model packages have been downloaded. You can use the pipeline now.</source>
+        <translation>模型包已下载完成，现在可以使用流程了。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2133" />
+        <source>Download partially complete.</source>
+        <translation>下载部分完成。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2141" />
+        <source>Download complete. Defaults updated.</source>
+        <translation>下载完成。默认值已更新。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2142" />
+        <source>Model packages have been downloaded. Applied modules:
+</source>
+        <translation>模型包已下载。应用模块：</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="3552" />
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <location filename="../ui/mainwindow.py" line="2543" />
+        <location filename="../ui/mainwindow.py" line="2488" />
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Export</source>
+        <translation>出口</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3570" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <location filename="../ui/mainwindow.py" line="2449" />
+        <location filename="../ui/mainwindow.py" line="2439" />
+        <source>Open a project first.</source>
+        <translation>首先打开一个项目。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2441" />
+        <source>Select output folder</source>
+        <translation>选择输出文件夹</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2458" />
+        <source>Choose a path for the ZIP file.</source>
+        <translation>选择 ZIP 文件的路径。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2462" />
+        <source>Select an output folder.</source>
+        <translation>选择输出文件夹。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2484" />
+        <source>Exported as ZIP: {}</source>
+        <translation>导出为 ZIP：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2541" />
+        <location filename="../ui/mainwindow.py" line="2487" />
+        <source>Cache cleaned.</source>
+        <translation>缓存已清理。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2522" />
+        <source>Exported {0} page(s) to {1}.</source>
+        <translation>已将 {0} 个页面导出到 {1}。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2531" />
+        <source>PDF saved: {}</source>
+        <translation>已保存 PDF：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2533" />
+        <source>PDF export skipped. Install img2pdf: pip install img2pdf</source>
+        <translation>已跳过 PDF 导出。安装img2pdf：pip install img2pdf</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2536" />
+        <source>PDF export failed: {}</source>
+        <translation>PDF 导出失败：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2538" />
+        <source>Missing result for {0} page(s). Run pipeline first.</source>
+        <translation>缺少 {0} 页的结果。首先运行管道。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2546" />
+        <source>Batch export failed</source>
+        <translation>批量导出失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2607" />
+        <location filename="../ui/mainwindow.py" line="2551" />
+        <source>Check project</source>
+        <translation>检查项目</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2557" />
+        <source>Project JSON not found: {}</source>
+        <translation>未找到项目 JSON：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2565" />
+        <source>No pages in project JSON.</source>
+        <translation>项目 JSON 中没有页面。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2567" />
+        <source>Invalid project JSON: {}</source>
+        <translation>项目 JSON 无效：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2571" />
+        <source>Missing image: {}</source>
+        <translation>缺少图像：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2595" />
+        <source>Page "{}": {} overlapping block pair(s): {}</source>
+        <translation>页面“{}”：{} 个重叠块对：{}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2600" />
+        <source>Duplicate/overlapping blocks:</source>
+        <translation>重复/重叠块：</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2604" />
+        <source>No issues found.</source>
+        <translation>没有发现问题。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2703" />
+        <source>Unsaved changes</source>
+        <translation>未保存的更改</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="2704" />
+        <source>Save project before closing?</source>
+        <translation>关闭前保存项目吗？</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>unsaved</source>
+        <translation>未保存</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3224" />
+        <source>saved</source>
+        <translation>已保存</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3258" />
+        <source>Saving image...</source>
+        <translation>保存中...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3297" />
+        <source>Confirmation</source>
+        <translation>确认</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3298" />
+        <source>"Run" will clear previous results, "Continue" will try to run from previous progress</source>
+        <translation>“运行”将清除以前的结果，“继续”将尝试从以前的进度运行</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3300" />
+        <source>Run</source>
+        <translation>跑步</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3301" />
+        <source>Continue</source>
+        <translation>继续</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3302" />
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3400" />
+        <source>Import Text Styles</source>
+        <translation>导入字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3417" />
+        <source>Save Text Styles</source>
+        <translation>导出字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3465" />
+        <source>Open a project and select a page first.</source>
+        <translation>打开一个项目并首先选择一个页面。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3531" />
+        <location filename="../ui/mainwindow.py" line="3520" />
+        <location filename="../ui/mainwindow.py" line="3497" />
+        <source>original</source>
+        <translation>原来的</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3528" />
+        <location filename="../ui/mainwindow.py" line="3500" />
+        <source>inpainted</source>
+        <translation>修复的</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3525" />
+        <location filename="../ui/mainwindow.py" line="3512" />
+        <location filename="../ui/mainwindow.py" line="3504" />
+        <source>result</source>
+        <translation>结果</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3517" />
+        <source>inpainted (no text yet)</source>
+        <translation>已修复（还没有文字）</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3534" />
+        <source>No image available for current page.</source>
+        <translation>当前页面没有可用的图像。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3538" />
+        <source>Export current page as</source>
+        <translation>将当前页面导出为</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3549" />
+        <source>Saved to {}</source>
+        <translation>保存到 {}</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3555" />
+        <source>Export failed</source>
+        <translation>导出失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3563" />
+        <source>Text file exported to </source>
+        <translation>文本文件已导出到</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3565" />
+        <source>Failed to export as TEXT file</source>
+        <translation>文本文件导出失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3574" />
+        <source>Export translation to LPtxt</source>
+        <translation>将翻译导出到 LPtxt</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3575" />
+        <source>Include font and size info in the LPtxt output?</source>
+        <translation>在 LPtxt 输出中包含字体和大小信息？</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3584" />
+        <source>LPtxt exported to: </source>
+        <translation>LPtxt 导出到：</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3586" />
+        <source>Failed to export LPtxt</source>
+        <translation>导出 LPtxt 失败</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3592" />
+        <source>Import *.md/*.txt</source>
+        <translation>导入*.md/*.txt</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3604" />
+        <source>Translation imported and matched successfully.</source>
+        <translation>译文已导入且匹配成功</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3606" />
+        <source>Imported txt file not fully matched with current project, please make sure source txt file structured like results from "export TXT/markdown"</source>
+        <translation>导入文件当前项目没能完全匹配，请确保导入文件格式和导出文件一致</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3608" />
+        <source>Missing pages: </source>
+        <translation>缺失页: </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3611" />
+        <source>Unexpected pages: </source>
+        <translation>额外页: </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3614" />
+        <source>Unmatched pages: </source>
+        <translation>未匹配页: </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3625" />
+        <source>Failed to import translation from </source>
+        <translation>从目标文件导入失败 </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3741" />
+        <source>Ignored in run (right-click → Include in run to process)</source>
+        <translation>在运行中忽略（右键单击→包含在运行中进行处理）</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3753" />
+        <source>Are you sure you want to remove "{}" from the project?</source>
+        <translation>您确定要从项目中删除“{}”吗？</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3755" />
+        <source>Are you sure you want to remove {} images from the project?</source>
+        <translation>您确定要从项目中删除 {} 个图像吗？</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3757" />
+        <source>Confirm Removal</source>
+        <translation>确认删除</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="3817" />
+        <source>Export to </source>
+        <translation>导出至 </translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4014" />
+        <location filename="../ui/mainwindow.py" line="3993" />
+        <source>Spell check</source>
+        <translation>拼写检查</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4015" />
+        <location filename="../ui/mainwindow.py" line="3994" />
+        <source>Spell check requires pyenchant. Install it and a system dictionary (e.g. en_US).</source>
+        <translation>拼写检查需要 pyenchant。安装它和系统字典（例如 en_US）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>Images</source>
+        <translation>图片</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4266" />
+        <source>All files</source>
+        <translation>所有文件</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4267" />
+        <source>Import Image</source>
+        <translation>导入图像</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4275" />
+        <source>Could not create overlays folder.</source>
+        <translation>无法创建覆盖文件夹。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4284" />
+        <source>Could not copy image: </source>
+        <translation>无法复制图像：</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4414" />
+        <source>Environment doctor report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>No page loaded</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4513" />
+        <location filename="../ui/mainwindow.py" line="4486" />
+        <location filename="../ui/mainwindow.py" line="4418" />
+        <source>Open a project/page first.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Page: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4432" />
+        <source>Blocks: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>Likely OCR triage (empty source): </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4433" />
+        <source>none</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4434" />
+        <source>Guardrail issues: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4437" />
+        <source>Glossary candidates (source -&gt; target):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4439" />
+        <source>Translation QA report</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Save run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4445" />
+        <source>Profile name:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Saved</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4459" />
+        <source>Run profile saved to project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No profiles</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4466" />
+        <source>No run profiles found in this project.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Apply run profile</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4470" />
+        <source>Select profile:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Applied</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4482" />
+        <source>Run profile applied.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4500" />
+        <source>Triage state: </source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4502" />
+        <source>Empty OCR source text</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4506" />
+        <source>No triage issues found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>Auto-extract glossary</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4521" />
+        <source>No glossary candidates found on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4535" />
+        <source>None (all candidates already existed).</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Auto-extract glossary complete</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4536" />
+        <source>Added terms: {0}</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Triage updated</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4544" />
+        <source>Selected blocks added to triage worklist.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4552" />
+        <source>Selected blocks marked as reviewed.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4583" />
+        <source>Canvas: Normal</source>
+        <translation>画布：普通</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4584" />
+        <source>Canvas: Original</source>
+        <translation>画布：原版</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4585" />
+        <source>Canvas: Debug (boxes/masks)</source>
+        <translation>画布：调试（框/遮罩）</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4586" />
+        <source>Canvas: Translated</source>
+        <translation>画布：翻译</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4597" />
+        <source>Canvas: Fit to width</source>
+        <translation>画布：适合宽度</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindow.py" line="4598" />
+        <source>Zoom canvas so image width fits the view.</source>
+        <translation>缩放画布，使图像宽度适合视图。</translation>
+    </message>
+</context><context>
     <name>MangaSourceDialog</name>
     <message>
         <location filename="../ui/manga_source_dialog.py" line="486" />
@@ -3609,8 +3657,8 @@ Package IDs: {5}</source>
         <translation>漫画/漫画来源</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="522" />
         <location filename="../ui/manga_source_dialog.py" line="540" />
+        <location filename="../ui/manga_source_dialog.py" line="522" />
         <source>Search</source>
         <translation>搜索</translation>
     </message>
@@ -3640,8 +3688,8 @@ Package IDs: {5}</source>
         <translation>搜索 NaruRaw、ManhwaRaw 或 1kkk 时：将搜索词从英语翻译为日语/韩语/中文，以便找到原始标题。</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="553" />
         <location filename="../ui/manga_source_dialog.py" line="787" />
+        <location filename="../ui/manga_source_dialog.py" line="553" />
         <source>Paste MangaDex chapter URL or chapter UUID...</source>
         <translation>粘贴 MangaDex 章节 URL 或章节 UUID...</translation>
     </message>
@@ -3671,9 +3719,9 @@ Package IDs: {5}</source>
         <translation>选中后，浏览器运行时不会出现可见窗口，因此不会干扰菜单。取消选中以显示浏览器窗口（例如用于调试）。</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="572" />
-        <location filename="../ui/manga_source_dialog.py" line="1051" />
         <location filename="../ui/manga_source_dialog.py" line="1053" />
+        <location filename="../ui/manga_source_dialog.py" line="1051" />
+        <location filename="../ui/manga_source_dialog.py" line="572" />
         <source>Install Chromium</source>
         <translation>安装铬</translation>
     </message>
@@ -3688,9 +3736,9 @@ Package IDs: {5}</source>
         <translation>打开图像文件夹以用作项目。</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="581" />
-        <location filename="../ui/manga_source_dialog.py" line="683" />
         <location filename="../ui/manga_source_dialog.py" line="1027" />
+        <location filename="../ui/manga_source_dialog.py" line="683" />
+        <location filename="../ui/manga_source_dialog.py" line="581" />
         <source>Open folder in BallonsTranslator</source>
         <translation>在 BallonsTranslator 中打开文件夹</translation>
     </message>
@@ -3705,8 +3753,8 @@ Package IDs: {5}</source>
         <translation>章节</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="615" />
         <location filename="../ui/manga_source_dialog.py" line="767" />
+        <location filename="../ui/manga_source_dialog.py" line="615" />
         <source>Language:</source>
         <translation>语言：</translation>
     </message>
@@ -3791,9 +3839,9 @@ Package IDs: {5}</source>
         <translation>粘贴章节页面 URL（带图像的 HTML）...</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="800" />
-        <location filename="../ui/manga_source_dialog.py" line="899" />
         <location filename="../ui/manga_source_dialog.py" line="901" />
+        <location filename="../ui/manga_source_dialog.py" line="899" />
+        <location filename="../ui/manga_source_dialog.py" line="800" />
         <source>Chapter from URL</source>
         <translation>来自 URL 的章节</translation>
     </message>
@@ -3823,8 +3871,8 @@ Package IDs: {5}</source>
         <translation>输入章节页面 URL。</translation>
     </message>
     <message>
-        <location filename="../ui/manga_source_dialog.py" line="822" />
         <location filename="../ui/manga_source_dialog.py" line="829" />
+        <location filename="../ui/manga_source_dialog.py" line="822" />
         <source>Loading chapter...</source>
         <translation>正在加载章节...</translation>
     </message>
@@ -3934,8 +3982,7 @@ You can open a chapter folder in BallonsTranslator to translate.</source>
         <source>Error</source>
         <translation>错误</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>MergeDialog</name>
     <message>
         <location filename="../ui/merge_dialog.py" line="15" />
@@ -4089,8 +4136,8 @@ qipao,qipao2</source>
         <translation>几何合并参数</translation>
     </message>
     <message>
-        <location filename="../ui/merge_dialog.py" line="124" />
         <location filename="../ui/merge_dialog.py" line="134" />
+        <location filename="../ui/merge_dialog.py" line="124" />
         <source>Max gap between boxes (px). 0 = must touch; negative = require overlap (e.g. -15 = at least 15 px overlap).</source>
         <translation>框之间的最大间隙 (px)。 0 = 必须触摸；负数 = 需要重叠（例如 -15 = 至少 15 px 重叠）。</translation>
     </message>
@@ -4179,19 +4226,19 @@ qipao,qipao2</source>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ModelDownloadProgressDialog</name>
     <message>
+        <location filename="../ui/mainwindow.py" line="139" />
         <source>Downloading model packages</source>
-        <translation type="vanished">正在下载模型包</translation>
+        <translation>正在下载模型包</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindow.py" line="141" />
         <source>Downloading model packages... This may take several minutes.</source>
-        <translation type="vanished">正在下载模型包……可能需要几分钟。</translation>
+        <translation>正在下载模型包……可能需要几分钟。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ModelManagerDialog</name>
     <message>
         <location filename="../ui/model_manager_dialog.py" line="99" />
@@ -4229,14 +4276,14 @@ qipao,qipao2</source>
         <translation>搜索模块键/名称/描述...</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="137" />
         <location filename="../ui/model_manager_dialog.py" line="369" />
+        <location filename="../ui/model_manager_dialog.py" line="137" />
         <source>All categories</source>
         <translation>所有类别</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="141" />
         <location filename="../ui/model_manager_dialog.py" line="388" />
+        <location filename="../ui/model_manager_dialog.py" line="141" />
         <source>All statuses</source>
         <translation>所有状态</translation>
     </message>
@@ -4261,11 +4308,11 @@ qipao,qipao2</source>
         <translation>细节</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="157" />
-        <location filename="../ui/model_manager_dialog.py" line="278" />
-        <location filename="../ui/model_manager_dialog.py" line="340" />
-        <location filename="../ui/model_manager_dialog.py" line="342" />
         <location filename="../ui/model_manager_dialog.py" line="352" />
+        <location filename="../ui/model_manager_dialog.py" line="342" />
+        <location filename="../ui/model_manager_dialog.py" line="340" />
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <location filename="../ui/model_manager_dialog.py" line="157" />
         <source>Download models</source>
         <translation>下载模型</translation>
     </message>
@@ -4320,39 +4367,54 @@ qipao,qipao2</source>
         <translation>支持级别：{0}</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="257" />
-        <location filename="../ui/model_manager_dialog.py" line="378" />
         <location filename="../ui/model_manager_dialog.py" line="401" />
+        <location filename="../ui/model_manager_dialog.py" line="378" />
+        <location filename="../ui/model_manager_dialog.py" line="257" />
         <source>Downloaded</source>
         <translation>已下载</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="258" />
-        <location filename="../ui/model_manager_dialog.py" line="379" />
         <location filename="../ui/model_manager_dialog.py" line="402" />
+        <location filename="../ui/model_manager_dialog.py" line="379" />
+        <location filename="../ui/model_manager_dialog.py" line="258" />
         <source>Missing</source>
         <translation>丢失的</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="259" />
-        <location filename="../ui/model_manager_dialog.py" line="380" />
         <location filename="../ui/model_manager_dialog.py" line="403" />
+        <location filename="../ui/model_manager_dialog.py" line="380" />
+        <location filename="../ui/model_manager_dialog.py" line="259" />
         <source>Hash mismatch</source>
         <translation>哈希不匹配</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="260" />
-        <location filename="../ui/model_manager_dialog.py" line="381" />
         <location filename="../ui/model_manager_dialog.py" line="404" />
+        <location filename="../ui/model_manager_dialog.py" line="381" />
+        <location filename="../ui/model_manager_dialog.py" line="260" />
         <source>No file list</source>
         <translation>无文件列表</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="261" />
-        <location filename="../ui/model_manager_dialog.py" line="382" />
         <location filename="../ui/model_manager_dialog.py" line="405" />
+        <location filename="../ui/model_manager_dialog.py" line="382" />
+        <location filename="../ui/model_manager_dialog.py" line="261" />
         <source>Download on load</source>
         <translation>按需下载</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="273" />
+        <source>Check models</source>
+        <translation>检查模型</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="278" />
+        <source>Select at least one model to download.</source>
+        <translation>请至少选择一个要下载的模型。</translation>
+    </message>
+    <message>
+        <location filename="../ui/model_manager_dialog.py" line="284" />
+        <source>Downloading…</source>
+        <translation>下载中…</translation>
     </message>
     <message>
         <location filename="../ui/model_manager_dialog.py" line="296" />
@@ -4378,26 +4440,31 @@ Destination: {}</source>
 {}</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="322" />
         <location filename="../ui/model_manager_dialog.py" line="324" />
+        <location filename="../ui/model_manager_dialog.py" line="322" />
         <source>Import local models</source>
         <translation>导入本地模型</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="383" />
+        <location filename="../ui/model_manager_dialog.py" line="333" />
+        <source>Download finished: {0} succeeded, {1} failed.</source>
+        <translation>下载完成：成功 {0} 个，失败 {1} 个。</translation>
+    </message>
+    <message>
         <location filename="../ui/model_manager_dialog.py" line="443" />
+        <location filename="../ui/model_manager_dialog.py" line="383" />
         <source>Incompatible</source>
         <translation>不兼容</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="384" />
         <location filename="../ui/model_manager_dialog.py" line="441" />
+        <location filename="../ui/model_manager_dialog.py" line="384" />
         <source>Optional</source>
         <translation>选修的</translation>
     </message>
     <message>
-        <location filename="../ui/model_manager_dialog.py" line="453" />
         <location filename="../ui/model_manager_dialog.py" line="468" />
+        <location filename="../ui/model_manager_dialog.py" line="453" />
         <source>Estimated size: {0}</source>
         <translation>预计尺寸：{0}</translation>
     </message>
@@ -4416,63 +4483,7 @@ Destination: {}</source>
         <source>Target path(s): {0}</source>
         <translation>目标路径：{0}</translation>
     </message>
-    <message>
-        <location filename="../ui/model_manager_dialog.py" line="273" />
-        <source>Check models</source>
-        <translation>检查模型</translation>
-    </message>
-    <message>
-        <location filename="../ui/model_manager_dialog.py" line="278" />
-        <source>Select at least one model to download.</source>
-        <translation>请至少选择一个要下载的模型。</translation>
-    </message>
-    <message>
-        <location filename="../ui/model_manager_dialog.py" line="284" />
-        <source>Downloading…</source>
-        <translation>下载中…</translation>
-    </message>
-    <message>
-        <location filename="../ui/model_manager_dialog.py" line="333" />
-        <source>Download finished: {0} succeeded, {1} failed.</source>
-        <translation>下载完成：成功 {0} 个，失败 {1} 个。</translation>
-    </message>
-</context>
-<context>
-    <name>ModelPackageCatalog</name>
-    <message>
-        <source>Core (recommended)</source>
-        <translation type="vanished">核心（推荐）</translation>
-    </message>
-    <message>
-        <source>Text detection, inpainting, OCR, pkuseg — minimal to run</source>
-        <translation type="vanished">文本检测、图像修复、OCR、pkuseg——运行所需的最小集合</translation>
-    </message>
-    <message>
-        <source>Advanced OCR</source>
-        <translation type="vanished">高级 OCR</translation>
-    </message>
-    <message>
-        <source>PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px</source>
-        <translation type="vanished">用于漫画的 PaddleOCR-VL（约 1.7 GB），以及 MIT 48px/32px</translation>
-    </message>
-    <message>
-        <source>Advanced inpainting</source>
-        <translation type="vanished">高级图像修复</translation>
-    </message>
-    <message>
-        <source>LaMa variants, ONNX, PatchMatch</source>
-        <translation type="vanished">LaMa 系列、ONNX、PatchMatch</translation>
-    </message>
-    <message>
-        <source>Optional ONNX inpainting</source>
-        <translation type="vanished">可选 ONNX 图像修复</translation>
-    </message>
-    <message>
-        <source>Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)</source>
-        <translation type="vanished">Lama 2025 / lama-manga ONNX（更小，CPU 更友好）</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>ModelPackageSelectorDialog</name>
     <message>
         <location filename="../ui/model_package_selector_dialog.py" line="59" />
@@ -4485,7 +4496,7 @@ Destination: {}</source>
         <translation>界面语言</translation>
     </message>
     <message>
-        <location filename="../ui/model_package_selector_dialog.py" line="87" />
+        <location filename="../ui/model_package_selector_dialog.py" line="86" />
         <source>Select which model packages to download now. You can download more later via Tools → Manage models.</source>
         <translation>选择现在要下载的模型包。之后可通过 工具 → 管理模型 下载更多。</translation>
     </message>
@@ -4515,24 +4526,6 @@ Destination: {}</source>
         <translation>手动选择包</translation>
     </message>
     <message>
-        <location filename="../ui/model_package_selector_dialog.py" line="231" />
-        <source>Core package not selected</source>
-        <translation>未选择核心包</translation>
-    </message>
-    <message>
-        <location filename="../ui/model_package_selector_dialog.py" line="233" />
-        <source>You did not select the Core package. Default modules may be unavailable until you download them.
-
-Continue with advanced-only packages?</source>
-        <translation>您没有选择核心包。默认模块在您下载之前可能不可用。
-
-继续使用仅限高级的软件包吗？</translation>
-    </message>
-    <message>
-        <source>Model packages</source>
-        <translation type="vanished">模型包</translation>
-    </message>
-    <message>
         <location filename="../ui/model_package_selector_dialog.py" line="155" />
         <source>Skip (Core only)</source>
         <translation>跳过（仅核心包）</translation>
@@ -4558,44 +4551,21 @@ Continue with advanced-only packages?</source>
         <translation>下载所选</translation>
     </message>
     <message>
-        <source>Core (recommended)</source>
-        <translation type="vanished">核心包（推荐）</translation>
+        <location filename="../ui/model_package_selector_dialog.py" line="231" />
+        <source>Core package not selected</source>
+        <translation>未选择核心包</translation>
     </message>
     <message>
-        <source>Text detection, inpainting, OCR, pkuseg — minimal to run</source>
-        <translation type="vanished">文本检测、图像修复、OCR、pkuseg — 最低可运行配置</translation>
+        <location filename="../ui/model_package_selector_dialog.py" line="232" />
+        <source>You did not select the Core package. Default modules may be unavailable until you download them.
+
+Continue with advanced-only packages?</source>
+        <translation>您没有选择核心包。默认模块在您下载之前可能不可用。
+
+继续使用仅限高级的软件包吗？</translation>
     </message>
-    <message>
-        <source>Advanced OCR</source>
-        <translation type="vanished">高级 OCR</translation>
-    </message>
-    <message>
-        <source>PaddleOCR-VL for manga (~1.7 GB), MIT 48px/32px</source>
-        <translation type="vanished">漫画用 PaddleOCR-VL（约 1.7 GB）、MIT 48px/32px</translation>
-    </message>
-    <message>
-        <source>Advanced inpainting</source>
-        <translation type="vanished">高级图像修复</translation>
-    </message>
-    <message>
-        <source>LaMa variants, ONNX, PatchMatch</source>
-        <translation type="vanished">LaMa 变体、ONNX、PatchMatch</translation>
-    </message>
-    <message>
-        <source>Optional ONNX inpainting</source>
-        <translation type="vanished">可选 ONNX 图像修复</translation>
-    </message>
-    <message>
-        <source>Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)</source>
-        <translation type="vanished">Lama 2025 / lama-manga ONNX（体积更小，适合 CPU）</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>ModuleManager</name>
-    <message>
-        <source>Invalid</source>
-        <translation type="obsolete">不可用</translation>
-    </message>
     <message>
         <location filename="../ui/module_manager.py" line="1825" />
         <source>Translation Failed</source>
@@ -4657,6 +4627,11 @@ Continue with advanced-only packages?</source>
         <translation>设置文本检测器失败。</translation>
     </message>
     <message>
+        <location filename="../ui/module_manager.py" line="2155" />
+        <source>Detection in region failed.</source>
+        <translation type="unfinished">区域检测失败。</translation>
+    </message>
+    <message>
         <location filename="../ui/module_manager.py" line="2183" />
         <source>No OCR module available.</source>
         <translation>没有可用的 OCR 模块。</translation>
@@ -4667,9 +4642,9 @@ Continue with advanced-only packages?</source>
         <translation>设置 OCR 失败。</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="2224" />
-        <location filename="../ui/module_manager.py" line="2235" />
         <location filename="../ui/module_manager.py" line="2238" />
+        <location filename="../ui/module_manager.py" line="2235" />
+        <location filename="../ui/module_manager.py" line="2224" />
         <source>Test translator</source>
         <translation>测试翻译器</translation>
     </message>
@@ -4684,15 +4659,15 @@ Continue with advanced-only packages?</source>
         <translation>成功。</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="2245" />
         <location filename="../ui/module_manager.py" line="2283" />
+        <location filename="../ui/module_manager.py" line="2245" />
         <source>Open a project and select a page with text blocks.</source>
         <translation>打开项目并选择带有文本块的页面。</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="2245" />
-        <location filename="../ui/module_manager.py" line="2257" />
         <location filename="../ui/module_manager.py" line="2277" />
+        <location filename="../ui/module_manager.py" line="2257" />
+        <location filename="../ui/module_manager.py" line="2245" />
         <source>Copy prompt</source>
         <translation>复制提示</translation>
     </message>
@@ -4707,14 +4682,14 @@ Continue with advanced-only packages?</source>
         <translation>提示复制到剪贴板。将其粘贴到您的工具中，然后将响应粘贴回来并单击“粘贴响应”。</translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="2283" />
-        <location filename="../ui/module_manager.py" line="2287" />
-        <location filename="../ui/module_manager.py" line="2291" />
-        <location filename="../ui/module_manager.py" line="2296" />
-        <location filename="../ui/module_manager.py" line="2309" />
-        <location filename="../ui/module_manager.py" line="2314" />
-        <location filename="../ui/module_manager.py" line="2337" />
         <location filename="../ui/module_manager.py" line="2351" />
+        <location filename="../ui/module_manager.py" line="2337" />
+        <location filename="../ui/module_manager.py" line="2314" />
+        <location filename="../ui/module_manager.py" line="2309" />
+        <location filename="../ui/module_manager.py" line="2296" />
+        <location filename="../ui/module_manager.py" line="2291" />
+        <location filename="../ui/module_manager.py" line="2287" />
+        <location filename="../ui/module_manager.py" line="2283" />
         <source>Paste response</source>
         <translation>粘贴响应</translation>
     </message>
@@ -4743,13 +4718,8 @@ Continue with advanced-only packages?</source>
         <source>Response applied to {} block(s). You can run Translate again or edit in the text panel.</source>
         <translation>响应应用于 {} 个块。您可以再次运行翻译或在文本面板中进行编辑。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ModuleThread</name>
-    <message>
-        <source>Failed to set </source>
-        <translation type="obsolete">无法设置 </translation>
-    </message>
     <message>
         <location filename="../ui/module_manager.py" line="116" />
         <source>No fallback available.</source>
@@ -4760,13 +4730,8 @@ Continue with advanced-only packages?</source>
         <source>Open Tools → Manage models to check or import local model files.</source>
         <translation>打开工具→管理模型，查看或导入本地模型文件。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>OCRConfigPanel</name>
-    <message>
-        <source>Keyword substitution for OCR results</source>
-        <translation type="obsolete">替换OCR文本中的关键词</translation>
-    </message>
     <message>
         <location filename="../ui/module_parse_widgets.py" line="830" />
         <source>Delete and restore region where OCR return empty string.</source>
@@ -4787,8 +4752,39 @@ Continue with advanced-only packages?</source>
         <source>Detect font properties (e.g. bold, italic) from the image after OCR. Useful for manga/comics.</source>
         <translation>OCR 后从图像中检测字体属性（例如粗体、斜体）。对于漫画/漫画很有用。</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>OcrTriageDialog</name>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="7" />
+        <source>OCR triage worklist</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Block</source>
+        <translation type="unfinished">块</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Source</source>
+        <translation type="unfinished">源语言</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Translation</source>
+        <translation type="unfinished">翻译</translation>
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="12" />
+        <source>Issue</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/ocr_triage_dialog.py" line="23" />
+        <source>Close</source>
+        <translation type="unfinished">关闭</translation>
+    </message>
+</context><context>
     <name>PageListView</name>
     <message>
         <location filename="../ui/mainwindow.py" line="88" />
@@ -4850,8 +4846,7 @@ Continue with advanced-only packages?</source>
         <source>Remove from Project</source>
         <translation>从项目中删除</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>PageSearchWidget</name>
     <message>
         <location filename="../ui/page_search_widget.py" line="207" />
@@ -4909,8 +4904,8 @@ Continue with advanced-only packages?</source>
         <translation>范围</translation>
     </message>
     <message>
-        <location filename="../ui/page_search_widget.py" line="245" />
         <location filename="../ui/page_search_widget.py" line="249" />
+        <location filename="../ui/page_search_widget.py" line="245" />
         <source>Replace</source>
         <translation>替换</translation>
     </message>
@@ -4924,22 +4919,28 @@ Continue with advanced-only packages?</source>
         <source>Close (Escape)</source>
         <translation>关闭 (Esc)</translation>
     </message>
-</context>
-<context>
+</context><context>
+    <name>ParamComboBox</name>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="77" />
+        <source>Flush</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/custom_widget/combobox.py" line="80" />
+        <source>Select Path</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>ParamWidget</name>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="193" />
         <location filename="../ui/module_parse_widgets.py" line="278" />
+        <location filename="../ui/module_parse_widgets.py" line="193" />
         <source>Default</source>
         <translation>默认</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>PenConfigPanel</name>
-    <message>
-        <source>alpha value</source>
-        <translation type="obsolete">alpha值</translation>
-    </message>
     <message>
         <location filename="../ui/drawingpanel.py" line="152" />
         <source>Color</source>
@@ -4956,10 +4957,6 @@ Continue with advanced-only packages?</source>
         <translation>大小</translation>
     </message>
     <message>
-        <source>pen thickness </source>
-        <translation type="obsolete">画笔大小 </translation>
-    </message>
-    <message>
         <location filename="../ui/drawingpanel.py" line="166" />
         <source>Shape</source>
         <translation>形状</translation>
@@ -4974,85 +4971,12 @@ Continue with advanced-only packages?</source>
         <source>Rectangle</source>
         <translation>方形</translation>
     </message>
-</context>
-<context>
-    <name>PresetListWidget</name>
-    <message>
-        <source>preset</source>
-        <translation type="obsolete">预设</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation type="obsolete">删除</translation>
-    </message>
-    <message>
-        <source>New preset</source>
-        <translation type="obsolete">新建预设</translation>
-    </message>
-    <message>
-        <source>Load preset</source>
-        <translation type="obsolete">载入预设</translation>
-    </message>
-</context>
-<context>
-    <name>PresetPanel</name>
-    <message>
-        <source>New</source>
-        <translation type="obsolete">新建</translation>
-    </message>
-    <message>
-        <source>Create new preset: </source>
-        <translation type="obsolete">新建预设: </translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation type="obsolete">删除</translation>
-    </message>
-    <message>
-        <source>Load</source>
-        <translation type="obsolete">加载</translation>
-    </message>
-    <message>
-        <source>Load preset as global format</source>
-        <translation type="obsolete">加载预设为全局字体格式</translation>
-    </message>
-    <message>
-        <source>Exit</source>
-        <translation type="obsolete">退出</translation>
-    </message>
-    <message>
-        <source>Text Style Presets</source>
-        <translation type="obsolete">字体样式预设</translation>
-    </message>
-</context>
-<context>
-    <name>ProgressMessageBox</name>
-    <message>
-        <source>Detecting: </source>
-        <translation type="obsolete">检测: </translation>
-    </message>
-    <message>
-        <source>OCR: </source>
-        <translation type="obsolete">OCR: </translation>
-    </message>
-    <message>
-        <source>Inpainting: </source>
-        <translation type="obsolete">修复: </translation>
-    </message>
-    <message>
-        <source>Translating: </source>
-        <translation type="obsolete">翻译: </translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>RectPanel</name>
     <message>
-        <source>method 1</source>
-        <translation type="vanished">方法1</translation>
-    </message>
-    <message>
-        <source>method 2</source>
-        <translation type="vanished">方法2</translation>
+        <location filename="../ui/drawingpanel.py" line="214" />
+        <source>Dilate</source>
+        <translation>膨胀</translation>
     </message>
     <message>
         <location filename="../ui/drawingpanel.py" line="217" />
@@ -5120,6 +5044,11 @@ Continue with advanced-only packages?</source>
         <translation>图像修复</translation>
     </message>
     <message>
+        <location filename="../ui/drawingpanel.py" line="244" />
+        <source>Space</source>
+        <translation>空格</translation>
+    </message>
+    <message>
         <location filename="../ui/drawingpanel.py" line="246" />
         <source>Fill</source>
         <translation>充满</translation>
@@ -5135,25 +5064,6 @@ Continue with advanced-only packages?</source>
         <translation>删除</translation>
     </message>
     <message>
-        <location filename="../ui/drawingpanel.py" line="266" />
-        <source>Shape</source>
-        <translation>形状</translation>
-    </message>
-    <message>
-        <location filename="../ui/drawingpanel.py" line="214" />
-        <source>Dilate</source>
-        <translation>膨胀</translation>
-    </message>
-    <message>
-        <source>kernel size: </source>
-        <translation type="obsolete">核大小: </translation>
-    </message>
-    <message>
-        <location filename="../ui/drawingpanel.py" line="244" />
-        <source>Space</source>
-        <translation>空格</translation>
-    </message>
-    <message>
         <location filename="../ui/drawingpanel.py" line="250" />
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
@@ -5164,11 +5074,11 @@ Continue with advanced-only packages?</source>
         <translation>修复工具</translation>
     </message>
     <message>
-        <source>Use Existing Mask</source>
-        <translation type="vanished">使用区域已有掩膜</translation>
+        <location filename="../ui/drawingpanel.py" line="266" />
+        <source>Shape</source>
+        <translation>形状</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>SelectTextMiniMenu</name>
     <message>
         <location filename="../ui/textedit_area.py" line="30" />
@@ -5180,79 +5090,137 @@ Continue with advanced-only packages?</source>
         <source>Look up selected text in SalaDict, see installation guide in configpanel</source>
         <translation>沙拉查词查询选中文本，在设置面板查看安装说明</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>SelectionWithConfigWidget</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1392" />
+        <location filename="../ui/mainwindowbars.py" line="1423" />
         <source>Open module settings</source>
         <translation>打开模块设置</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="36" />
+        <location filename="../ui/shortcuts_dialog.py" line="38" />
         <source>Keyboard Shortcuts</source>
         <translation>键盘快捷键</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="48" />
+        <location filename="../ui/shortcuts_dialog.py" line="50" />
         <source>Filter:</source>
         <translation>筛选：</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="50" />
+        <location filename="../ui/shortcuts_dialog.py" line="52" />
         <source>Search action or category...</source>
         <translation>搜索操作或类别...</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="54" />
+        <location filename="../ui/shortcuts_dialog.py" line="56" />
         <source>All categories</source>
         <translation>所有类别</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="59" />
+        <location filename="../ui/shortcuts_dialog.py" line="61" />
         <source>Category:</source>
         <translation>类别：</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="67" />
+        <location filename="../ui/shortcuts_dialog.py" line="66" />
+        <source>Find by key:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="76" />
         <source>Category</source>
         <translation>类别</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="68" />
+        <location filename="../ui/shortcuts_dialog.py" line="77" />
         <source>Action</source>
         <translation>行动</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="69" />
+        <location filename="../ui/shortcuts_dialog.py" line="78" />
         <source>Shortcut</source>
         <translation>捷径</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="85" />
+        <location filename="../ui/shortcuts_dialog.py" line="94" />
         <source>Reset all to default</source>
         <translation>全部重置为默认值</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="88" />
+        <location filename="../ui/shortcuts_dialog.py" line="97" />
+        <source>Export JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="100" />
+        <source>Import JSON</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="103" />
         <source>Apply</source>
         <translation>申请</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="92" />
+        <location filename="../ui/shortcuts_dialog.py" line="107" />
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../ui/shortcuts_dialog.py" line="120" />
+        <location filename="../ui/shortcuts_dialog.py" line="135" />
         <source>Reset</source>
         <translation>重置</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>Export shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <location filename="../ui/shortcuts_dialog.py" line="198" />
+        <source>JSON files (*.json)</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="206" />
+        <source>Import shortcuts</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="222" />
+        <source>Import failed</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="239" />
+        <source>Shortcut conflicts found:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="241" />
+        <source>Hard conflicts:</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="246" />
+        <source>Alias conflicts (alternate variants):</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="251" />
+        <source>Auto-resolve can keep first action and clear duplicates. Apply auto-resolve?</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/shortcuts_dialog.py" line="252" />
+        <source>Shortcut conflicts</source>
+        <translation type="unfinished" />
+    </message>
+</context><context>
     <name>SpellCheckPanel</name>
     <message>
         <location filename="../ui/spellcheck_panel.py" line="34" />
@@ -5290,8 +5258,8 @@ Continue with advanced-only packages?</source>
         <translation>替换为建议</translation>
     </message>
     <message>
-        <location filename="../ui/spellcheck_panel.py" line="76" />
         <location filename="../ui/spellcheck_panel.py" line="86" />
+        <location filename="../ui/spellcheck_panel.py" line="76" />
         <source>Spell check</source>
         <translation>拼写检查</translation>
     </message>
@@ -5310,87 +5278,7 @@ Continue with advanced-only packages?</source>
         <source>(no suggestions)</source>
         <translation>（没有建议）</translation>
     </message>
-</context>
-<context>
-    <name>StartupModelCoverage</name>
-    <message>
-        <source>Copy model files from an existing local folder into this app\'s data/models directory.</source>
-        <translation type="vanished">从现有本地文件夹复制模型文件到本应用的 data/models 目录。</translation>
-    </message>
-    <message>
-        <source>Core package</source>
-        <translation type="vanished">核心包</translation>
-    </message>
-    <message>
-        <source>Core package not selected</source>
-        <translation type="vanished">未选择核心包</translation>
-    </message>
-    <message>
-        <source>Do not download any model package now. Use only already-local modules/files.</source>
-        <translation type="vanished">暂不下载任何模型包。仅使用已在本地的模块/文件。</translation>
-    </message>
-    <message>
-        <source>Download complete. Defaults updated.</source>
-        <translation type="vanished">下载完成。默认配置已更新。</translation>
-    </message>
-    <message>
-        <source>Download partially complete.</source>
-        <translation type="vanished">下载部分完成。</translation>
-    </message>
-    <message>
-        <source>First-run local-only mode is active. Use Tools → Manage models to import/download models, or edit config/config.json to enable packages and restart.</source>
-        <translation type="vanished">首次运行的仅本地模式已启用。请使用“工具 → 管理模型”导入/下载模型，或编辑 config/config.json 启用模型包后重启。</translation>
-    </message>
-    <message>
-        <source>Import local model directory...</source>
-        <translation type="vanished">导入本地模型目录...</translation>
-    </message>
-    <message>
-        <source>Import local models</source>
-        <translation type="vanished">导入本地模型</translation>
-    </message>
-    <message>
-        <source>Manual package selection</source>
-        <translation type="vanished">手动选择模型包</translation>
-    </message>
-    <message>
-        <source>Manually select low-level packages instead of using a preset.</source>
-        <translation type="vanished">手动选择底层模型包，而不是使用预设。</translation>
-    </message>
-    <message>
-        <source>Model package download complete</source>
-        <translation type="vanished">模型包下载完成</translation>
-    </message>
-    <message>
-        <source>Model package download partially complete</source>
-        <translation type="vanished">模型包下载部分完成</translation>
-    </message>
-    <message>
-        <source>Model packages have been downloaded. Applied modules:\n</source>
-        <translation type="vanished">模型包已下载。已应用模块：\n</translation>
-    </message>
-    <message>
-        <source>Open Manage Models</source>
-        <translation type="vanished">打开“管理模型”</translation>
-    </message>
-    <message>
-        <source>Select local model directory</source>
-        <translation type="vanished">选择本地模型目录</translation>
-    </message>
-    <message>
-        <source>Skip all downloads (local-only)</source>
-        <translation type="vanished">跳过所有下载（仅本地）</translation>
-    </message>
-    <message>
-        <source>Some model packages failed. Failed items: {0}</source>
-        <translation type="vanished">部分模型包失败。失败项：{0}</translation>
-    </message>
-    <message>
-        <source>Summary: downloaded {0}, failed {1}, skipped {2}.</source>
-        <translation type="vanished">摘要：下载 {0} 个，失败 {1} 个，跳过 {2} 个。</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>SubtitleFileTranslateThread</name>
     <message>
         <location filename="../ui/subtitle_file_translator_dialog.py" line="94" />
@@ -5417,8 +5305,7 @@ Continue with advanced-only packages?</source>
         <source>Translation failed (API error).</source>
         <translation>翻译失败（API 错误）。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>SubtitleFileTranslatorDialog</name>
     <message>
         <location filename="../ui/subtitle_file_translator_dialog.py" line="184" />
@@ -5426,7 +5313,7 @@ Continue with advanced-only packages?</source>
         <translation>翻译字幕文件...</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="195" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="194" />
         <source>Uses the translator selected in Config (recommended: LLM_API_Translator + OpenRouter). Batching follows Video translator NLP settings (chunk size / parallel workers).</source>
         <translation>使用在 Config 中选择的转换器（推荐：LLM_API_Translator + OpenRouter）。批处理遵循视频转换器 NLP 设置（块大小/并行工作人员）。</translation>
     </message>
@@ -5456,13 +5343,13 @@ Continue with advanced-only packages?</source>
         <translation>SubRip (.srt)</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
         <location filename="../ui/subtitle_file_translator_dialog.py" line="239" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="216" />
         <source>Timestamped text (.txt)</source>
         <translation>带时间戳的文本 (.txt)</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="219" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="218" />
         <source>Timestamped text: one cue per line, e.g. [00:01:02,345 --&gt; 00:01:05,678] Hello</source>
         <translation>带时间戳的文本：每行一个提示，例如[00:01:02,345 --&gt; 00:01:05,678] 你好</translation>
     </message>
@@ -5502,7 +5389,7 @@ Continue with advanced-only packages?</source>
         <translation>系列翻译上下文</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="248" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="247" />
         <source>Loads series glossary (glossary.txt under data/translation_context/). Leave blank to use the translator’s Series context path from Config.</source>
         <translation>加载系列术语表（data/translation_context/下的glossary.txt）。留空以使用 Config 中翻译器的系列上下文路径。</translation>
     </message>
@@ -5517,12 +5404,12 @@ Continue with advanced-only packages?</source>
         <translation>包括系列商店中的最新页面 (recent_context.json)</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="268" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="267" />
         <source>Uses the same “previous pages” count as the translator config. Requires an existing series folder with recent_context.json (e.g. from comic translation).</source>
         <translation>使用与翻译器配置相同的“前一页”计数。需要一个包含centre_context.json的现有系列文件夹（例如来自漫画翻译）。</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="276" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="275" />
         <source>Extra project glossary for this run only (merged with series + translator; one line per entry):</source>
         <translation>仅适用于本次运行的额外项目词汇表（与系列+翻译器合并；每个条目一行）：</translation>
     </message>
@@ -5554,8 +5441,8 @@ Continue with advanced-only packages?</source>
         <translation>翻译并另存为...</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
         <location filename="../ui/subtitle_file_translator_dialog.py" line="464" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="310" />
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -5600,7 +5487,7 @@ Continue with advanced-only packages?</source>
         <translation>翻译者</translation>
     </message>
     <message>
-        <location filename="../ui/subtitle_file_translator_dialog.py" line="375" />
+        <location filename="../ui/subtitle_file_translator_dialog.py" line="374" />
         <source>Current translator is '%s'. OpenRouter works best with LLM_API_Translator. Continue anyway?</source>
         <translation>当前翻译者是“%s”。 OpenRouter 与 LLM_API_Translator 配合使用效果最佳。还是继续吗？</translation>
     </message>
@@ -5641,8 +5528,7 @@ Continue with advanced-only packages?</source>
         <source>Translation is still running. Close anyway?</source>
         <translation>翻译仍在进行中。还是关闭吧？</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextAdvancedFormatPanel</name>
     <message>
         <location filename="../ui/text_advanced_format.py" line="170" />
@@ -5665,11 +5551,6 @@ Continue with advanced-only packages?</source>
         <translation>文本不透明度</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="209" />
-        <source>Shadow</source>
-        <translation>阴影</translation>
-    </message>
-    <message>
         <location filename="../ui/text_advanced_format.py" line="184" />
         <source>Opacity</source>
         <translation>不透明度</translation>
@@ -5680,8 +5561,8 @@ Continue with advanced-only packages?</source>
         <translation>细体</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="195" />
         <location filename="../ui/text_advanced_format.py" line="228" />
+        <location filename="../ui/text_advanced_format.py" line="195" />
         <source>Normal</source>
         <translation>常规</translation>
     </message>
@@ -5711,14 +5592,9 @@ Continue with advanced-only packages?</source>
         <translation>字重</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="230" />
-        <source>Blend mode for compositing with the page image</source>
-        <translation>与页面图像的混合模式</translation>
-    </message>
-    <message>
-        <location filename="../ui/text_advanced_format.py" line="232" />
-        <source>Blend Mode</source>
-        <translation>混合模式</translation>
+        <location filename="../ui/text_advanced_format.py" line="209" />
+        <source>Shadow</source>
+        <translation>阴影</translation>
     </message>
     <message>
         <location filename="../ui/text_advanced_format.py" line="228" />
@@ -5744,6 +5620,16 @@ Continue with advanced-only packages?</source>
         <location filename="../ui/text_advanced_format.py" line="228" />
         <source>Lighten</source>
         <translation>变亮</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="230" />
+        <source>Blend mode for compositing with the page image</source>
+        <translation>与页面图像的混合模式</translation>
+    </message>
+    <message>
+        <location filename="../ui/text_advanced_format.py" line="232" />
+        <source>Blend Mode</source>
+        <translation>混合模式</translation>
     </message>
     <message>
         <location filename="../ui/text_advanced_format.py" line="238" />
@@ -5785,8 +5671,7 @@ Continue with advanced-only packages?</source>
         <source>Skew Y</source>
         <translation>倾斜 Y</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextDetectConfigPanel</name>
     <message>
         <location filename="../ui/module_parse_widgets.py" line="615" />
@@ -5814,7 +5699,7 @@ Continue with advanced-only packages?</source>
         <translation>仅外部气泡</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="633" />
+        <location filename="../ui/module_parse_widgets.py" line="632" />
         <source>Only add secondary detector boxes that are outside primary (bubble) regions. Use when primary is good at bubbles (e.g. YSGYOLO) and secondary is for signs/captions (e.g. EasyOCR).</source>
         <translation>仅添加主要（气泡）区域之外的辅助检测器框。当主要擅长气泡（例如 YSGYOLO）和次要擅长标志/标题（例如 EasyOCR）时使用。</translation>
     </message>
@@ -5839,7 +5724,7 @@ Continue with advanced-only packages?</source>
         <translation>OSB 布局后备（垂直堆叠 + 恢复原始）</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="656" />
+        <location filename="../ui/module_parse_widgets.py" line="655" />
         <source>When checked (default), if layout fails for outside-speech-bubble (OSB) blocks, retry with vertical stacking; if that fails, restore the original image region. Uncheck to only mark failed OSB blocks and restore original (no vertical retry).</source>
         <translation>选中后（默认），如果外部语音气泡 (OSB) 块的布局失败，请重试垂直堆叠；如果失败，则恢复原始图像区域。取消选中仅标记失败的 OSB 块并恢复原始块（无垂直重试）。</translation>
     </message>
@@ -5849,7 +5734,7 @@ Continue with advanced-only packages?</source>
         <translation>允许倾斜文本框旋转</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="664" />
+        <location filename="../ui/module_parse_widgets.py" line="663" />
         <source>When enabled, text detection can set the rotation angle of horizontal boxes for slanted text. Only angles at or above the threshold are applied; smaller slants stay 0°.</source>
         <translation>启用后，文本检测可以设置倾斜文本的水平框的旋转角度。仅应用等于或高于阈值的角度；较小的倾斜保持 0°。</translation>
     </message>
@@ -5868,114 +5753,7 @@ Continue with advanced-only packages?</source>
         <source>Tertiary detector params:</source>
         <translation>三级探测器参数：</translation>
     </message>
-</context>
-<context>
-    <name>TextEffectPanel</name>
-    <message>
-        <source>Effect</source>
-        <translation type="obsolete">特效</translation>
-    </message>
-    <message>
-        <source>Opacity</source>
-        <translation type="obsolete">不透明度</translation>
-    </message>
-    <message>
-        <source>Shadow</source>
-        <translation type="obsolete">阴影</translation>
-    </message>
-    <message>
-        <source>Change shadow color</source>
-        <translation type="obsolete">修改阴影颜色</translation>
-    </message>
-    <message>
-        <source>Apply</source>
-        <translation type="obsolete">应用</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="obsolete">取消</translation>
-    </message>
-    <message>
-        <source>Opacity: </source>
-        <translation type="obsolete">不透明度: </translation>
-    </message>
-    <message>
-        <source>radius: </source>
-        <translation type="obsolete">半径: </translation>
-    </message>
-    <message>
-        <source>strength: </source>
-        <translation type="obsolete">强度: </translation>
-    </message>
-    <message>
-        <source>x offset: </source>
-        <translation type="obsolete">x偏移: </translation>
-    </message>
-    <message>
-        <source>y offset: </source>
-        <translation type="obsolete">y偏移: </translation>
-    </message>
-    <message>
-        <source>radius</source>
-        <translation type="obsolete">半径</translation>
-    </message>
-    <message>
-        <source>strength</source>
-        <translation type="obsolete">强度</translation>
-    </message>
-    <message>
-        <source>x offset</source>
-        <translation type="obsolete">x偏移</translation>
-    </message>
-    <message>
-        <source>y offset</source>
-        <translation type="obsolete">y偏移</translation>
-    </message>
-</context>
-<context>
-    <name>TextEffectPanelDeprecated</name>
-    <message>
-        <source>Effect</source>
-        <translation type="obsolete">特效</translation>
-    </message>
-    <message>
-        <source>Opacity</source>
-        <translation type="obsolete">不透明度</translation>
-    </message>
-    <message>
-        <source>Shadow</source>
-        <translation type="obsolete">阴影</translation>
-    </message>
-    <message>
-        <source>Change shadow color</source>
-        <translation type="obsolete">修改阴影颜色</translation>
-    </message>
-    <message>
-        <source>radius</source>
-        <translation type="obsolete">半径</translation>
-    </message>
-    <message>
-        <source>strength</source>
-        <translation type="obsolete">强度</translation>
-    </message>
-    <message>
-        <source>x offset</source>
-        <translation type="obsolete">x偏移</translation>
-    </message>
-    <message>
-        <source>y offset</source>
-        <translation type="obsolete">y偏移</translation>
-    </message>
-    <message>
-        <source>Apply</source>
-        <translation type="obsolete">应用</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="obsolete">取消</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>TextGradientGroup</name>
     <message>
         <location filename="../ui/text_advanced_format.py" line="91" />
@@ -6008,14 +5786,14 @@ Continue with advanced-only packages?</source>
         <translation>径向</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="119" />
-        <source>Set Gradient Angle</source>
-        <translation>渐变方向</translation>
+        <location filename="../ui/text_advanced_format.py" line="106" />
+        <source>Gradient type: Linear or Radial</source>
+        <translation>渐变类型：线性或径向</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="121" />
-        <source>Angle</source>
-        <translation>方向</translation>
+        <location filename="../ui/text_advanced_format.py" line="108" />
+        <source>Type</source>
+        <translation>类型</translation>
     </message>
     <message>
         <location filename="../ui/text_advanced_format.py" line="112" />
@@ -6028,22 +5806,17 @@ Continue with advanced-only packages?</source>
         <translation>范围</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="106" />
-        <source>Gradient type: Linear or Radial</source>
-        <translation>渐变类型：线性或径向</translation>
+        <location filename="../ui/text_advanced_format.py" line="119" />
+        <source>Set Gradient Angle</source>
+        <translation>渐变方向</translation>
     </message>
     <message>
-        <location filename="../ui/text_advanced_format.py" line="108" />
-        <source>Type</source>
-        <translation>类型</translation>
+        <location filename="../ui/text_advanced_format.py" line="121" />
+        <source>Angle</source>
+        <translation>方向</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextShadowGroup</name>
-    <message>
-        <source>Shadow</source>
-        <translation type="obsolete">阴影</translation>
-    </message>
     <message>
         <location filename="../ui/text_advanced_format.py" line="17" />
         <source>Set X offset</source>
@@ -6079,39 +5852,7 @@ Continue with advanced-only packages?</source>
         <source>Offset</source>
         <translation>偏移量</translation>
     </message>
-</context>
-<context>
-    <name>TextStyleArea</name>
-    <message>
-        <source>Style</source>
-        <translation type="obsolete">样式</translation>
-    </message>
-    <message>
-        <source>New Text Style</source>
-        <translation type="obsolete">新建字体样式</translation>
-    </message>
-    <message>
-        <source>Remove All</source>
-        <translation type="obsolete">清空</translation>
-    </message>
-    <message>
-        <source>Remove all styles?</source>
-        <translation type="obsolete">清空所有样式?</translation>
-    </message>
-    <message>
-        <source>Remove all</source>
-        <translation type="obsolete">清空</translation>
-    </message>
-    <message>
-        <source>Import Text Styles</source>
-        <translation type="obsolete">导入字体样式</translation>
-    </message>
-    <message>
-        <source>Export Text Styles</source>
-        <translation type="obsolete">导出字体样式</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>TextStyleLabel</name>
     <message>
         <location filename="../ui/text_style_presets.py" line="87" />
@@ -6133,8 +5874,7 @@ Continue with advanced-only packages?</source>
         <source>Delete Style</source>
         <translation>删除</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TextStylePresetPanel</name>
     <message>
         <location filename="../ui/text_style_presets.py" line="277" />
@@ -6142,8 +5882,8 @@ Continue with advanced-only packages?</source>
         <translation>样式</translation>
     </message>
     <message>
-        <location filename="../ui/text_style_presets.py" line="281" />
         <location filename="../ui/text_style_presets.py" line="461" />
+        <location filename="../ui/text_style_presets.py" line="281" />
         <source>New Text Style</source>
         <translation>新建字体样式</translation>
     </message>
@@ -6172,8 +5912,7 @@ Continue with advanced-only packages?</source>
         <source>Export Text Styles</source>
         <translation>导出字体样式</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>ThemeCustomizerDialog</name>
     <message>
         <location filename="../ui/theme_customizer_dialog.py" line="52" />
@@ -6196,8 +5935,8 @@ Continue with advanced-only packages?</source>
         <translation>使用深色主题（Eva Dark）。取消选中灯光 (Eva Light)。</translation>
     </message>
     <message>
-        <location filename="../ui/theme_customizer_dialog.py" line="67" />
         <location filename="../ui/theme_customizer_dialog.py" line="137" />
+        <location filename="../ui/theme_customizer_dialog.py" line="67" />
         <source>Accent color</source>
         <translation>强调色</translation>
     </message>
@@ -6261,15 +6000,7 @@ Continue with advanced-only packages?</source>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
-</context>
-<context>
-    <name>ThreadBase</name>
-    <message>
-        <source>Execution error</source>
-        <translation type="obsolete">执行错误</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>TitleBar</name>
     <message>
         <location filename="../ui/mainwindowbars.py" line="443" />
@@ -6297,18 +6028,174 @@ Continue with advanced-only packages?</source>
         <translation>全局搜索</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindowbars.py" line="458" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>替换机翻前文本关键字</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="460" />
+        <source>Keyword substitution for machine translation</source>
+        <translation>替换机翻结果中的关键词</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="462" />
+        <source>Keyword substitution for source text</source>
+        <translation>替换原文关键词</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="465" />
+        <source>Translation context (project)...</source>
+        <translation>翻译上下文（项目）...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="468" />
+        <source>Keyword substitution</source>
+        <translation>关键词替换</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindowbars.py" line="484" />
         <source>View</source>
         <translation>视图</translation>
     </message>
     <message>
-        <source>Drawing Board </source>
-        <translation type="obsolete">画板 </translation>
+        <location filename="../ui/mainwindowbars.py" line="486" />
+        <source>Display Language</source>
+        <translation>界面语言</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="500" />
+        <source>Drawing Board</source>
+        <translation>画板</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="502" />
         <source>Text Editor</source>
         <translation>编辑器</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="504" />
+        <source>Import Text Styles</source>
+        <translation>导入字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="505" />
+        <source>Export Text Styles</source>
+        <translation>导出字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="506" />
+        <source>Spell check panel</source>
+        <translation>拼写检查面板</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="507" />
+        <source>Show spell check panel (PR #974).</source>
+        <translation>显示拼写检查面板（PR #974）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="509" />
+        <source>Keyboard Shortcuts...</source>
+        <translation>键盘快捷键...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="512" />
+        <source>Context menu options...</source>
+        <translation>右键菜单选项...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="514" />
+        <source>Show or hide canvas right-click menu actions by category.</source>
+        <translation>按类别显示或隐藏画布右键菜单项。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="516" />
+        <source>Dark Mode</source>
+        <translation>深色模式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="518" />
+        <source>Light</source>
+        <translation>浅色</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="519" />
+        <source>Use light theme (Eva Light).</source>
+        <translation>使用浅色主题（Eva Light）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="520" />
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="521" />
+        <source>Use dark theme (Eva Dark).</source>
+        <translation>使用深色主题（Eva Dark）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="530" />
+        <source>Bubbly UI</source>
+        <translation>Bubbly 界面</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="532" />
+        <source>Rounder corners, gradients, and softer look.</source>
+        <translation>更圆角、渐变与柔和外观。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="538" />
+        <source>Help</source>
+        <translation>帮助</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="539" />
+        <source>Documentation</source>
+        <translation>文档</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="540" />
+        <source>Open project README (installation and usage).</source>
+        <translation>打开项目 README（安装与使用）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="541" />
+        <source>About</source>
+        <translation>关于</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="542" />
+        <source>Show application version and info.</source>
+        <translation>显示应用版本与信息。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="543" />
+        <source>Update from GitHub</source>
+        <translation>从 GitHub 更新</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="544" />
+        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
+        <translation>从 GitHub 拉取最新更改。保留配置与本地文件不变。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="561" />
+        <source>Theme</source>
+        <translation>主题</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="567" />
+        <source>Theme and UI customizer...</source>
+        <translation>主题和 UI 定制器...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="568" />
+        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
+        <translation>更改强调色、应用字体、浅/深色、简洁/高级界面。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="584" />
+        <source>Region merge tool</source>
+        <translation>区域合并工具</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="600" />
@@ -6324,283 +6211,6 @@ Continue with advanced-only packages?</source>
         <location filename="../ui/mainwindowbars.py" line="602" />
         <source>Next Page</source>
         <translation>下一页</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="742" />
-        <source>Run</source>
-        <translation>运行</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="744" />
-        <source>Translate page</source>
-        <translation>翻译本页</translation>
-    </message>
-    <message>
-        <source>Text Style Presets</source>
-        <translation type="obsolete">字体样式预设</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="516" />
-        <source>Dark Mode</source>
-        <translation>深色模式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="460" />
-        <source>Keyword substitution for machine translation</source>
-        <translation>替换机翻结果中的关键词</translation>
-    </message>
-    <message>
-        <source>Keyword substitution for OCR results</source>
-        <translation type="obsolete">替换OCR文本中的关键词</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="486" />
-        <source>Display Language</source>
-        <translation>界面语言</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="500" />
-        <source>Drawing Board</source>
-        <translation>画板</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="732" />
-        <source>Enable Text Dection</source>
-        <translation>启用文本检测</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="733" />
-        <source>Enable OCR</source>
-        <translation>启用OCR</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="734" />
-        <source>Enable Translation</source>
-        <translation>启用翻译</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="735" />
-        <source>Enable Inpainting</source>
-        <translation>启用修复</translation>
-    </message>
-    <message>
-        <source>Text Styles Panel</source>
-        <translation type="obsolete">字体样式面板</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="504" />
-        <source>Import Text Styles</source>
-        <translation>导入字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="505" />
-        <source>Export Text Styles</source>
-        <translation>导出字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="743" />
-        <source>Run without update textstyle</source>
-        <translation>运行且不更新字体样式</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="462" />
-        <source>Keyword substitution for source text</source>
-        <translation>替换原文关键词</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="458" />
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>替换机翻前文本关键字</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="650" />
-        <source>Manage models...</source>
-        <translation>管理模型...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="651" />
-        <source>Check which models are downloaded and download selected models.</source>
-        <translation>查看已下载的模型并下载所选模型。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="654" />
-        <source>Retry model downloads</source>
-        <translation>重试下载模型</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="655" />
-        <source>Retry downloading model packages (e.g. after a failed first install).</source>
-        <translation>重新下载模型包（例如首次安装失败后可使用）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="702" />
-        <source>Models</source>
-        <translation>模型</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="637" />
-        <source>Show last batch report</source>
-        <translation>显示上次批处理报告</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="793" />
-        <source>File</source>
-        <translation>文件</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1236" />
-        <source>Open Folder ...</source>
-        <translation>打开文件夹...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1238" />
-        <source>Open Images ...</source>
-        <translation>打开图片...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1240" />
-        <source>Open Project ... *.json</source>
-        <translation>打开项目... *.json</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1245" />
-        <source>Close project and go to welcome screen</source>
-        <translation>关闭项目并转到欢迎页</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1249" />
-        <source>Save Project</source>
-        <translation>保存项目</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="691" />
-        <location filename="../ui/mainwindowbars.py" line="1253" />
-        <source>Export</source>
-        <translation>导出</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="849" />
-        <source>Show search results</source>
-        <translation>显示搜索结果</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1254" />
-        <source>Export as Doc</source>
-        <translation>导出为 Word 文档</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1256" />
-        <source>Export current page as...</source>
-        <translation>导出当前页为...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1258" />
-        <source>Export source text as TXT</source>
-        <translation>导出原文为 TXT</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1260" />
-        <source>Export translation as TXT</source>
-        <translation>导出译文为 TXT</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1262" />
-        <source>Export source text as markdown</source>
-        <translation>导出原文为 Markdown</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1264" />
-        <source>Export translation as markdown</source>
-        <translation>导出译文为 Markdown</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1270" />
-        <source>Import</source>
-        <translation>导入</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1271" />
-        <source>Import from Doc</source>
-        <translation>从 Word 导入</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="1273" />
-        <source>Import translation from TXT/markdown</source>
-        <translation>从 TXT/Markdown 导入译文</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="465" />
-        <source>Translation context (project)...</source>
-        <translation>翻译上下文（项目）...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="468" />
-        <source>Keyword substitution</source>
-        <translation>关键词替换</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="506" />
-        <source>Spell check panel</source>
-        <translation>拼写检查面板</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="509" />
-        <source>Keyboard Shortcuts...</source>
-        <translation>键盘快捷键...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="512" />
-        <source>Context menu options...</source>
-        <translation>右键菜单选项...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="518" />
-        <source>Light</source>
-        <translation>浅色</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="520" />
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="530" />
-        <source>Bubbly UI</source>
-        <translation>Bubbly 界面</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="538" />
-        <source>Help</source>
-        <translation>帮助</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="539" />
-        <source>Documentation</source>
-        <translation>文档</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="541" />
-        <source>About</source>
-        <translation>关于</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="543" />
-        <source>Update from GitHub</source>
-        <translation>从 GitHub 更新</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="561" />
-        <source>Theme</source>
-        <translation>主题</translation>
-    </message>
-    <message>
-        <source>Theme &amp; UI customizer...</source>
-        <translation type="vanished">主题与界面自定义...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="584" />
-        <source>Region merge tool</source>
-        <translation>区域合并工具</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="603" />
@@ -6638,9 +6248,24 @@ Continue with advanced-only packages?</source>
         <translation>导出全部页面为...</translation>
     </message>
     <message>
+        <location filename="../ui/mainwindowbars.py" line="632" />
+        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
+        <translation>选择输出文件夹与格式（PNG、JPEG、WebP、JXL）。</translation>
+    </message>
+    <message>
         <location filename="../ui/mainwindowbars.py" line="634" />
         <source>Check project</source>
         <translation>检查项目</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="637" />
+        <source>Show last batch report</source>
+        <translation>显示上次批处理报告</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="638" />
+        <source>Open the report of skipped pages from the last pipeline run.</source>
+        <translation>打开上次流程运行中跳过页面的报告。</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="643" />
@@ -6651,6 +6276,31 @@ Continue with advanced-only packages?</source>
         <location filename="../ui/mainwindowbars.py" line="646" />
         <source>Batch queue...</source>
         <translation>批处理队列...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="647" />
+        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
+        <translation>按顺序处理多个文件夹，支持暂停/取消（issue #1020）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="650" />
+        <source>Manage models...</source>
+        <translation>管理模型...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="651" />
+        <source>Check which models are downloaded and download selected models.</source>
+        <translation>查看已下载的模型并下载所选模型。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="654" />
+        <source>Retry model downloads</source>
+        <translation>重试下载模型</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="655" />
+        <source>Retry downloading model packages (e.g. after a failed first install).</source>
+        <translation>重新下载模型包（例如首次安装失败后可使用）。</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="657" />
@@ -6714,219 +6364,307 @@ Continue with advanced-only packages?</source>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="676" />
+        <source>Environment doctor...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="677" />
+        <source>Run dependency and auth checks and show a report.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="680" />
+        <source>OCR triage worklist (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="681" />
+        <source>Show blocks that likely need OCR/translation review and triage.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="684" />
+        <source>Auto-extract glossary (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="685" />
+        <source>Extract frequent source terms and append to project glossary.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="688" />
+        <source>Translation QA report (current page)...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="689" />
+        <source>Run glossary candidate extraction and guardrail checks on current page.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="692" />
+        <source>Save run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="693" />
+        <source>Save current module selections as a project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="696" />
+        <source>Apply run profile snapshot...</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="697" />
+        <source>Apply a previously saved project-local run profile.</source>
+        <translation type="unfinished" />
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="700" />
         <source>Release model caches</source>
         <translation>释放模型缓存</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="680" />
-        <source>Clear OCR and translation caches</source>
-        <translation>清除 OCR 与翻译缓存</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="685" />
-        <source>Project</source>
-        <translation>项目</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="694" />
-        <source>Export translation to LPtxt...</source>
-        <translation>导出译文为 LPtxt...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="698" />
-        <source>Sources</source>
-        <translation>来源</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="700" />
-        <source>Queue</source>
-        <translation>队列</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="762" />
-        <source>Video translator...</source>
-        <translation>视频翻译器...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="763" />
-        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
-        <translation>翻译视频中的硬编码字幕：每帧检测、OCR、翻译、修复。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="766" />
-        <source>Translate subtitle file…</source>
-        <translation>翻译字幕文件...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="768" />
-        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
-        <translation>使用配置的转换器（通过 LLM API 的 OpenRouter）翻译独立的 .srt 或带时间戳的 .txt。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="772" />
-        <source>Video Subtitle Editor...</source>
-        <translation>视频字幕编辑器...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="773" />
-        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
-        <translation>编辑视频字幕：剪切、编辑文本、帧精确定时、导出 SRT/ASS/VTT、使用内置字幕进行渲染。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="796" />
-        <source>BallonsTranslatorPro</source>
-        <translation>气球翻译器Pro</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="803" />
-        <source>Search: menus, settings, canvas…</source>
-        <translation>搜索：菜单、设置、画布…</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="729" />
-        <source>Pipeline</source>
-        <translation>流程</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="745" />
-        <source>Preset: Full</source>
-        <translation>预设：完整</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="746" />
-        <source>Preset: Detect + OCR only</source>
-        <translation>预设：仅检测 + OCR</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="747" />
-        <source>Preset: Translate only</source>
-        <translation>预设：仅翻译</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="748" />
-        <source>Preset: Inpaint only</source>
-        <translation>预设：仅修复</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="756" />
-        <source>Pipeline presets</source>
-        <translation>流水线预设</translation>
-    </message>
-    <message>
-        <source>Select Directory</source>
-        <translation type="vanished">选择目录</translation>
-    </message>
-    <message>
-        <source>Comic archives (*.cbz *.zip)</source>
-        <translation type="vanished">漫画压缩包 (*.cbz *.zip)</translation>
-    </message>
-    <message>
-        <source>Comic RAR archives (*.cbr *.rar)</source>
-        <translation type="vanished">漫画 RAR 压缩包 (*.cbr *.rar)</translation>
-    </message>
-    <message>
-        <source>Open a comic book archive (.cbz/.zip); extracts to a folder and opens as project.</source>
-        <translation type="vanished">打开漫画压缩包（.cbz/.zip）；解压到文件夹并作为项目打开。</translation>
-    </message>
-    <message>
-        <source>Open a comic book RAR archive (.cbr/.rar). Requires: pip install rarfile; WinRAR/7-Zip in PATH.</source>
-        <translation type="vanished">打开漫画 RAR 压缩包（.cbr/.rar）。需要：pip install rarfile；PATH 中的 WinRAR/7-Zip。</translation>
-    </message>
-    <message>
-        <source>Save current page result image in chosen format (PNG, JPEG, WebP, JXL).</source>
-        <translation type="vanished">以所选格式（PNG、JPEG、WebP、JXL）保存当前页结果图。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="519" />
-        <source>Use light theme (Eva Light).</source>
-        <translation>使用浅色主题（Eva Light）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="521" />
-        <source>Use dark theme (Eva Dark).</source>
-        <translation>使用深色主题（Eva Dark）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="507" />
-        <source>Show spell check panel (PR #974).</source>
-        <translation>显示拼写检查面板（PR #974）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="514" />
-        <source>Show or hide canvas right-click menu actions by category.</source>
-        <translation>按类别显示或隐藏画布右键菜单项。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="532" />
-        <source>Rounder corners, gradients, and softer look.</source>
-        <translation>更圆角、渐变与柔和外观。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="540" />
-        <source>Open project README (installation and usage).</source>
-        <translation>打开项目 README（安装与使用）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="542" />
-        <source>Show application version and info.</source>
-        <translation>显示应用版本与信息。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="544" />
-        <source>Pull latest changes from GitHub. Keeps your config and local files unchanged.</source>
-        <translation>从 GitHub 拉取最新更改。保留配置与本地文件不变。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="567" />
-        <source>Theme and UI customizer...</source>
-        <translation>主题和 UI 定制器...</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="568" />
-        <source>Change accent color, app font, light/dark, simple vs advanced UI.</source>
-        <translation>更改强调色、应用字体、浅/深色、简洁/高级界面。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="632" />
-        <source>Choose output folder and format (PNG, JPEG, WebP, JXL).</source>
-        <translation>选择输出文件夹与格式（PNG、JPEG、WebP、JXL）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="638" />
-        <source>Open the report of skipped pages from the last pipeline run.</source>
-        <translation>打开上次流程运行中跳过页面的报告。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="647" />
-        <source>Process multiple folders in sequence with Pause/Cancel (issue #1020).</source>
-        <translation>按顺序处理多个文件夹，支持暂停/取消（issue #1020）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindowbars.py" line="677" />
+        <location filename="../ui/mainwindowbars.py" line="701" />
         <source>Unload detector/OCR/inpainter/translator models and free GPU memory. Use after a batch to reduce RAM.</source>
         <translation>卸载检测/OCR/修复/翻译模型并释放显存。批处理后使用以降低内存。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="681" />
+        <location filename="../ui/mainwindowbars.py" line="704" />
+        <source>Clear OCR and translation caches</source>
+        <translation>清除 OCR 与翻译缓存</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="705" />
         <source>Clear in-session OCR and translation caches (current project). Next run will recompute.</source>
         <translation>清除本次会话的 OCR 与翻译缓存（当前项目）。下次运行将重新计算。</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="695" />
+        <location filename="../ui/mainwindowbars.py" line="709" />
+        <source>Project</source>
+        <translation>项目</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1284" />
+        <location filename="../ui/mainwindowbars.py" line="721" />
+        <source>Export</source>
+        <translation>导出</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="724" />
+        <source>Export translation to LPtxt...</source>
+        <translation>导出译文为 LPtxt...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="725" />
         <source>Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).</source>
         <translation>以 LPtxt 格式导出译文，供自动打标工具使用（如气泡翻译器自动打标）。</translation>
     </message>
-</context>
-<context>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="728" />
+        <source>Sources</source>
+        <translation>来源</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="730" />
+        <source>Queue</source>
+        <translation>队列</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="732" />
+        <source>Models</source>
+        <translation>模型</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="760" />
+        <source>Pipeline</source>
+        <translation>流程</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="763" />
+        <source>Enable Text Dection</source>
+        <translation>启用文本检测</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="764" />
+        <source>Enable OCR</source>
+        <translation>启用OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="765" />
+        <source>Enable Translation</source>
+        <translation>启用翻译</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="766" />
+        <source>Enable Inpainting</source>
+        <translation>启用修复</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="773" />
+        <source>Run</source>
+        <translation>运行</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="774" />
+        <source>Run without update textstyle</source>
+        <translation>运行且不更新字体样式</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="775" />
+        <source>Translate page</source>
+        <translation>翻译本页</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="776" />
+        <source>Preset: Full</source>
+        <translation>预设：完整</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="777" />
+        <source>Preset: Detect + OCR only</source>
+        <translation>预设：仅检测 + OCR</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="778" />
+        <source>Preset: Translate only</source>
+        <translation>预设：仅翻译</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="779" />
+        <source>Preset: Inpaint only</source>
+        <translation>预设：仅修复</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="787" />
+        <source>Pipeline presets</source>
+        <translation>流水线预设</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="793" />
+        <source>Video translator...</source>
+        <translation>视频翻译器...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="794" />
+        <source>Translate hardcoded subtitles in video: detect, OCR, translate, inpaint per frame.</source>
+        <translation>翻译视频中的硬编码字幕：每帧检测、OCR、翻译、修复。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="797" />
+        <source>Translate subtitle file…</source>
+        <translation>翻译字幕文件...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="799" />
+        <source>Translate a standalone .srt or timestamped .txt using the configured translator (OpenRouter via LLM API).</source>
+        <translation>使用配置的转换器（通过 LLM API 的 OpenRouter）翻译独立的 .srt 或带时间戳的 .txt。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="803" />
+        <source>Video Subtitle Editor...</source>
+        <translation>视频字幕编辑器...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="804" />
+        <source>Edit video captions: cut, edit text, frame-accurate timing, export SRT/ASS/VTT, render with burned-in subtitles.</source>
+        <translation>编辑视频字幕：剪切、编辑文本、帧精确定时、导出 SRT/ASS/VTT、使用内置字幕进行渲染。</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="824" />
+        <source>File</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="827" />
+        <source>BallonsTranslatorPro</source>
+        <translation>气球翻译器Pro</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="834" />
+        <source>Search: menus, settings, canvas…</source>
+        <translation>搜索：菜单、设置、画布…</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="880" />
+        <source>Show search results</source>
+        <translation>显示搜索结果</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1267" />
+        <source>Open Folder ...</source>
+        <translation>打开文件夹...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1269" />
+        <source>Open Images ...</source>
+        <translation>打开图片...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1271" />
+        <source>Open Project ... *.json</source>
+        <translation>打开项目... *.json</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1276" />
+        <source>Close project and go to welcome screen</source>
+        <translation>关闭项目并转到欢迎页</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1280" />
+        <source>Save Project</source>
+        <translation>保存项目</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1285" />
+        <source>Export as Doc</source>
+        <translation>导出为 Word 文档</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1287" />
+        <source>Export current page as...</source>
+        <translation>导出当前页为...</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1289" />
+        <source>Export source text as TXT</source>
+        <translation>导出原文为 TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1291" />
+        <source>Export translation as TXT</source>
+        <translation>导出译文为 TXT</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1293" />
+        <source>Export source text as markdown</source>
+        <translation>导出原文为 Markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1295" />
+        <source>Export translation as markdown</source>
+        <translation>导出译文为 Markdown</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1301" />
+        <source>Import</source>
+        <translation>导入</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1302" />
+        <source>Import from Doc</source>
+        <translation>从 Word 导入</translation>
+    </message>
+    <message>
+        <location filename="../ui/mainwindowbars.py" line="1304" />
+        <source>Import translation from TXT/markdown</source>
+        <translation>从 TXT/Markdown 导入译文</translation>
+    </message>
+</context><context>
     <name>TranslateThread</name>
-    <message>
-        <source>The selected language is not supported by </source>
-        <translation type="obsolete">所选语言不被目标翻译器支持</translation>
-    </message>
-    <message>
-        <source>support list: </source>
-        <translation type="obsolete">支持语言列表: </translation>
-    </message>
     <message>
         <location filename="../ui/module_manager.py" line="261" />
         <source>Failed to set translator. No fallback available.</source>
@@ -6938,19 +6676,13 @@ Continue with advanced-only packages?</source>
         <translation>翻译器设置失败 </translation>
     </message>
     <message>
-        <location filename="../ui/module_manager.py" line="463" />
-        <source> is required for </source>
-        <translation>是翻译器必填项</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_manager.py" line="382" />
-        <location filename="../ui/module_manager.py" line="386" />
         <location filename="../ui/module_manager.py" line="461" />
+        <location filename="../ui/module_manager.py" line="386" />
+        <location filename="../ui/module_manager.py" line="382" />
         <source>Translation Failed.</source>
         <translation>翻译失败.</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TranslationContextDialog</name>
     <message>
         <location filename="../ui/translation_context_dialog.py" line="54" />
@@ -6993,21 +6725,32 @@ Continue with advanced-only packages?</source>
         <source>Series path: glossary is loaded from data/translation_context/&lt;path&gt;/glossary.txt — you do not need to add those terms here or in Config → Translator. Project glossary above is for extra terms that apply only to this project (merged with series + translator). Optional: in Config → Translator set "Series context prompt" (e.g. "This is a cultivation manhua. Keep place names and terms consistent.") for style instructions.</source>
         <translation>系列路径：词汇表从 data/translation_context/&lt;path&gt;/glossary.txt 加载 - 您不需要在此处或“配置 → 翻译器”中添加这些术语。上面的项目术语表是仅适用于该项目的额外术语（与系列+翻译器合并）。可选：在配置→翻译器中设置“系列上下文提示”（例如“这是一本修真漫画。保持地名和术语一致。”）作为风格说明。</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>TranslatorConfigPanel</name>
     <message>
-        <source>Source </source>
-        <translation type="obsolete">源语言 </translation>
+        <location filename="../ui/module_parse_widgets.py" line="427" />
+        <source>Test translator</source>
+        <translation>测试翻译器</translation>
     </message>
     <message>
-        <source>Target </source>
-        <translation type="obsolete">目标语言 </translation>
+        <location filename="../ui/module_parse_widgets.py" line="428" />
+        <source>Test if the current translator is available (e.g. API key, network).</source>
+        <translation>测试当前翻译器是否可用（例如 API 密钥、网络）。</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="432" />
+        <source>Keyword substitution for machine translation source text</source>
+        <translation>替换机翻前文本关键字</translation>
     </message>
     <message>
         <location filename="../ui/module_parse_widgets.py" line="435" />
         <source>Keyword substitution for machine translation</source>
         <translation>替换机翻结果中的关键词</translation>
+    </message>
+    <message>
+        <location filename="../ui/module_parse_widgets.py" line="438" />
+        <source>Keyword substitution for source text</source>
+        <translation>替换原文关键词</translation>
     </message>
     <message>
         <location filename="../ui/module_parse_widgets.py" line="441" />
@@ -7030,7 +6773,7 @@ Continue with advanced-only packages?</source>
         <translation>软翻译失败时继续批处理</translation>
     </message>
     <message>
-        <location filename="../ui/module_parse_widgets.py" line="450" />
+        <location filename="../ui/module_parse_widgets.py" line="449" />
         <source>When checked (default), non-critical translation failures (e.g. timeout, parse error) use a placeholder and continue the batch. When unchecked, show an error dialog and stop like critical errors (auth, quota).</source>
         <translation>选中（默认）后，非关键翻译失败（例如超时、解析错误）将使用占位符并继续批处理。未选中时，显示错误对话框并像严重错误（身份验证、配额）一样停止。</translation>
     </message>
@@ -7064,66 +6807,29 @@ Continue with advanced-only packages?</source>
         <source>Target</source>
         <translation>目标语言</translation>
     </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="438" />
-        <source>Keyword substitution for source text</source>
-        <translation>替换原文关键词</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="427" />
-        <source>Test translator</source>
-        <translation>测试翻译器</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="428" />
-        <source>Test if the current translator is available (e.g. API key, network).</source>
-        <translation>测试当前翻译器是否可用（例如 API 密钥、网络）。</translation>
-    </message>
-    <message>
-        <location filename="../ui/module_parse_widgets.py" line="432" />
-        <source>Keyword substitution for machine translation source text</source>
-        <translation>替换机翻前文本关键字</translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>TranslatorSelectionWidget</name>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1437" />
+        <location filename="../ui/mainwindowbars.py" line="1468" />
         <source>Translate</source>
         <translation>翻译</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1439" />
+        <location filename="../ui/mainwindowbars.py" line="1470" />
         <source>Source</source>
         <translation>源语言</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1441" />
+        <location filename="../ui/mainwindowbars.py" line="1472" />
         <source>Target</source>
         <translation>目标语言</translation>
     </message>
     <message>
-        <location filename="../ui/mainwindowbars.py" line="1455" />
+        <location filename="../ui/mainwindowbars.py" line="1486" />
         <source>Open module settings</source>
         <translation>打开模块设置</translation>
     </message>
-</context>
-<context>
-    <name>TranslatorStatusButton</name>
-    <message>
-        <source>Translator: </source>
-        <translation type="obsolete">翻译器： </translation>
-    </message>
-    <message>
-        <source>Source: </source>
-        <translation type="obsolete">源语言: </translation>
-    </message>
-    <message>
-        <source>Target: </source>
-        <translation type="obsolete">目标语言: </translation>
-    </message>
-</context>
-<context>
+</context><context>
     <name>VideoSubtitleEditorWindow</name>
     <message>
         <location filename="../ui/video_subtitle_editor.py" line="184" />
@@ -7181,9 +6887,9 @@ Continue with advanced-only packages?</source>
         <translation>打开视频进行预览</translation>
     </message>
     <message>
-        <location filename="../ui/video_subtitle_editor.py" line="259" />
-        <location filename="../ui/video_subtitle_editor.py" line="657" />
         <location filename="../ui/video_subtitle_editor.py" line="671" />
+        <location filename="../ui/video_subtitle_editor.py" line="657" />
+        <location filename="../ui/video_subtitle_editor.py" line="259" />
         <source>Play</source>
         <translation>玩</translation>
     </message>
@@ -7248,8 +6954,8 @@ Continue with advanced-only packages?</source>
         <translation>0:00（留空=开始）</translation>
     </message>
     <message>
-        <location filename="../ui/video_subtitle_editor.py" line="320" />
         <location filename="../ui/video_subtitle_editor.py" line="328" />
+        <location filename="../ui/video_subtitle_editor.py" line="320" />
         <source>Set at playhead</source>
         <translation>设置在播放头</translation>
     </message>
@@ -7279,8 +6985,8 @@ Continue with advanced-only packages?</source>
         <translation>字幕样式：</translation>
     </message>
     <message>
-        <location filename="../ui/video_subtitle_editor.py" line="369" />
         <location filename="../ui/video_subtitle_editor.py" line="454" />
+        <location filename="../ui/video_subtitle_editor.py" line="369" />
         <source>Default</source>
         <translation>默认</translation>
     </message>
@@ -7310,16 +7016,16 @@ Continue with advanced-only packages?</source>
         <translation>视频文件 (*.mp4 *.avi *.mkv *.mov *.webm);;所有文件 (*)</translation>
     </message>
     <message>
-        <location filename="../ui/video_subtitle_editor.py" line="400" />
-        <location filename="../ui/video_subtitle_editor.py" line="419" />
-        <location filename="../ui/video_subtitle_editor.py" line="444" />
-        <location filename="../ui/video_subtitle_editor.py" line="711" />
-        <location filename="../ui/video_subtitle_editor.py" line="731" />
-        <location filename="../ui/video_subtitle_editor.py" line="748" />
-        <location filename="../ui/video_subtitle_editor.py" line="765" />
-        <location filename="../ui/video_subtitle_editor.py" line="788" />
-        <location filename="../ui/video_subtitle_editor.py" line="807" />
         <location filename="../ui/video_subtitle_editor.py" line="842" />
+        <location filename="../ui/video_subtitle_editor.py" line="807" />
+        <location filename="../ui/video_subtitle_editor.py" line="788" />
+        <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
+        <location filename="../ui/video_subtitle_editor.py" line="444" />
+        <location filename="../ui/video_subtitle_editor.py" line="419" />
+        <location filename="../ui/video_subtitle_editor.py" line="400" />
         <source>Error</source>
         <translation>错误</translation>
     </message>
@@ -7384,10 +7090,10 @@ Continue with advanced-only packages?</source>
         <translation>暂停</translation>
     </message>
     <message>
-        <location filename="../ui/video_subtitle_editor.py" line="711" />
-        <location filename="../ui/video_subtitle_editor.py" line="731" />
-        <location filename="../ui/video_subtitle_editor.py" line="748" />
         <location filename="../ui/video_subtitle_editor.py" line="765" />
+        <location filename="../ui/video_subtitle_editor.py" line="748" />
+        <location filename="../ui/video_subtitle_editor.py" line="731" />
+        <location filename="../ui/video_subtitle_editor.py" line="711" />
         <source>Open a video first.</source>
         <translation>先打开一个视频。</translation>
     </message>
@@ -7486,8 +7192,7 @@ Continue with advanced-only packages?</source>
         <source>Render failed: %s</source>
         <translation>渲染失败：%s</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>VideoTranslatorDialog</name>
     <message>
         <location filename="../ui/video_translator_dialog.py" line="3167" />
@@ -7505,12 +7210,12 @@ Continue with advanced-only packages?</source>
         <translation>输入视频路径</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3199" />
-        <location filename="../ui/video_translator_dialog.py" line="3207" />
-        <location filename="../ui/video_translator_dialog.py" line="3246" />
-        <location filename="../ui/video_translator_dialog.py" line="3521" />
-        <location filename="../ui/video_translator_dialog.py" line="3698" />
         <location filename="../ui/video_translator_dialog.py" line="3867" />
+        <location filename="../ui/video_translator_dialog.py" line="3698" />
+        <location filename="../ui/video_translator_dialog.py" line="3521" />
+        <location filename="../ui/video_translator_dialog.py" line="3246" />
+        <location filename="../ui/video_translator_dialog.py" line="3207" />
+        <location filename="../ui/video_translator_dialog.py" line="3199" />
         <source>Browse...</source>
         <translation>浏览...</translation>
     </message>
@@ -7695,7 +7400,7 @@ Continue with advanced-only packages?</source>
         <translation>离开</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3348" />
+        <location filename="../ui/video_translator_dialog.py" line="3347" />
         <source>When &gt; 0 and duration &gt;= the threshold below, ASR runs in time slices (seconds per slice). Helps very long files and enables checkpoint resume. 0 = transcribe whole extract in one pass.</source>
         <translation>当 &gt; 0 且持续时间 &gt;= 下面的阈值时，ASR 按时间片运行（每片秒）。支持非常长的文件并启用检查点恢复。 0 = 一次性转录整个摘录。</translation>
     </message>
@@ -7710,7 +7415,7 @@ Continue with advanced-only packages?</source>
         <translation>绝不</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3373" />
+        <location filename="../ui/video_translator_dialog.py" line="3372" />
         <source>Minimum audio length (seconds) before chunking activates. 0 = never chunk by duration. Requires chunk size &gt; 0.</source>
         <translation>分块激活之前的最小音频长度（秒）。 0 = 从不按持续时间分块。要求块大小 &gt; 0。</translation>
     </message>
@@ -7720,7 +7425,7 @@ Continue with advanced-only packages?</source>
         <translation>保存/恢复 ASR 块检查点（临时 JSON）</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3387" />
+        <location filename="../ui/video_translator_dialog.py" line="3386" />
         <source>When chunking is active, progress is saved after each slice so a failed run can resume. Checkpoint is tied to the input video path and ASR settings.</source>
         <translation>当分块处于活动状态时，每个切片后都会保存进度，以便可以恢复失败的运行。检查点与输入视频路径和 ASR 设置相关。</translation>
     </message>
@@ -7760,7 +7465,7 @@ Continue with advanced-only packages?</source>
         <translation>纪录片/字幕</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3411" />
+        <location filename="../ui/video_translator_dialog.py" line="3410" />
         <source>Apply a bundle of settings for different use cases. Custom leaves your current settings unchanged. Don't miss text = catch every subtitle (slower). Balanced = good default. Maximum speed = fastest. Anime = long series with bottom subs. Documentary = captions anywhere on screen.</source>
         <translation>为不同的用例应用一组设置。自定义使您当前的设置保持不变。不要错过文本 = 捕获每个字幕（较慢）。平衡=良好的默认值。最大速度=最快。动漫 = 带底部字幕的长系列。纪录片=屏幕上任意位置的字幕。</translation>
     </message>
@@ -7770,7 +7475,7 @@ Continue with advanced-only packages?</source>
         <translation>处理每个：</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3421" />
+        <location filename="../ui/video_translator_dialog.py" line="3420" />
         <source>Run detect/OCR/translate/inpaint only every N frames; other frames reuse the last result. Output video FPS is always the same as input (every frame is written). Lower N = subtitles update more often but more work.
 At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with less cost (~15–10 runs/sec); 5–6 for a good balance (~6–5 runs/sec). Higher values (e.g. 24–30) are faster but short-lived subtitles may be missed; use temporal smoothing to reduce flicker.</source>
         <translation>每 N 帧运行一次检测/OCR/翻译/修复；其他帧重用最后的结果。输出视频 FPS 始终与输入相同（写入每一帧）。 N 越低 = 字幕更新越频繁，但工作量越大。
@@ -7807,7 +7512,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>字幕栏：文本后面的实心框（无修复）</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3464" />
+        <location filename="../ui/video_translator_dialog.py" line="3463" />
         <source>Skips inpainting. Draws a filled rectangle behind each detected subtitle using the same line wrap as burn-in, so multi-line translations expand the bar. Only the text area is covered, not the whole bottom band. Color/padding: config keys video_translator_subtitle_black_box_*.</source>
         <translation>跳过修复。使用与老化相同的换行在每个检测到的字幕后面绘制一个填充矩形，因此多行翻译会扩展该栏。仅覆盖文本区域，而不覆盖整个底部区域。颜色/填充：配置键 video_translator_subtitle_black_box_*。</translation>
     </message>
@@ -7887,7 +7592,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>纪录片（较小）</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3509" />
+        <location filename="../ui/video_translator_dialog.py" line="3508" />
         <source>Burn-in only: font size/position on the video. SRT sidecar files do not carry these styles; use ASS export + a player that reads styling, or burn-in for a fixed look.</source>
         <translation>仅烧录：视频上的字体大小/位置。 SRT sidecar 文件不携带这些样式；使用 ASS 导出 + 读取样式的播放器，或烧录以获得固定外观。</translation>
     </message>
@@ -7912,7 +7617,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>仅软字幕（无烙印；输出视频+SRT，速度非常快）</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3531" />
+        <location filename="../ui/video_translator_dialog.py" line="3530" />
         <source>Soft subs: original video pixels unchanged; timing + text go to SRT (plain text/timing only). The player chooses font/size/color. Fast path; not the same as burn-in style above.</source>
         <translation>软字幕：原始视频像素不变；计时 + 文本转至 SRT（仅限纯文本/计时）。玩家选择字体/大小/颜色。快速路径；和上面的老化风格不一样。</translation>
     </message>
@@ -8242,7 +7947,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>导出SRT</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3764" />
+        <location filename="../ui/video_translator_dialog.py" line="3763" />
         <source>SRT: standard sidecar format (cues + plain text). No advanced styling. Only when not burning in, to avoid double subtitles in players.</source>
         <translation>SRT：标准 sidecar 格式（提示 + 纯文本）。没有高级的造型。仅在不烧录时，避免播放器出现双字幕。</translation>
     </message>
@@ -8252,7 +7957,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>出口ASS</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3774" />
+        <location filename="../ui/video_translator_dialog.py" line="3773" />
         <source>ASS includes styling (font, size, colors). SRT/VTT are mostly timing + plain text. Use ASS if you need styles without burn-in.</source>
         <translation>ASS 包括样式（字体、大小、颜色）。 SRT/VTT大多是计时+纯文本。如果您需要没有老化的样式，请使用 ASS。</translation>
     </message>
@@ -8267,7 +7972,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>写入WebVTT字幕文件（与SRT相同的时间）。</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3786" />
+        <location filename="../ui/video_translator_dialog.py" line="3785" />
         <source>Note: Burn-in style (Default / Anime / Documentary) only affects text drawn on the video. Soft subtitles and exported SRT/ASS/VTT are separate: the player uses its own font for soft subs; ASS may include styling if the player supports it.</source>
         <translation>注意：老化样式（默认/动漫/纪录片）仅影响视频上绘制的文本。软字幕和导出的SRT/ASS/VTT是分开的：播放器使用自己的软字幕字体；如果播放器支持，ASS 可能包括样式。</translation>
     </message>
@@ -8312,7 +8017,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>关闭（一项请求）</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3823" />
+        <location filename="../ui/video_translator_dialog.py" line="3822" />
         <source>Max subtitle lines per LLM API call for video ASR/existing subs and subtitle-file translate. 0 = send all lines in one request (can be slow or hit limits). 20–40 is a practical range.</source>
         <translation>每个 LLM API 调用视频 ASR/现有字幕和字幕文件翻译的最大字幕行数。 0 = 在一个请求中发送所有行（可能会很慢或达到限制）。 20-40 是一个实用范围。</translation>
     </message>
@@ -8322,7 +8027,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>并行工作者：</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3835" />
+        <location filename="../ui/video_translator_dialog.py" line="3834" />
         <source>When chunking produces multiple batches, run up to this many LLM requests at once. Increase only if your API allows concurrent calls (watch rate limits).</source>
         <translation>当分块产生多个批次时，一次运行最多这么多 LLM 请求。仅当您的 API 允许并发调用（观看速率限制）时才增加。</translation>
     </message>
@@ -8557,7 +8262,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>运行后全局字幕流程审核</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3979" />
+        <location filename="../ui/video_translator_dialog.py" line="3978" />
         <source>After translation, one pass over the full subtitle timeline for flow (pronouns, continuity, punctuation). Uses the dedicated flow-fixer model when configured; otherwise the main translator (LLM_API), if enabled below.</source>
         <translation>翻译完成后，我们会浏览完整的字幕时间线（代词、连续性、标点符号）。配置时使用专用的流量固定器模型；否则是主转换器 (LLM_API)（如果在下面启用）。</translation>
     </message>
@@ -8567,7 +8272,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>当流程固定器关闭时允许通过主翻译器进行后期审查</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="3993" />
+        <location filename="../ui/video_translator_dialog.py" line="3992" />
         <source>When no dedicated flow-fixer backend is set (or it is “none”), run the same timeline review using your normal translation model (extra API calls). Turn off to only review when a flow-fixer model is configured.</source>
         <translation>如果未设置专用的流程修复程序后端（或者为“无”），请使用正常翻译模型（额外的 API 调用）运行相同的时间线审核。关闭以仅在配置了流量固定器模型时进行检查。</translation>
     </message>
@@ -8592,7 +8297,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>审稿后/主 LLM 流程通过：启用推理</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="4023" />
+        <location filename="../ui/video_translator_dialog.py" line="4022" />
         <source>When the main translation model runs the timeline flow review, allow reasoning (thinking) tokens. Batched subtitle translation always runs without reasoning for reliable JSON.</source>
         <translation>当主翻译模型运行时间线流程审查时，允许推理（思考）标记。批量字幕翻译始终运行，无需推理可靠的 JSON。</translation>
     </message>
@@ -8602,12 +8307,12 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>审后推理工作：</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="4044" />
+        <location filename="../ui/video_translator_dialog.py" line="4043" />
         <source>Long videos (e.g. 17h): Use FFmpeg, Scene detection, and optionally Skip detection + Bottom 20%% for anime.</source>
         <translation>长视频（例如 17 小时）：使用 FFmpeg、场景检测，并可选择跳过检测 + 动画的底部 20%%。</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="4051" />
+        <location filename="../ui/video_translator_dialog.py" line="4050" />
         <source>Recommended for long anime: Enable Scene detection (threshold 25–35), Skip detection + Subtitle region Bottom 20%%, Use FFmpeg (CRF 23), Process every 24–30 frames. Temporal smoothing 0.2–0.3 reduces flicker. All models work; progress is throttled for very long runs. If you see 'CUDA out of memory' with inpainting, set Inpainter device to CPU or lower inpaint_size in Config → Inpainting.</source>
         <translation>建议长动画：启用场景检测（阈值 25–35）、跳过检测 + 字幕区域底部 20%%、使用 FFmpeg (CRF 23)、每 24–30 帧处理一次。时间平滑 0.2–0.3 可减少闪烁。所有型号均有效；在很长的时间内，进度会受到限制。如果您在修复时看到“CUDA 内存不足”，请在 Config → Inpainting 中将 Inpainter 设备设置为 CPU 或降低 inpaint_size。</translation>
     </message>
@@ -8692,9 +8397,9 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="4132" />
-        <location filename="../ui/video_translator_dialog.py" line="4798" />
         <location filename="../ui/video_translator_dialog.py" line="4909" />
+        <location filename="../ui/video_translator_dialog.py" line="4798" />
+        <location filename="../ui/video_translator_dialog.py" line="4132" />
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -8789,8 +8494,8 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>正在运行的管道...</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="4621" />
         <location filename="../ui/video_translator_dialog.py" line="4696" />
+        <location filename="../ui/video_translator_dialog.py" line="4621" />
         <source>Batch done.</source>
         <translation>批量完成。</translation>
     </message>
@@ -8975,20 +8680,20 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <translation>A/B 比较完成。已保存：{}</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="5069" />
         <location filename="../ui/video_translator_dialog.py" line="5071" />
+        <location filename="../ui/video_translator_dialog.py" line="5069" />
         <source>A/B compare done.</source>
         <translation>A/B 比较完成。</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="5089" />
         <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5089" />
         <source>Pass 1/2</source>
         <translation>通过1/2</translation>
     </message>
     <message>
-        <location filename="../ui/video_translator_dialog.py" line="5093" />
         <location filename="../ui/video_translator_dialog.py" line="5100" />
+        <location filename="../ui/video_translator_dialog.py" line="5093" />
         <source>Pass 2/2</source>
         <translation>通过 2/2</translation>
     </message>
@@ -9022,8 +8727,7 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <source>Error: {}</source>
         <translation>错误： {}</translation>
     </message>
-</context>
-<context>
+</context><context>
     <name>WelcomeWidget</name>
     <message>
         <location filename="../ui/welcome_widget.py" line="155" />
@@ -9100,26 +8804,4 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
         <source>Project files (*.json);;All files (*)</source>
         <translation>项目文件 (*.json);;所有文件 (*)</translation>
     </message>
-</context>
-<context>
-    <name>manager</name>
-    <message>
-        <location filename="../ui/module_manager.py" line="2155" />
-        <source>Detection in region failed.</source>
-        <translation>区域检测失败。</translation>
-    </message>
-</context>
-<context>
-    <name>parent</name>
-    <message>
-        <location filename="../ui/mainwindow.py" line="139" />
-        <source>Downloading model packages</source>
-        <translation>下载模型包</translation>
-    </message>
-    <message>
-        <location filename="../ui/mainwindow.py" line="141" />
-        <source>Downloading model packages... This may take several minutes.</source>
-        <translation>正在下载模型包...这可能需要几分钟的时间。</translation>
-    </message>
-</context>
-</TS>
+</context></TS>


### PR DESCRIPTION
### Motivation
- Non-English UI locales were falling behind because `.ts` catalogs were not being updated from UI `self.tr(...)` sources, leaving many screens still hardcoded in English.
- Provide a one-pass, repeatable workflow to update all shipped `translate/*.ts` catalogs so non-EN/ZH locales can stay in sync with UI changes.

### Description
- Extend `scripts/update_translation.py` to support updating all `translate/*.ts` files or a single locale via `--locale`, iterate per-target, and print per-locale compile instructions.
- Use `pylupdate6` with `--no-obsolete --verbose` (and fall back to `pylupdate5`) in a helper `_run_update()` to produce robust updates and avoid stale/obsolete entries.
- Make the script fail non‑zero when any target update fails so CI/automation can catch problems early.
- Regenerated the shipped locale `.ts` catalogs so UI source strings are present in the non-English catalogs (updated locales include `es_MX`, `fr_FR`, `hu_HU`, `ko_KR`, `pt_BR`, `ru_RU`, `zh_CN`).

### Testing
- Ran `python -m compileall -f -q scripts/update_translation.py` to verify the script compiles, which succeeded.
- Executed `python scripts/update_translation.py --locale zh_CN` to update one locale and confirmed it completed (the script reports updated file and shows `Compile with: lrelease translate/zh_CN.ts`).
- Executed `python scripts/update_translation.py` to refresh all `translate/*.ts` targets and confirmed all shipped `.ts` files were updated (script output lists each updated file and compile hint).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4af736120832c97e827657941f515)