### PR TITLE
Add layout review agent (planner/providers), integrate into UI and scene manager, and add unit tests

### DIFF
--- a/tests/test_layout_review_agent.py
+++ b/tests/test_layout_review_agent.py
@@ -1,0 +1,136 @@
+from utils.layout_review_agent import (
+    BlockSnapshot,
+    LayoutReviewPlanner,
+    ReviewModelConfig,
+    ReviewAction,
+    ExternalReviewProvider,
+    HeuristicReviewProvider,
+    collect_actions_from_list,
+    collect_actions_by_type,
+    filter_actions_by_block_indices,
+    iterative_review,
+)
+
+
+def test_planner_proposes_fit_actions_for_overflow():
+    planner = LayoutReviewPlanner()
+    rst = planner.review_page(
+        "p1",
+        [
+            BlockSnapshot(
+                block_index=0,
+                xyxy=(10, 10, 110, 50),
+                text="A long sentence that should overflow this short box",
+                font_size=28,
+                est_text_size=(150, 70),
+                bubble_center=(60, 30),
+            )
+        ],
+    )
+    actions = [a.action for a in rst.blocks[0].actions]
+    assert "auto_fit" in actions
+    assert "resize_to_fit_content" in actions
+
+
+def test_planner_proposes_center_action_when_far_from_bubble_center():
+    planner = LayoutReviewPlanner()
+    rst = planner.review_page(
+        "p1",
+        [
+            BlockSnapshot(
+                block_index=1,
+                xyxy=(0, 0, 100, 100),
+                text="hello",
+                font_size=18,
+                est_text_size=(40, 20),
+                bubble_center=(200, 200),
+            )
+        ],
+    )
+    actions = [a.action for a in rst.blocks[0].actions]
+    assert "center_in_bubble" in actions
+
+
+def test_collect_actions_by_type_groups_actions():
+    planner = LayoutReviewPlanner()
+    rst = planner.review_page(
+        "p1",
+        [BlockSnapshot(block_index=0, xyxy=(0, 0, 40, 40), text="x" * 30, font_size=20, est_text_size=(120, 80))],
+    )
+    grouped = collect_actions_by_type(rst)
+    assert len(grouped["auto_fit"]) >= 1
+    assert len(grouped["resize_to_fit_content"]) >= 1
+
+
+def test_iterative_review_stops_when_apply_resolves_issues():
+    start = [BlockSnapshot(block_index=0, xyxy=(0, 0, 80, 30), text="overflow", font_size=24, est_text_size=(120, 60))]
+
+    def apply_actions(_actions):
+        return [BlockSnapshot(block_index=0, xyxy=(0, 0, 180, 100), text="overflow", font_size=16, est_text_size=(90, 20))]
+
+    result, loops = iterative_review("p1", start, apply_actions, max_iters=3)
+    assert loops == 1
+    assert result.blocks[0].actions == []
+
+
+def test_collect_actions_from_list_groups_actions():
+    grouped = collect_actions_from_list(
+        [
+            ReviewAction(action="auto_fit", block_index=0),
+            ReviewAction(action="auto_fit", block_index=1),
+            ReviewAction(action="resize", block_index=0, args={"scale": 1.1}),
+        ]
+    )
+    assert len(grouped["auto_fit"]) == 2
+    assert len(grouped["resize"]) == 1
+
+
+def test_planner_tiny_dense_box_proposes_resize_scale():
+    planner = LayoutReviewPlanner()
+    rst = planner.review_page(
+        "p1",
+        [
+            BlockSnapshot(
+                block_index=4,
+                xyxy=(0, 0, 48, 48),
+                text="This is a dense sentence for a tiny area.",
+                font_size=14,
+                est_text_size=(42, 38),
+            )
+        ],
+    )
+    resize_actions = [a for a in rst.blocks[0].actions if a.action == "resize"]
+    assert len(resize_actions) == 1
+    assert resize_actions[0].args["scale"] > 1.0
+
+
+def test_filter_actions_by_block_indices_keeps_only_requested_targets():
+    actions = [
+        ReviewAction(action="auto_fit", block_index=0),
+        ReviewAction(action="center_in_bubble", block_index=2),
+        ReviewAction(action="resize", block_index=5, args={"scale": 1.1}),
+    ]
+    filtered = filter_actions_by_block_indices(actions, [2, 5])
+    assert [a.block_index for a in filtered] == [2, 5]
+
+
+def test_heuristic_provider_returns_page_result():
+    provider = HeuristicReviewProvider()
+    cfg = ReviewModelConfig(provider="heuristic")
+    result = provider.review("p1", [BlockSnapshot(block_index=0, xyxy=(0, 0, 30, 30), text="x", font_size=12)], cfg)
+    assert result.page_name == "p1"
+    assert len(result.blocks) == 1
+
+
+def test_external_provider_uses_handler():
+    def handler(page_name, blocks, config):
+        assert config.provider == "cloud_api"
+        return HeuristicReviewProvider().review(page_name, blocks, ReviewModelConfig(provider="heuristic"))
+
+    provider = ExternalReviewProvider(handler)
+    result = provider.review(
+        "p2",
+        [BlockSnapshot(block_index=1, xyxy=(0, 0, 40, 20), text="hello", font_size=10)],
+        ReviewModelConfig(provider="cloud_api", prompt="custom"),
+    )
+    assert result.page_name == "p2"

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -11,7 +11,7 @@ import time
 import cv2
 
 from tqdm import tqdm
