### PR TITLE
Add Windows icon handling and make textstyles dir user-writable; update installer config

### DIFF
--- a/installer/windows/BallonsTranslatorPro.iss
+++ b/installer/windows/BallonsTranslatorPro.iss
@@ -22,10 +22,11 @@ OutputBaseFilename=BallonsTranslatorPro-Setup
 Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
-ArchitecturesAllowed=x64
-ArchitecturesInstallIn64BitMode=x64
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
 PrivilegesRequired=admin
 UninstallDisplayIcon={app}\{#MyAppExeName}
+SetupIconFile=..\..\icons\icon2.ico
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"
@@ -37,8 +38,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 Source: "{#MyBuildDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
-Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\icons\icon2.ico"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; IconFilename: "{app}\icons\icon2.ico"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent

--- a/launch.spec
+++ b/launch.spec
@@ -102,12 +102,15 @@ a = Analysis([
 )
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
 
+win_icon = 'icons/icon2.ico' if os.path.exists('icons/icon2.ico') else None
+
 exe = EXE(
     pyz,
     a.scripts,
     [],
     exclude_binaries=True,
     name='launch',
+    icon=win_icon,
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/scripts/build_windows_installer.py
+++ b/scripts/build_windows_installer.py
@@ -11,6 +11,26 @@ import subprocess
 import sys
 
 
+def _ensure_windows_icon(root: str) -> str | None:
+    """Create icons/icon2.ico from doc/src/icon2.png when possible."""
+    src = osp.join(root, "doc", "src", "icon2.png")
+    dst = osp.join(root, "icons", "icon2.ico")
+    if osp.isfile(dst):
+        return dst
+    if not osp.isfile(src):
+        print("[warn] icon source not found:", src)
+        return None
+    try:
+        from PIL import Image
+        img = Image.open(src)
+        img.save(dst, sizes=[(16, 16), (24, 24), (32, 32), (48, 48), (64, 64), (128, 128), (256, 256)])
+        print("[ok] generated", dst)
+        return dst
+    except Exception as e:
+        print(f"[warn] could not generate {dst}: {e}")
+        return None
+
+
 def _find_iscc() -> str:
     candidates = [
         os.environ.get("ISCC_EXE", ""),
@@ -27,6 +47,9 @@ def main() -> int:
     root = osp.abspath(osp.join(osp.dirname(__file__), ".."))
     os.chdir(root)
     py = sys.executable
+
+    # 0) Ensure optional Windows .ico exists for installer/exe branding
+    _ensure_windows_icon(root)
 
     # 1) Build standalone exe with PyInstaller
     subprocess.check_call([py, "scripts/package_release.py"])

--- a/utils/shared.py
+++ b/utils/shared.py
@@ -21,9 +21,23 @@ STYLESHEET_PATH = osp.join(PROGRAM_PATH, 'config/stylesheet.css')
 THEME_PATH = osp.join(PROGRAM_PATH, 'config/themes.json')
 CONFIG_PATH = osp.join(PROGRAM_PATH, 'config/config.json')
 
-DEFAULT_TEXTSTYLE_DIR = osp.join(PROGRAM_PATH, 'config/textstyles')
-if not osp.exists(DEFAULT_TEXTSTYLE_DIR):
-    os.makedirs(DEFAULT_TEXTSTYLE_DIR)
+def _user_config_root() -> str:
+    if sys.platform == 'win32':
+        appdata = os.environ.get('APPDATA')
+        if appdata:
+            return osp.join(appdata, 'BallonsTranslator Pro')
+    return osp.join(osp.expanduser('~'), '.ballonstranslator-pro')
+
+
+def _resolve_textstyle_dir() -> str:
+    installed_dir = osp.join(PROGRAM_PATH, 'config/textstyles')
+    if os.access(PROGRAM_PATH, os.W_OK):
+        return installed_dir
+    return osp.join(_user_config_root(), 'config', 'textstyles')
+
+
+DEFAULT_TEXTSTYLE_DIR = _resolve_textstyle_dir()
+os.makedirs(DEFAULT_TEXTSTYLE_DIR, exist_ok=True)
 
 
 CONFIG_FONTSIZE_HEADER = 18


### PR DESCRIPTION
### Motivation
- Provide a bundled Windows icon for the EXE and Inno Setup installer so shortcuts and installer use the app icon. 
- Generate a `.ico` from source PNG at build time when available to automate branding. 
- Make the default `textstyles` directory writable for users when the installed program directory is not writable. 
- Improve Inno Setup settings to use `x64compatible` and point installer icon entries at the packaged icon.

### Description
- Added `_ensure_windows_icon` to `scripts/build_windows_installer.py` which attempts to create `icons/icon2.ico` from `doc/src/icon2.png` using `PIL` and called it before packaging. 
- Updated `installer/windows/BallonsTranslatorPro.iss` to set `ArchitecturesAllowed`/`ArchitecturesInstallIn64BitMode` to `x64compatible`, added `SetupIconFile`, and changed shortcut `IconFilename` entries to `"{app}\icons\icon2.ico"`. 
- Modified `launch.spec` to detect `icons/icon2.ico` (if present) and pass it as the `icon` for the PyInstaller `EXE`. 
- Reworked `utils/shared.py` to resolve `DEFAULT_TEXTSTYLE_DIR` into a user-writable location when the program install directory is not writable, using `%APPDATA%` on Windows or the home directory otherwise, and create the directory with `os.makedirs(..., exist_ok=True)`. 

### Testing
- No automated tests were added or modified for these changes. 
- No CI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f6548e3478832c9bc87eb3dd4ac73b)