### PR TITLE
Fix Windows installer build when source is not a Git repo

### DIFF
--- a/launch.spec
+++ b/launch.spec
@@ -3,8 +3,14 @@ import os
 import subprocess
 from PyInstaller.utils.hooks import collect_data_files
 
-# 获取提交哈希值
-commit_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).decode('utf-8').strip()
+# 获取提交哈希值（如果不是 git 仓库则使用 fallback）
+try:
+    commit_hash = subprocess.check_output(
+        ['git', 'rev-parse', '--short', 'HEAD'],
+        stderr=subprocess.DEVNULL,
+    ).decode('utf-8').strip()
+except Exception:
+    commit_hash = os.environ.get('BATR_COMMIT_HASH', 'nogit')
 
 # 构造带提交哈希值的版本号
 version = "1.4.0.dev." + commit_hash


### PR DESCRIPTION
### Motivation
- The PyInstaller `launch.spec` script assumed `git` metadata was always available and caused `subprocess.CalledProcessError` when building from a ZIP or other non-git source, which broke the Windows installer build.

### Description
- Replace the direct `git rev-parse` call in `launch.spec` with a `try`/`except` that suppresses Git stderr and falls back to the `BATR_COMMIT_HASH` environment variable or the literal `nogit` when Git information is unavailable.
- Preserve the existing version format `1.4.0.dev.<hash>` while making the spec resilient to missing `.git` metadata.

### Testing
- Verified the updated `launch.spec` content with `sed` and `nl` to confirm the new `try`/`except` and fallback logic are present and syntactically correct. (succeeded)
- Confirmed the change targets only `launch.spec` and addresses the exact code path that previously raised on `git rev-parse` failure. (inspection succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6509f50bc832c84d6413a62732bce)