-from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QProgressBar, QLabel, QWidget
+from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QProgressBar, QLabel, QWidget, QInputDialog
 from qtpy.QtCore import Qt, QPoint, QSize, QEvent, Signal, QTimer
 from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QKeyEvent, QPainter, QClipboard, QImage, QShowEvent, QCursor, QPixmap
 
@@ -29,6 +29,7 @@ from modules import GET_VALID_TEXTDETECTORS, GET_VALID_INPAINTERS, GET_VALID_TRA
 from .misc import parse_stylesheet, set_html_family, QKEY, pixmap2ndarray
 from .custom_widget.animated_stack import AnimatedStackWidget
 from utils.config import ProgramConfig, pcfg, save_config, text_styles, save_text_styles, load_textstyle_from, FontFormat, log_diagnostic_event
+from utils.layout_review_agent import ReviewModelConfig
 from utils.shortcuts import get_shortcut
 from utils.proj_imgtrans import ProjImgTrans
 from utils.zip_batch import ZipBatchManager
@@ -1186,6 +1187,9 @@ class MainWindow(mainwindow_cls):
         _mk_shortcut("format.auto_fit_binary", "", self.shortcutFormatAutoFitBinary)
         _mk_shortcut("format.balloon_shape_auto", "", self.shortcutBalloonShapeAuto)
         _mk_shortcut("format.resize_to_fit_content", "", self.shortcutResizeToFitContent)
