### PR TITLE
Add runtime resource summary, respect welcome-screen preference, show .ts compile stats, and avoid disabling GPU option

### DIFF
--- a/scripts/compile_translation.py
+++ b/scripts/compile_translation.py
@@ -11,6 +11,7 @@ import os.path as osp
 import subprocess
 import sys
 from glob import glob
+import xml.etree.ElementTree as ET
 
 
 def _lrelease_candidates(ts_path: str, qm_path: str):
@@ -49,6 +50,30 @@ def _compile_one(root: str, ts_path: str, qm_path: str) -> bool:
             print(stderr, file=sys.stderr)
     return False
 
+
+
+def _ts_translation_stats(ts_path: str) -> tuple[int, int, int]:
+    """Return (total_messages, finished_messages, unfinished_messages)."""
+    try:
+        root = ET.parse(ts_path).getroot()
+    except Exception:
+        return (0, 0, 0)
+
+    total = 0
+    finished = 0
+    unfinished = 0
+    for msg in root.findall('.//message'):
+        trans = msg.find('translation')
+        if trans is None:
+            continue
+        total += 1
+        is_unfinished = trans.get('type') == 'unfinished' or not (trans.text or '').strip()
+        if is_unfinished:
+            unfinished += 1
+        else:
+            finished += 1
+    return total, finished, unfinished
+
 def main():
     root = osp.dirname(osp.dirname(osp.abspath(__file__)))
     trans_dir = osp.join(root, 'translate')
@@ -73,13 +98,21 @@ def main():
 
     ok = 0
     fail = 0
+    stats = []
     for ts_path in targets:
+        total, finished, unfinished = _ts_translation_stats(ts_path)
+        stats.append((ts_path, total, finished, unfinished))
         qm_path = ts_path[:-3] + '.qm'
         if _compile_one(root, ts_path, qm_path):
             ok += 1
         else:
             fail += 1
             print(f'Failed to compile: {ts_path}', file=sys.stderr)
+
+    for ts_path, total, finished, unfinished in stats:
+        locale = osp.basename(ts_path).replace('.ts', '')
+        if total:
+            print(f'[i18n] {locale}: {finished}/{total} finished, {unfinished} unfinished')
 
     if fail == 0:
         print(f'All translations compiled successfully ({ok}/{ok}).')

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -209,6 +209,12 @@ class MainWindow(mainwindow_cls):
         self.setAcceptDrops(True)
 
         force_welcome = bool(getattr(shared, 'FORCE_SHOW_WELCOME_ON_STARTUP', False))
+        # Respect startup preference: when enabled, always land on welcome screen unless
+        # user explicitly launched with a project path/json.
+        startup_prefers_welcome = bool(getattr(pcfg, 'show_welcome_screen', True))
+        explicit_start_target = bool(open_dir and str(open_dir).strip())
+        if startup_prefers_welcome and not explicit_start_target:
+            force_welcome = True
         if not force_welcome and open_dir != '' and osp.exists(open_dir):
             if osp.isfile(open_dir) and open_dir.lower().endswith('.json'):
                 self.openJsonProj(open_dir)
@@ -1114,6 +1120,7 @@ class MainWindow(mainwindow_cls):
         self.titleBar.apply_run_profile_trigger.connect(self.on_apply_run_profile_snapshot)
         self.titleBar.show_model_download_diag_trigger.connect(self.on_show_model_download_diagnostics)
         self.titleBar.copy_startup_diag_trigger.connect(self.on_copy_startup_diagnostics)
+        self.titleBar.runtime_resource_summary_trigger.connect(self.on_runtime_resource_summary)
         self.titleBar.export_startup_diag_trigger.connect(self.on_export_startup_report)
         self.titleBar.open_log_folder_trigger.connect(self.on_open_log_folder)
         self.titleBar.relaunch_pyqt5_trigger.connect(self.on_relaunch_pyqt5_safe_mode)
@@ -1928,6 +1935,53 @@ class MainWindow(mainwindow_cls):
         if app is not None:
             app.clipboard().setText(text)
         create_info_dialog({'title': self.tr('Diagnostics copied'), 'text': self.tr('Startup diagnostics copied to clipboard.')})