+        _mk_shortcut("format.layout_review_selected", "", self.shortcutLayoutReviewSelected)
+        _mk_shortcut("format.layout_review_page", "", self.shortcutLayoutReviewPage)
+        _mk_shortcut("format.layout_review_config", "", self.shortcutLayoutReviewConfig)
 
         drawpanel_shortcuts = [
             ("draw.hand", "H", "hand"),
@@ -1680,6 +1684,86 @@ class MainWindow(mainwindow_cls):
         """Resize selected text box(es) to fit content (Format shortcut)."""
         if self.centralStackWidget.currentIndex() == 1 and self.canvas.gv.isVisible() and self.canvas.selected_text_items():
             self.canvas.resize_to_fit_content_signal.emit()
+
+    def shortcutLayoutReviewSelected(self):
+        """Run layout review/fix for selected textboxes."""
+        if self.centralStackWidget.currentIndex() != 1 or not self.canvas.gv.isVisible():
+            return
+        if not self.canvas.selected_text_items():
+            return
+        cfg = self._get_layout_review_config()
+        loops = self.st_manager.review_and_fix_selected_textboxes_with_provider(
+            config=cfg,
+            max_iters=2,
+        )
+        if loops <= 0:
+            self.statusBar().showMessage(self.tr("Layout review: no issues detected in selection."), 4000)
+            return
+        self.statusBar().showMessage(self.tr(f"Layout review applied to selection ({loops} iteration(s))."), 5000)
+
+    def shortcutLayoutReviewPage(self):
+        """Run layout review/fix for all textboxes on current page."""
+        if self.centralStackWidget.currentIndex() != 1 or not self.canvas.gv.isVisible():
+            return
+        cfg = self._get_layout_review_config()
+        target_indices = [
+            blk.idx for blk in self.st_manager.textblk_item_list
+            if blk is not None and not getattr(blk.fontformat, "vertical", False)
+        ]
+        loops = self.st_manager.review_and_fix_selected_textboxes_with_provider(
+            config=cfg,
+            target_block_indices=target_indices,
+            max_iters=2,
+        )
+        if loops <= 0:
+            self.statusBar().showMessage(self.tr("Layout review: no page-level issues detected."), 4000)
+            return
+        self.statusBar().showMessage(self.tr(f"Layout review applied to page ({loops} iteration(s))."), 5000)
+
+    def _get_layout_review_config(self) -> ReviewModelConfig:
+        cfg = getattr(self, "_layout_review_config", None)
+        if isinstance(cfg, ReviewModelConfig):
+            return cfg
+        self._layout_review_config = ReviewModelConfig(provider="heuristic")
+        return self._layout_review_config
+
+    def shortcutLayoutReviewConfig(self):
+        """Configure provider/prompt for layout review."""
+        cfg = self._get_layout_review_config()
+        provider_items = ["heuristic", "local_api", "cloud_api"]
+        provider_idx = max(0, provider_items.index(cfg.provider) if cfg.provider in provider_items else 0)
+        provider, ok = QInputDialog.getItem(self, self.tr("Layout Review Provider"), self.tr("Provider"), provider_items, provider_idx, False)
+        if not ok:
+            return
+        model_name, ok = QInputDialog.getText(self, self.tr("Layout Review Model"), self.tr("Model name"), text=cfg.model_name)
+        if not ok:
+            return
+        prompt, ok = QInputDialog.getText(self, self.tr("Layout Review Prompt"), self.tr("Prompt"), text=cfg.prompt)
+        if not ok:
+            return
+        temperature, ok = QInputDialog.getDouble(
+            self, self.tr("Layout Review Temperature"), self.tr("Temperature"), float(cfg.temperature), 0.0, 2.0, 2
+        )
+        if not ok:
+            return
+        top_p, ok = QInputDialog.getDouble(
+            self, self.tr("Layout Review Top-p"), self.tr("Top-p"), float(cfg.top_p), 0.0, 1.0, 2
+        )
+        if not ok:
+            return
+        max_tokens, ok = QInputDialog.getInt(
+            self, self.tr("Layout Review Max Tokens"), self.tr("Max tokens"), int(cfg.max_tokens), 64, 8192, 32
+        )
+        if not ok:
+            return
+        cfg.provider = provider
+        cfg.model_name = model_name
+        cfg.prompt = prompt
+        cfg.temperature = temperature
+        cfg.top_p = top_p
+        cfg.max_tokens = max_tokens
+        self._layout_review_config = cfg
+        self.statusBar().showMessage(self.tr(f"Layout review config updated ({provider})."), 4000)
 
     def on_redo(self):
         log_diagnostic_event(

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -30,6 +30,17 @@ from utils.box_size_check_model import check_box_size_from_model
 from utils.text_processing import seg_text, is_cjk
 from utils.text_layout import layout_text
 from utils.line_breaking import split_long_token_with_hyphenation
+from utils.layout_review_agent import (
+    BlockSnapshot,
+    ExternalReviewProvider,
+    HeuristicReviewProvider,
+    LayoutReviewPlanner,
+    ReviewModelConfig,
+    ReviewProvider,
+    ReviewAction,
+    collect_actions_from_list,
+    filter_actions_by_block_indices,
+)
 from utils.logger import logger as LOGGER
 from modules.textdetector.outside_text_processor import OSB_LABELS
 
@@ -1240,6 +1251,299 @@ class SceneTextManager(QObject):
             self.layout_textblk(blkitem)
             self._scale_font_to_fit_box(blkitem)
         self.canvas.push_undo_command(AutoLayoutCommand(selected_blks, old_rect_lst, old_html_lst, trans_widget_lst))
+
+    def review_and_fix_selected_textboxes(
+        self,
+        max_iters: int = 2,
+        target_block_indices: Optional[List[int]] = None,
+    ) -> int:
+        """Iteratively review selected blocks and apply conservative fixes.
+
+        Returns the number of iterations used. This reuses existing operations
+        (auto-fit, resize-to-fit-content, center-in-bubble) to preserve behavior.
+        """
+        selected = self._get_review_target_blocks(target_block_indices)
+        if not selected:
+            return 0
+        planner = LayoutReviewPlanner()
+        loops = 0
+        for i in range(max(1, int(max_iters))):
+            snapshots: List[BlockSnapshot] = []
+            for blk in selected:
+                abr = blk.absBoundingRect(qrect=True)
+                doc = blk.document()
+                est = None
+                if doc is not None:
+                    ds = doc.size()
+                    est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
+                bubble_center = self._estimate_block_bubble_center(blk)
+                snapshots.append(
+                    BlockSnapshot(
+                        block_index=blk.idx,
+                        xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
+                        text=blk.toPlainText(),
+                        font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
+                        est_text_size=est,
+                        bubble_center=bubble_center,
+                    )
+                )
+            result = planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
+            pending_actions = [a for block_result in result.blocks for a in block_result.actions]
+            if not pending_actions:
+                return loops
+            if target_block_indices:
+                pending_actions = filter_actions_by_block_indices(pending_actions, target_block_indices)
+                if not pending_actions:
+                    return loops
+            self._apply_layout_review_actions(pending_actions, selected)
+            loops = i + 1
+        return loops
+
+    def review_selected_textboxes_dry_run(
+        self, target_block_indices: Optional[List[int]] = None
+    ):
+        """Run planner only and return PageReviewResult without applying fixes."""
+        selected = self._get_review_target_blocks(target_block_indices)
+        planner = LayoutReviewPlanner()
+        snapshots: List[BlockSnapshot] = []
+        for blk in selected:
+            abr = blk.absBoundingRect(qrect=True)
+            doc = blk.document()
+            est = None
+            if doc is not None:
+                ds = doc.size()
+                est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
+            snapshots.append(
+                BlockSnapshot(
+                    block_index=blk.idx,
+                    xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
+                    text=blk.toPlainText(),
+                    font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
+                    est_text_size=est,
+                    bubble_center=self._estimate_block_bubble_center(blk),
+                )
+            )
+        return planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
+
+    def review_selected_textboxes_with_provider(
+        self,
+        config: Optional[ReviewModelConfig] = None,
+        target_block_indices: Optional[List[int]] = None,
+        provider: Optional[ReviewProvider] = None,
+    ):
+        """Review selected/targeted boxes with heuristic/local/cloud provider and return proposals."""
+        cfg = config or ReviewModelConfig()
+        selected = self._get_review_target_blocks(target_block_indices)
+        snapshots: List[BlockSnapshot] = []
+        for blk in selected:
+            abr = blk.absBoundingRect(qrect=True)
+            doc = blk.document()
+            est = None
+            if doc is not None:
+                ds = doc.size()
+                est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
+            snapshots.append(
+                BlockSnapshot(
+                    block_index=blk.idx,
+                    xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
+                    text=blk.toPlainText(),
+                    font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
+                    est_text_size=est,
+                    bubble_center=self._estimate_block_bubble_center(blk),
+                )
+            )
+        provider_impl = provider or self._resolve_review_provider(cfg)
+        return provider_impl.review(getattr(self.imgtrans_proj, "current_img", ""), snapshots, cfg)
+
+    def apply_review_result(
+        self,
+        review_result,
+        target_block_indices: Optional[List[int]] = None,
+    ) -> int:
+        """Apply actions from a precomputed review result and return number of actions applied."""
+        pending_actions = [a for block_result in review_result.blocks for a in block_result.actions]
+        if target_block_indices:
+            pending_actions = filter_actions_by_block_indices(pending_actions, target_block_indices)
+        if not pending_actions:
+            return 0
+        selected = self._get_review_target_blocks(target_block_indices)
+        if not selected:
+            return 0
+        self._apply_layout_review_actions(pending_actions, selected)
+        return len(pending_actions)
+
+    def review_and_fix_selected_textboxes_with_provider(
+        self,
+        config: Optional[ReviewModelConfig] = None,
+        target_block_indices: Optional[List[int]] = None,
+        provider: Optional[ReviewProvider] = None,
+        max_iters: int = 2,
+    ) -> int:
+        """Provider-driven iterative review/apply loop."""
+        loops = 0
+        for i in range(max(1, int(max_iters))):
+            rst = self.review_selected_textboxes_with_provider(config=config, target_block_indices=target_block_indices, provider=provider)
+            applied = self.apply_review_result(rst, target_block_indices=target_block_indices)
+            if applied <= 0:
+                return loops
+            loops = i + 1
+        return loops
+
+    def _resolve_review_provider(self, config: ReviewModelConfig) -> ReviewProvider:
+        """Return configured review provider.
+
+        For `local_api` / `cloud_api`, attach a callable at runtime via:
+        - `self.layout_review_local_api_handler`
+        - `self.layout_review_cloud_api_handler`
+        """
+        if config.provider == "heuristic":
+            return HeuristicReviewProvider()
+        attr = "layout_review_local_api_handler" if config.provider == "local_api" else "layout_review_cloud_api_handler"
+        handler = getattr(self, attr, None)
+        if callable(handler):
+            return ExternalReviewProvider(handler)
+        LOGGER.warning("layout review provider '%s' requested but handler is not configured; falling back to heuristic", config.provider)
+        return HeuristicReviewProvider()
+
+    def review_all_textboxes_on_page_dry_run(self):
+        """Run planner against all non-vertical blocks without mutating layout."""
+        target_indices = [
+            blk.idx
+            for blk in self.textblk_item_list
+            if blk is not None and not getattr(blk.fontformat, "vertical", False)
+        ]
+        return self.review_selected_textboxes_dry_run(target_indices)
+
+    def review_and_fix_all_textboxes_on_page(self, max_iters: int = 2) -> int:
+        """Review/fix all non-vertical text boxes on the current page."""
+        target_indices = [
+            blk.idx
+            for blk in self.textblk_item_list
+            if blk is not None and not getattr(blk.fontformat, "vertical", False)
+        ]
+        if not target_indices:
+            return 0
+        return self._run_layout_review_with_temporary_selection(target_indices, max_iters=max_iters)
+
+    def _run_layout_review_with_temporary_selection(self, target_indices: List[int], max_iters: int = 2) -> int:
+        """Run review while temporarily selecting requested targets, then restore selection."""
+        selected_before = list(self.canvas.selected_text_items())
+        was_editing = self.canvas.editing_textblkitem
+        try:
+            for blk in self.textblk_item_list:
+                if blk is not None:
+                    blk.setSelected(False)
+            idx_set = set(target_indices)
+            for blk in self.textblk_item_list:
+                if blk is None:
+                    continue
+                blk.setSelected(blk.idx in idx_set)
+            return self.review_and_fix_selected_textboxes(
+                max_iters=max_iters,
+                target_block_indices=target_indices,
+            )
+        finally:
+            for blk in self.textblk_item_list:
+                if blk is not None:
+                    blk.setSelected(False)
+            for blk in selected_before:
+                try:
+                    blk.setSelected(True)
+                except Exception:
+                    continue
+            if was_editing is not None and was_editing in self.textblk_item_list:
+                self.canvas.editing_textblkitem = was_editing
+
+    def _get_review_target_blocks(self, target_block_indices: Optional[List[int]] = None) -> List[TextBlkItem]:
+        """Resolve review targets deterministically by block index.
+
+        If target_block_indices is None, currently selected blocks are used.
+        """
+        if not target_block_indices:
+            return [blk for blk in self.canvas.selected_text_items() if not blk.fontformat.vertical]
+        all_blocks = [
+            blk for blk in self.textblk_item_list
+            if blk is not None and not getattr(blk.fontformat, "vertical", False)
+        ]
+        selected_by_idx = {blk.idx: blk for blk in all_blocks}
+        targets: List[TextBlkItem] = []
+        for idx in target_block_indices:
+            blk = selected_by_idx.get(idx)
+            if blk is None:
+                continue
+            targets.append(blk)
+        return targets
+
+    def _estimate_block_bubble_center(self, blkitem: TextBlkItem) -> Optional[Tuple[float, float]]:
+        """Estimate bubble center for a block so off-center review checks can run."""
+        img = self.imgtrans_proj.img_array
+        if img is None:
+            return None
+        abr = blkitem.absBoundingRect(qrect=True)
+        br = [int(abr.x()), int(abr.y()), int(abr.width()), int(abr.height())]
+        if br[2] <= 0 or br[3] <= 0:
+            return None
+        try:
+            enlarge_ratio = min(max(br[2] / max(br[3], 1), br[3] / max(br[2], 1)) * 1.5, 3.0)
+            mask, _area, mask_xyxy, _region_rect = extract_ballon_region(
+                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD
+            )
+            cx_crop, cy_crop = mask_centroid_in_crop(mask)
+            return (float(mask_xyxy[0] + cx_crop), float(mask_xyxy[1] + cy_crop))
+        except Exception as e:
+            LOGGER.debug("layout review: failed to estimate bubble center for block idx=%s: %s", getattr(blkitem, "idx", -1), e)
+            return None
+
+    def _apply_layout_review_actions(self, actions: List[ReviewAction], selected: List[TextBlkItem]) -> None:
+        """Apply planner actions through existing commands whenever possible."""
+        grouped = collect_actions_from_list(actions)
+        selected_by_idx = {blk.idx: blk for blk in selected}
+        # Keep existing action handlers first to preserve current undo behavior.
+        if grouped["auto_fit"]:
+            self.onAutoFitFontToBox()
+        if grouped["resize_to_fit_content"]:
+            self.onResizeToFitContent()
+        if grouped["center_in_bubble"]:
+            self.onCenterInBubble()
+        for action in grouped["move"]:
+            blkitem = selected_by_idx.get(action.block_index)
+            if blkitem is None:
+                continue
+            dx = float(action.args.get("dx", 0.0) or 0.0)
+            dy = float(action.args.get("dy", 0.0) or 0.0)
+            if dx == 0.0 and dy == 0.0:
+                continue
+            rect = blkitem.absBoundingRect(qrect=True)
+            blkitem.oldRect = rect
+            blkitem.setRect([rect.x() + dx, rect.y() + dy, rect.width(), rect.height()], repaint=True)
+            self.canvas.push_undo_command(ReshapeItemCommand(blkitem))
+        for action in grouped["resize"]:
+            blkitem = selected_by_idx.get(action.block_index)
+            if blkitem is None:
+                continue
+            scale = float(action.args.get("scale", 1.0) or 1.0)
+            if scale <= 0:
+                continue
+            rect = blkitem.absBoundingRect(qrect=True)
+            if rect.width() <= 0 or rect.height() <= 0:
+                continue
+            new_w = max(1.0, rect.width() * scale)
+            new_h = max(1.0, rect.height() * scale)
+            cx = rect.x() + rect.width() / 2.0
+            cy = rect.y() + rect.height() / 2.0
+            blkitem.oldRect = rect
+            blkitem.setRect([cx - new_w / 2.0, cy - new_h / 2.0, new_w, new_h], repaint=True)
+            self.canvas.push_undo_command(ReshapeItemCommand(blkitem))
+        for action in grouped["set_font_size"]:
+            blkitem = selected_by_idx.get(action.block_index)
+            if blkitem is None:
+                continue
+            size_pt = float(action.args.get("font_size", 0.0) or 0.0)
+            if size_pt <= 0:
+                continue
+            blkitem.setFontSize(size_pt)
+            if blkitem.blk is not None:
+                blkitem.blk.fontformat.font_size = pt2px(size_pt)
 
     def onSetBalloonShape(self, shape: str):
         """Set global balloon shape and run layout on selected blocks."""

--- a/utils/layout_review_agent.py
+++ b/utils/layout_review_agent.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Literal, Optional, Protocol, Sequence, Tuple
+
+ActionType = Literal[
+    "move",
+    "resize",
+    "set_font_size",
+    "auto_fit",
+    "center_in_bubble",
+    "resize_to_fit_content",
+]
+
+
+@dataclass
+class ReviewIssue:
+    """A deterministic issue emitted by the review pass."""
+
+    code: str
+    severity: Literal["info", "warning", "error"]
+    message: str
+    score_penalty: float = 0.0
+
+
+@dataclass
+class ReviewAction:
+    """Action that can be safely replayed and undone by caller command stack."""
+
+    action: ActionType
+    block_index: int
+    args: Dict[str, float | int | str | bool] = field(default_factory=dict)
+    reason: str = ""
+
+
+@dataclass
+class BlockSnapshot:
+    """Minimal geometry/style snapshot used by the planner.
+
+    This is intentionally UI-agnostic so callers can map TextBlkItem/TextBlock into it.
+    """
+
+    block_index: int
+    xyxy: Tuple[float, float, float, float]
+    text: str
+    font_size: float
+    bubble_center: Optional[Tuple[float, float]] = None
+    est_text_size: Optional[Tuple[float, float]] = None
+
+
+@dataclass
+class BlockReviewResult:
+    block_index: int
+    score_before: float
+    score_after: float
+    issues: List[ReviewIssue]
+    actions: List[ReviewAction]
+
+
+@dataclass
+class PageReviewResult:
+    page_name: str
+    blocks: List[BlockReviewResult]
+
+
+@dataclass
+class ReviewModelConfig:
+    """Model/provider controls for prompt and generation parameters."""
+
+    provider: Literal["heuristic", "local_api", "cloud_api"] = "heuristic"
+    model_name: str = ""
+    prompt: str = (
+        "Review text boxes for overflow, off-center placement, and readability issues. "
+        "Return deterministic fix actions only."
+    )
+    temperature: float = 0.0
+    top_p: float = 1.0
+    max_tokens: int = 512
+    extra_params: Dict[str, Any] = field(default_factory=dict)
+
+
+class ReviewProvider(Protocol):
+    def review(self, page_name: str, blocks: Sequence[BlockSnapshot], config: ReviewModelConfig) -> PageReviewResult:
+        ...
+
+
+class LayoutReviewPlanner:
+    """Heuristic first-pass planner for text box clean-up.
+
+    The planner is conservative: it proposes small fixes that can be executed through
+    existing commands (move/resize/auto-fit/center). A higher-level caller can run
+    these actions, re-render, then feed updated snapshots back for another pass.
+    """
+
+    def review_page(self, page_name: str, blocks: Sequence[BlockSnapshot]) -> PageReviewResult:
+        reviewed: List[BlockReviewResult] = []
+        for blk in blocks:
+            issues, actions, before, after = self._review_block(blk)
+            reviewed.append(
+                BlockReviewResult(
+                    block_index=blk.block_index,
+                    score_before=before,
+                    score_after=after,
+                    issues=issues,
+                    actions=actions,
+                )
+            )
+        return PageReviewResult(page_name=page_name, blocks=reviewed)
+
+    def _review_block(self, blk: BlockSnapshot):
+        issues: List[ReviewIssue] = []
+        actions: List[ReviewAction] = []
+
+        x1, y1, x2, y2 = blk.xyxy
+        bw = max(1.0, x2 - x1)
+        bh = max(1.0, y2 - y1)
+        box_area = bw * bh
+
+        est_w, est_h = blk.est_text_size or (0.0, 0.0)
+        overflow_x = est_w > bw * 0.98
+        overflow_y = est_h > bh * 0.98
+
+        score_before = 1.0
+
+        if overflow_x or overflow_y:
+            issues.append(
+                ReviewIssue(
+                    code="text_overflow",
+                    severity="warning",
+                    message="Estimated text bounds exceed text box bounds.",
+                    score_penalty=0.25,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="auto_fit",
+                    block_index=blk.block_index,
+                    reason="Reduce font size to fit current box before resizing.",
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="resize_to_fit_content",
+                    block_index=blk.block_index,
+                    reason="Expand box if auto-fit alone is insufficient.",
+                )
+            )
+            score_before -= 0.25
+
+        if blk.bubble_center is not None:
+            cx, cy = (x1 + x2) / 2.0, (y1 + y2) / 2.0
+            bcx, bcy = blk.bubble_center
+            dx, dy = abs(cx - bcx), abs(cy - bcy)
+            if dx > bw * 0.2 or dy > bh * 0.2:
+                issues.append(
+                    ReviewIssue(
+                        code="off_center",
+                        severity="info",
+                        message="Text box center is far from bubble center.",
+                        score_penalty=0.1,
+                    )
+                )
+                actions.append(
+                    ReviewAction(
+                        action="center_in_bubble",
+                        block_index=blk.block_index,
+                        reason="Recenters text while preserving style.",
+                    )
+                )
+                score_before -= 0.1
+
+        tiny_area = box_area < 64 * 64
+        if tiny_area and len((blk.text or "").strip()) > 20:
+            issues.append(
+                ReviewIssue(
+                    code="tiny_box_dense_text",
+                    severity="warning",
+                    message="Dense text in very small box likely unreadable.",
+                    score_penalty=0.15,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="resize",
+                    block_index=blk.block_index,
+                    args={"scale": 1.1},
+                    reason="Slightly increase box area before final fit pass.",
+                )
+            )
+            score_before -= 0.15
+
+        score_after = max(score_before + 0.2 * (1 if actions else 0), 0.0)
+        return issues, actions, max(score_before, 0.0), min(score_after, 1.0)
+
+
+def collect_actions_by_type(page_result: PageReviewResult) -> Dict[ActionType, List[ReviewAction]]:
+    """Group proposed actions by action type."""
+    grouped: Dict[ActionType, List[ReviewAction]] = {
+        "move": [],
+        "resize": [],
+        "set_font_size": [],
+        "auto_fit": [],
+        "center_in_bubble": [],
+        "resize_to_fit_content": [],
+    }
+    for blk in page_result.blocks:
+        for action in blk.actions:
+            grouped[action.action].append(action)
+    return grouped
+
+
+def collect_actions_from_list(actions: Sequence[ReviewAction]) -> Dict[ActionType, List[ReviewAction]]:
+    """Group already-flattened actions by action type."""
+    grouped: Dict[ActionType, List[ReviewAction]] = {
+        "move": [],
+        "resize": [],
+        "set_font_size": [],
+        "auto_fit": [],
+        "center_in_bubble": [],
+        "resize_to_fit_content": [],
+    }
+    for action in actions:
+        grouped[action.action].append(action)
+    return grouped
+
+
+def filter_actions_by_block_indices(
+    actions: Sequence[ReviewAction], block_indices: Sequence[int]
+) -> List[ReviewAction]:
+    """Keep only actions targeting the requested block indices."""
+    target_ids = set(block_indices)
+    return [a for a in actions if a.block_index in target_ids]
+
+
+class HeuristicReviewProvider:
+    """Default deterministic provider backed by LayoutReviewPlanner."""
+
+    def __init__(self):
+        self.planner = LayoutReviewPlanner()
+
+    def review(self, page_name: str, blocks: Sequence[BlockSnapshot], config: ReviewModelConfig) -> PageReviewResult:
+        return self.planner.review_page(page_name, blocks)
+
+
+class ExternalReviewProvider:
+    """Adapter for local/cloud API review handlers.
+
+    `handler` should accept `(page_name, blocks, config)` and return `PageReviewResult`.
+    """
+
+    def __init__(self, handler: Callable[[str, Sequence[BlockSnapshot], ReviewModelConfig], PageReviewResult]):
+        self.handler = handler
+
+    def review(self, page_name: str, blocks: Sequence[BlockSnapshot], config: ReviewModelConfig) -> PageReviewResult:
+        return self.handler(page_name, blocks, config)
+
+
+def iterative_review(
+    page_name: str,
+    initial_blocks: Sequence[BlockSnapshot],
+    apply_actions: Callable[[List[ReviewAction]], Sequence[BlockSnapshot]],
+    max_iters: int = 3,
+) -> Tuple[PageReviewResult, int]:
+    """Run review -> apply -> re-review loop.
+
+    Caller provides `apply_actions`, which maps actions into actual UI/model mutations
+    and returns the new block snapshots from the updated render state.
+    """
+
+    planner = LayoutReviewPlanner()
+    current = list(initial_blocks)
+    last = planner.review_page(page_name, current)
+
+    for i in range(max_iters):
+        pending = [a for b in last.blocks for a in b.actions]
+        if not pending:
+            return last, i
+        current = list(apply_actions(pending))
+        last = planner.review_page(page_name, current)
+
+    return last, max_iters


### PR DESCRIPTION
### Motivation

- Provide a deterministic, conservative layout review system to detect and propose safe fixes for text box issues (overflow, off-center placement, tiny/dense boxes) usable by both heuristic and external providers.
- Expose provider-driven review/apply loops so callers can iteratively fix layouts and preserve existing command/undo behavior.
- Integrate layout review controls into the UI to run review on selection or whole page and allow runtime configuration of the review provider.

### Description

- Add a new module `utils/layout_review_agent.py` implementing `LayoutReviewPlanner`, `ReviewModelConfig`, `ReviewAction`, `BlockSnapshot`, providers (`HeuristicReviewProvider`, `ExternalReviewProvider`), helpers (`collect_actions_from_list`, `collect_actions_by_type`, `filter_actions_by_block_indices`), and `iterative_review` loop.
- Integrate planner/providers into scene manager by adding review APIs in `ui/scenetext_manager.py`: `review_and_fix_selected_textboxes`, `review_selected_textboxes_dry_run`, `review_selected_textboxes_with_provider`, `apply_review_result`, `review_and_fix_selected_textboxes_with_provider`, provider resolution `_resolve_review_provider`, page-level helpers (`review_all_textboxes_on_page_dry_run`, `review_and_fix_all_textboxes_on_page`), and utility methods to estimate bubble center and map targets; and implement `_apply_layout_review_actions` to replay actions via existing commands.
- Wire UI entry points in `ui/mainwindow.py` by importing `ReviewModelConfig`, adding shortcuts and handlers `shortcutLayoutReviewSelected`, `shortcutLayoutReviewPage`, and `shortcutLayoutReviewConfig` which read/update a `ReviewModelConfig` via `QInputDialog` and call scene manager review functions.
- Add unit tests `tests/test_layout_review_agent.py` that validate planner proposals, action grouping/filtering, iterative review loop behavior, and provider adapters.

### Testing

- Ran the new unit tests with `pytest tests/test_layout_review_agent.py` and the suite passed successfully (all tests in that file succeeded).
- Exercised the planner flow and grouping helpers in tests covering overflow, centering, tiny/dense boxes, action collection, provider adapters, and the iterative review loop, all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f4e968b0d8832c8c3561a82b5ec3af)