+
+    def _collect_runtime_resource_summary_text(self) -> str:
+        lines = []
+        run_state = self.tr("RUNNING") if self.imgtrans_thread.isRunning() else self.tr("IDLE")
+        lines.append(self.tr("Pipeline state: {}").format(run_state))
+        try:
+            import psutil
+            vm = psutil.virtual_memory()
+            proc = psutil.Process(os.getpid())
+            proc_mem = proc.memory_info().rss / (1024 ** 3)
+            cpu_pct = psutil.cpu_percent(interval=0.1)
+            lines.append(self.tr("CPU usage: {0:.1f}%").format(cpu_pct))
+            lines.append(self.tr("System RAM: {0:.1f} / {1:.1f} GB ({2:.0f}%)").format(
+                (vm.total - vm.available) / (1024 ** 3), vm.total / (1024 ** 3), vm.percent
+            ))
+            lines.append(self.tr("App RAM (RSS): {0:.2f} GB").format(proc_mem))
+        except Exception as e:
+            lines.append(self.tr("CPU/RAM stats unavailable: {0}").format(str(e)))
+
+        try:
+            import torch
+            if hasattr(torch, "cuda") and torch.cuda.is_available():
+                dev_idx = torch.cuda.current_device()
+                total = torch.cuda.get_device_properties(dev_idx).total_memory / (1024 ** 3)
+                allocated = torch.cuda.memory_allocated(dev_idx) / (1024 ** 3)
+                reserved = torch.cuda.memory_reserved(dev_idx) / (1024 ** 3)
+                lines.append(self.tr("GPU ({0}) VRAM allocated/reserved/total: {1:.2f} / {2:.2f} / {3:.2f} GB").format(
+                    torch.cuda.get_device_name(dev_idx), allocated, reserved, total
+                ))
+                if reserved / max(total, 1e-6) > 0.75:
+                    lines.append(self.tr("Suggestion: VRAM usage is high; use low-VRAM mode, smaller models, CPU device, or quantized variants (4-bit/8-bit) when available."))
+            else:
+                lines.append(self.tr("GPU VRAM: CUDA not available in current runtime."))
+        except Exception as e:
+            lines.append(self.tr("GPU stats unavailable: {0}").format(str(e)))
+
+        lines.append(self.tr("Quantization note: model quantization is module-dependent; some HF/LLM modules provide low-VRAM/4-bit/8-bit style options, but not every detector/OCR/inpainter supports quantized loading."))
+        return "\n".join(lines)
+
+    def on_runtime_resource_summary(self):
+        text = self._collect_runtime_resource_summary_text()
+        msg = QMessageBox(self)
+        msg.setWindowTitle(self.tr("Runtime resource summary"))
+        msg.setText(self.tr("Current resource usage snapshot."))
+        msg.setDetailedText(text)
+        msg.setIcon(QMessageBox.Icon.Information)
+        msg.exec()
 
     def on_export_startup_report(self):
         text = self._collect_startup_diagnostics_text()

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -660,6 +660,9 @@ class TitleBar(Widget):
         copyStartupDiagAction = QAction(self.tr('Copy startup diagnostics'), self)
         copyStartupDiagAction.setToolTip(self.tr('Copy startup and environment diagnostics to clipboard.'))
         self.copy_startup_diag_trigger = copyStartupDiagAction.triggered
+        runtimeResourceSummaryAction = QAction(self.tr('Runtime resource summary'), self)
+        runtimeResourceSummaryAction.setToolTip(self.tr('Show current CPU/RAM/VRAM usage and quick quantization guidance.'))
+        self.runtime_resource_summary_trigger = runtimeResourceSummaryAction.triggered
         exportStartupDiagAction = QAction(self.tr('Export startup report...'), self)
         exportStartupDiagAction.setToolTip(self.tr('Save startup diagnostics to a text file for support.'))
         self.export_startup_diag_trigger = exportStartupDiagAction.triggered
@@ -736,6 +739,7 @@ class TitleBar(Widget):
         modelsMenu.addAction(showDownloadDiagAction)
         modelsMenu.addSeparator()
         modelsMenu.addAction(copyStartupDiagAction)
+        modelsMenu.addAction(runtimeResourceSummaryAction)
         modelsMenu.addAction(exportStartupDiagAction)
         modelsMenu.addAction(openLogFolderAction)
         modelsMenu.addAction(relaunchPyQt5Action)

--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -199,13 +199,11 @@ class ParamWidget(QWidget):
                     param_widget = ParamComboBox(
                         param_key, options_list, size=size, scrollWidget=scrollWidget, flush_btn=flush_btn, path_selector=path_selector)
 
-                    if param_key == 'device' and DEFAULT_DEVICE == 'cpu':
+                    if param_key == 'device' and DEFAULT_DEVICE == 'cpu' and str(param_dict.get('value', '')).strip() == '':
+                        # Keep CPU as the implicit default when runtime did not detect GPU,
+                        # but do not disable GPU choices in UI: users may still run with
+                        # CUDA/XPU/MPS in environments where torch detection is incomplete.
                         param_dict['value'] = 'cpu'
-                        for ii, device in enumerate(options_list):
-                            if device in GPUINTENSIVE_SET:
-                                model = param_widget.model()
-                                item = model.item(ii, 0)
-                                item.setEnabled(False)
                     param_widget.setCurrentText(str(value))
                     param_widget.setEditable(param_dict.get('editable', False))
 


### PR DESCRIPTION
### Motivation
- Provide a quick runtime snapshot (CPU/RAM/VRAM) and guidance to users from the UI for diagnosing resource usage.
- Honor the user's startup preference to show the welcome screen unless an explicit project path or file was provided.
- Improve translation workflow visibility by reporting per-locale translation progress when compiling `.ts` files.
- Avoid hiding GPU device options when runtime detection simply did not detect a GPU, so users can still select GPU devices manually.

### Description
- Added `_ts_translation_stats` in `scripts/compile_translation.py` to parse `.ts` XML and report `(total, finished, unfinished)` counts and print per-locale progress after attempting compilation.
- Updated `ui/mainwindow.py` to respect `pcfg.show_welcome_screen` and only force the welcome screen when no explicit start target was provided, and added a runtime resource summary flow with `_collect_runtime_resource_summary_text` and `on_runtime_resource_summary` that uses `psutil` and `torch` when available.
- Added a new `runtimeResourceSummaryAction` in `ui/mainwindowbars.py` and wired it into the tools/models menu and the main window via `runtime_resource_summary_trigger`.
- Adjusted device parameter handling in `ui/module_parse_widgets.py` so that when `DEFAULT_DEVICE == 'cpu'` we only set `param_dict['value'] = 'cpu'` if the runtime value is empty, and removed logic that disabled GPU choices in the UI.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4b9293c30832c8aee9b45bf00bc3e)