### PR TITLE
Add Koharu-inspired layout review, page completion state, rendering controls, structured OCR/PSD handoff, and related UI/automation

### DIFF
--- a/docs/KOHARU_GAP_ANALYSIS.md
+++ b/docs/KOHARU_GAP_ANALYSIS.md
@@ -1,123 +1,150 @@
-# Koharu Deep-Dive Gap Analysis (for BallonsTranslator Pro)
+# Koharu Gap Analysis and Implementation Audit
 
-## Scope
-This analysis reviews `mayocream/koharu` architecture and documents concrete implementations we can port or adapt.
+_Last audited: 2026-05-05 against BallonsTranslator Pro current branch and public `mayocream/koharu` issue/API surface._
 
-## High-value architecture differences
+## Audit scope
 
-1. **Strict stage pipeline contracts**
-   - Koharu isolates `Detect -> OCR -> Inpaint -> LLM Generate -> Render` with explicit stage outputs.
-   - Recommendation: formalize per-stage typed payload schemas and add a stage-contract validator between modules.
+This audit compares BallonsTranslator Pro against Koharu's current public direction: a local-first staged manga translation stack with provider/runtime settings, MCP/API automation, vertical/PSD-focused rendering, and recent issue themes such as page completion state, skipping satisfied pipeline work, global/fixed text styling, dictionary/glossary workflow, and bulk project processing.
 
-2. **Multi-model detect stage split**
-   - Koharu separates text+bubble detection from segmentation mask generation and font hints.
-   - Recommendation: add an optional dual-detector orchestration mode that fuses current detector output with segmentation confidence maps before inpaint.
+Repository search before implementation found that BallonsTranslator Pro already had substantial foundations: Pipeline Insights, local automation actions, mask diagnostics, OCR crop inspection, reading-order editing, glossary guardrails, run profiles, skip ignored pages, and heuristic layout review wiring. The work below therefore completes gaps and avoids duplicating existing features.
 
-3. **Scene op/history protocol for automation**
-   - Koharu exposes low-level mutation ops (`AddNode`, `UpdateNode`, `Batch`) and undo/redo through HTTP/MCP tools.
-   - Recommendation: add a stable JSON op API over current project edits for scriptability and future MCP integration.
+## Existing implementations found
 
-4. **MCP-first automation endpoint**
-   - Koharu supports background pipeline jobs from MCP and external agents.
-   - Recommendation: expose `open_project`, `run_pipeline`, `apply_edit`, `undo`, `redo`, and `export` actions in our local API.
+| Area | Existing status | Evidence in repo |
+| --- | --- | --- |
+| Pipeline observability | Substantially implemented: job/progress UI, warnings, provider health, engine registry, events. | `ui/pipeline_insights_widget.py`, `ui/module_manager.py` |
+| Layout review agent | Partial before this PR: heuristic/provider planner existed and menu/shortcut/API entry points existed, but page-level provider application could act on stale selection and there was no human-readable report/approval UI. | `utils/layout_review_agent.py`, `ui/scenetext_manager.py`, `ui/mainwindow.py` |
+| Local automation API | Implemented basic command surface including `layout_review`. | `ui/mainwindow.py`, `tests/test_local_automation_api.py` |
+| OCR/text QA | Implemented triage, OCR crop inspector, translation QA, auto glossary extraction. | `ui/ocr_crop_inspector_widget.py`, `utils/translation_review.py` |
+| Project ops/history | Implemented initial JSON project ops dialog/protocol; not a full MCP op log. | `ui/project_ops_dialog.py`, `tests/test_project_ops_protocol.py` |
+| Page skipping | Partial: skip ignored pages and skip already translated text existed; skip already-satisfied stage work did not exist for normal full runs. | `ui/mainwindow.py`, `ui/configpanel.py` |
+| Page completion state | Missing before this PR. | No `completion_state` implementation before this audit. |
+| Fixed/global text style | Partial: rich text style presets existed; no simple batch fixed font size/alignment override like Koharu issue requests. | `ui/text_style_presets.py`, `ui/scenetext_manager.py` |
+| Credential separation | Partial: keyring support exists for selected flows only; full translator/LLM key migration remains open. | `utils/credential_store.py` |
+| Rendering parity | Partial: vertical CJK controls and many text effects exist; PSD text/effect fidelity mode remains incomplete. | `ui/scene_textlayout.py`, export scripts |
 
-5. **Credential storage separation**
-   - Koharu stores API keys in platform credential storage, separate from config.
-   - Recommendation: move translator/LLM API keys to OS keyring and keep only base URLs in config.
+## Highest-impact missing or partial items selected for this PR
 
-## Feature opportunities to implement in BallonsTranslator Pro
+1. **Complete layout review end-to-end**: make review auditable, provider/API safe, undo-friendly, and selection-correct.
+2. **Page completion state** (Koharu issue #651): add durable user-visible page state for needs-work/translated/reviewed/exported.
+3. **Skip already-satisfied pipeline pages** (Koharu issue #650): avoid rerunning pages whose persisted finish state already satisfies enabled stages.
+4. **Global/fixed text style override** (Koharu issues #649/#640/#648): add a connected UI and backend to apply fixed font size, font family, alignment, and auto-fit across current page or project.
+5. **Structured OCR export** (Koharu issue #555): expose page/block geometry, OCR text, translations, font hints, and workflow state for LLM/tooling integrations.
+6. **Visible UI polish**: improve Pipeline Insights empty state/action affordance and add icon assets for completion/export workflows.
 
-## 1) Pipeline UX & reliability
-- **Per-stage retry policy** (different retries for OCR vs LLM vs downloads).
-- **Stage-level warnings panel** with structured machine-readable warning codes.
-- **Selective re-run**: rerun from OCR onward without repeating detection/inpaint.
-- **Job IDs + event stream** for long runs (desktop and future headless modes).
+## Implemented in this PR
 
-## 2) Detection, segmentation, and cleanup quality
-- **Mask diagnostics view**: overlay raw mask, thresholded mask, and dilated mask.
-- **Auto-threshold tuner** using page histogram + confidence percentiles.
-- **Bubble-aware cleanup expansion**: dilate differently inside/outside bubble regions.
-- **Edge-halo detector** post-inpaint QA to auto-flag pages needing manual touch-up.
+### 1) Layout review agent completion
 
-## 3) OCR and text editing workflow
-- **OCR crop inspector** per text block (image crop + recognized text + confidence).
-- **Reading-order editor** with quick reorder shortcuts and visual graph edges.
-- **Text normalization module**: punctuation style, half/full-width normalization, ruby stripping presets.
-- **Batch find/replace with regex profiles** scoped by page/chapter.
+- Added a report dialog that summarizes issues, actions, and score before applying fixes.
+- Added per-block/action checkboxes so reviewers can approve only selected proposed fixes instead of applying an all-or-nothing batch.
+- Changed selected/page menu flows to run provider-backed review, show the report, and apply through `SceneTextManager.apply_review_result` only after user approval.
+- Fixed provider/page review application so target blocks are temporarily selected before low-level auto-fit/center/resize commands run; this prevents page-level/API review from accidentally mutating only the previously selected block.
+- Enhanced the automation API `layout_review` action to return structured summary data and applied action count.
 
-## 4) LLM procedure improvements
-- **Prompt profiles per content type** (dialogue, narration, SFX, signboard).
-- **Two-pass translation**: draft pass + style-consistency refinement pass.
-- **Glossary enforcement mode** with hard/soft constraints and violation report.
-- **Back-translation QA** (target->source sanity check for meaning drift).
-- **Token-budget planner** that chunks oversized pages deterministically.
+### 2) Page completion state
 
-## 5) Rendering and typography
-- **Font hint fusion**: combine OCR language/script detection + palette sampling + manual presets.
-- **Vertical CJK layout presets** (line-gap defaults, punctuation hanging, rotate-latin toggles).
-- **PSD export fidelity mode** preserving text layers and effect metadata.
-- **Per-bubble style templates** auto-applied based on bubble geometry class.
+- Added per-page `completion_state` persisted in project `image_info` with validated states: `todo`, `translated`, `reviewed`, `exported`.
+- Added page list context menu actions to set completion state for selected pages.
+- Added visible page-list row styling and tooltips for completion state while preserving existing ignored-page behavior.
+- Added automation API support to list/set page completion state.
+- Added an optional automatic transition that marks pages as `translated` when a completed run satisfies the enabled stage finish contract.
 
-## 6) Settings & runtime modules
-- **Runtime HTTP controls** in UI (connect timeout, read timeout, retries) with restart hint.
-- **Engine registry panel** showing active engine IDs and compatibility diagnostics.
-- **Provider health status dots** (ready/missing/error/unknown) beside each API provider.
-- **Data path manager** with migration helper + free-space check.
+### 3) Skip already-satisfied pipeline pages
 
-## Proposed implementation plan (phased)
+- Added a persisted setting `skip_satisfied_pipeline_steps`.
+- Added General settings UI for the setting.
+- Full runs now keep already-satisfied pages out of `pages_to_process` before resetting finish codes, with Pipeline Insights telemetry for skipped pages and a status message when everything is already satisfied.
 
-### Phase A (2-3 weeks): automation & observability
-- Add pipeline job IDs + progress events.
-- Add stage warning codes and rerun-from-stage action.
-- Add provider status diagnostics and keyring-backed key storage.
+### 4) Batch fixed text styling
 
-### Phase B (3-4 weeks): quality stack
-- Add mask diagnostics panel and adaptive thresholding.
-- Add OCR inspector + reading-order editor.
-- Add glossary enforcement and translation drift checker.
+- Added a Pipeline Insights action for batch text style overrides.
+- Added connected backend behavior for current-page or whole-project scope.
+- Supports font family, fixed font size in points, alignment, and enabling auto-fit after the override.
+- Persists project changes and refreshes current page scene text.
 
-### Phase C (3-4 weeks): advanced rendering
-- Add vertical CJK layout preset system.
-- Add per-bubble style template auto-apply.
-- Improve PSD export metadata fidelity.
+### 5) Structured OCR export
 
-## Implementation progress snapshot (updated)
+- Added a stable `ballonstranslator.structured_ocr.v1` JSON payload builder for current project state.
+- Export includes page dimensions, ignored/completion state, finish code, block order, geometry, OCR/source text, translation, labels, confidence, and font hints.
+- Added a Tools → Export action and automation API command for structured OCR JSON export.
 
-### Completed or substantially implemented
-- ✅ **Layout review agent end-to-end wiring**: menu/shortcuts + Pipeline Insights trigger + local automation API route (`layout_review`) all invoke the same review flow.
-- ✅ **Theme settings cleanup**: removed legacy Bubbly UI mode and unified light/dark switching so theme controls are no longer duplicated.
-- ✅ **Edge-halo detector QA (initial implementation)** in mask diagnostics with edge-ring halo ratio scoring to flag likely cleanup artifacts.
-- ✅ **Auto-threshold tuner foundation** in mask diagnostics (Otsu recommendation + live mask fill metrics).
-- ✅ **Stage-level warnings panel with structured codes** (Pipeline Insights warnings: `MT_DRIFT`, `RERUN`, `HTTP_RETRY_FAIL`, etc.).
-- ✅ **Pipeline job IDs + event stream basics** (job sequence IDs + timeline events emitted from ModuleManager to UI).
-- ✅ **Selective stage intent controls** (rerun requests from pipeline panel; currently mapped to full run with stage intent retained in telemetry).
-- ✅ **Mask diagnostics view foundation** (raw/thresholded/dilated mask preview + threshold/dilation controls).
-- ✅ **OCR crop inspector (initial)** with per-block crop preview, OCR text, translation preview, and confidence listing from Pipeline Insights.
-- ✅ **Glossary enforcement mode** with UI editor and postprocess integration.
-- ✅ **Back-translation drift QA** with threshold setting and visible warnings.
-- ✅ **Token-budget-aware helper utilities** for chunk planning.
-- ✅ **Runtime HTTP controls in UI** (timeout/retry) applied to provider-backed review calls.
-- ✅ **Data path manager (initial)** with custom data path picker and free-space health indicator in settings.
-- ✅ **Engine/provider health surfaces** (provider readiness and engine registry snapshot in Pipeline Insights).
-- ✅ **Text normalization + regex replace profiles** (configurable postprocess and reusable profile editor/apply flow).
-- ✅ **Vertical CJK render controls (initial pass)**: rotate-latin toggle + punctuation hanging toggle exposed in settings and applied in scene text layout logic.
+### 6) UI polish and assets
 
-### In progress / partial
-- 🟡 **Dual-detector orchestration**: partial groundwork via detector options/retries; confidence-map fusion policy still pending.
-- 🟡 **Automation operation protocol**: introduced a stable ProjectOps schema (`UpdateText`, `Batch`) with undo/redo-ready operation chunks and a full JSON ProjectOps Console (apply/undo/redo/commit) in Pipeline Insights; local localhost automation API routes (`open_project`, `run_pipeline`, `apply_edit`, `undo`, `redo`, `export`) are now implemented as an initial command surface with optional API-key auth, queued UI-thread dispatch, and live queue status in Pipeline Insights.
-- 🟡 **Credential storage separation**: keyring-backed storage added for video flow-fixer API keys with config fallback; full translator/LLM migration still pending.
-- 🟡 **Reading-order/editor tooling**: helper workflows + OCR crop inspector are in place; a dedicated Reading Order Editor (manual reorder) is now implemented, while graph-edge visualization and auto-order suggestions remain pending.
+- Added a clearer Pipeline Insights empty state.
+- Highlighted the Layout Review Agent action as the primary review entry point.
+- Added `icons/page_completion.svg` and `icons/structured_ocr_export.svg` for the new completion/export workflows.
 
-### Not yet implemented
-- ⏳ MCP-first command surface hardening (documented stable contract, richer validation, and external tool docs) for the new localhost routes (auth + queued UI-thread execution are now supported).
-- ⏳ Keyring-backed credential storage migration for all translator/LLM keys (beyond current flow-fixer keyring support).
-- ⏳ Bubble-aware adaptive cleanup expansion (inside/outside bubble differential dilation policy).
-- ⏳ Vertical CJK policy engine and renderer-level punctuation hanging/rotate toggles.
-- ⏳ PSD text/effect metadata fidelity mode.
+## Remaining limitations
 
-## Notes on source references reviewed
-- `docs/en-US/explanation/how-koharu-works.md`
-- `docs/en-US/explanation/technical-deep-dive.md`
-- `docs/en-US/reference/settings.md`
-- `docs/en-US/reference/mcp-tools.md`
-- Repository structure under `/tmp/koharu` for modules (`koharu-app`, `koharu-core`, `koharu-renderer`, `koharu-llm`, `koharu-psd`).
+- Layout review provider schema is intentionally conservative and still expects OpenAI-compatible chat-completions JSON responses; richer provider adapters and model-specific response parsing remain future work.
+- Page completion can auto-mark `translated`, but `reviewed` and `exported` remain manual to avoid surprising users.
+- Skip already-satisfied pages uses the existing `finish_code` contract. If users change provider/model settings and want a clean rerun, they should leave the new setting off or manually rerun selected pages.
+- Batch text style override changes project/block formats directly, but does not yet expose named reusable project-level style policies.
+- Full translator/LLM keyring migration, PSD text/effect fidelity mode, and bubble-aware differential mask expansion remain open.
+
+## Updated phased plan
+
+### Completed / substantially implemented
+
+- Layout review agent end-to-end report/apply/API flow with selectable proposed actions.
+- Page completion state with persistence, page-list UI, automation API, and optional translated auto-marking.
+- Skip already-satisfied full-run pages.
+- Batch fixed text style override for page/project scope.
+- Structured OCR JSON export for LLM/tooling workflows.
+- Pipeline Insights empty/action-state polish.
+- Existing foundations retained: warnings/events, local automation API, mask diagnostics, OCR crop inspector, reading-order editor, glossary guardrails, run profiles, runtime HTTP controls, engine registry.
+
+### Next recommended tranche
+
+1. Document and harden the local automation contract for external agents/MCP clients.
+2. Add guarded automatic `reviewed`/`exported` completion transitions where user intent is unambiguous.
+3. Add reusable project style policies/templates rather than one-off batch overrides.
+4. Extend layout review provider adapters beyond OpenAI-compatible JSON chat completions.
+5. Continue keyring migration for all translator/LLM API keys.
+
+---
+
+## 2026-05-05 major rendering-focused implementation pass
+
+This pass re-audited the repository and Koharu's public issue tracker before implementation. Searches covered renderer/text layout/font/stroke/shadow/vertical text, PSD/export, layout review, config, shortcuts, and automation code paths in `ui/`, `utils/`, `tests/`, and docs.
+
+### Koharu issue research used
+
+Relevant public Koharu issues reviewed via the GitHub API and documentation pages:
+
+| Koharu issue/doc | Relevant idea | BallonsTranslator-Pro outcome |
+| --- | --- | --- |
+| [#597](https://github.com/mayocream/koharu/issues/597) manual text direction toggle | Add user-visible writing direction control instead of relying only on heuristics. | Implemented per-textbox writing mode in the text panel and context menu; persisted in `FontFormat`; review can switch modes. |
+| [#602](https://github.com/mayocream/koharu/issues/602), [#583](https://github.com/mayocream/koharu/issues/583), [#431](https://github.com/mayocream/koharu/issues/431) Arabic/RTL render quality | RTL should be detected and not treated as LTR/CJK. | Auto writing-mode resolution detects Arabic/Hebrew; diagnostics/API report resolved RTL and review can flag mode mismatch. Full shaping remains dependent on Qt. |
+| [#594](https://github.com/mayocream/koharu/issues/594) advanced text formatting | Spacing/effects/kerning/gradient-style formatting should be first-class. | Added fit policies, preset-driven stroke/spacing/padding/font-size, diagnostics-aware bounds, and config defaults; existing gradient/path/warp controls remain connected. |
+| [#593](https://github.com/mayocream/koharu/issues/593), [#640](https://github.com/mayocream/koharu/issues/640), [#649](https://github.com/mayocream/koharu/issues/649), [#528](https://github.com/mayocream/koharu/issues/528) presets/fixed/global font options | Users need repeatable lettering styles across projects/pages. | Added manga lettering presets with font size/stroke/spacing/alignment/writing mode/padding and default render config fields. Existing batch style override remains available. |
+| [#595](https://github.com/mayocream/koharu/issues/595), [#490](https://github.com/mayocream/koharu/issues/490) font UX/fallback/family weights | Font choice/fallback needs better diagnostics. | Added per-script fallback chains, missing-glyph diagnostics, fallback chain reporting, and config UI. Weight subfamily selection is deferred. |
+| [#545](https://github.com/mayocream/koharu/issues/545), [#462](https://github.com/mayocream/koharu/issues/462), [#446](https://github.com/mayocream/koharu/issues/446), [#447](https://github.com/mayocream/koharu/issues/447) bounds/overlap/cropped outlines | Bounds must account for stroke, shadow, punctuation, and DPI. | Added renderer-independent bounds estimates, overlay diagnostics, stroke/shadow expansion in text item bounds, padding quick fixes, and layout-review overflow actions. |
+| [#558](https://github.com/mayocream/koharu/issues/558), [#587](https://github.com/mayocream/koharu/issues/587), [#535](https://github.com/mayocream/koharu/issues/535), [#568](https://github.com/mayocream/koharu/issues/568) PSD/export reliability | Export should preserve editable text and surface unsupported cases. | Added a layered PSD handoff export with helper layers, editable text metadata, JSX rebuild script, status feedback, and warnings instead of silent rasterization/failure. Native PSD writing remains deferred. |
+| [#519](https://github.com/mayocream/koharu/issues/519), [#410](https://github.com/mayocream/koharu/issues/410), [#365](https://github.com/mayocream/koharu/issues/365), [#646](https://github.com/mayocream/koharu/issues/646) keyboard/tool polish | Tool shortcuts and brush-size shortcuts should be discoverable and safe while editing. | Added text eraser and brush-size shortcuts, visible shortcut tooltips, single-key shortcut input guards, and a duplicate-hard-conflict test. |
+| Koharu docs: text rendering/vertical CJK layout and PSD export docs | Columns flow top-to-bottom/right-to-left, punctuation is normalized/recentered, bounds are tight, PSD has helper layers/editable text. | Implemented Python/PyQt equivalents where practical: vertical column diagnostics/wrapping, punctuation classes, fit-to-box, fallback diagnostics, helper-layer PSD handoff. |
+
+### Progress audit
+
+| Category | Implemented | Partially implemented | Missing/deferred with reason | Newly implemented in this pass |
+| --- | --- | --- | --- | --- |
+| Writing mode controls | Per-textbox `writing_mode` values Auto/Horizontal LTR/Vertical RL/RTL are normalized, persisted in `FontFormat`, visible in the text panel, available from context menu, and used by layout/review/API diagnostics. | Qt's underlying RTL shaping is used; complex HarfBuzz-level shaping is not bundled. | Full OpenType feature control (`vert`/`vrt2`) is deferred because PyQt's text stack does not expose a stable cross-binding API. | `utils/text_rendering.py`, `ui/text_panel.py`, `ui/fontformat_commands.py`, `ui/canvas.py`, `ui/scenetext_manager.py`, `utils/fontformat.py`. |
+| Vertical CJK | Existing real `VerticalTextDocumentLayout` already stacks glyphs into vertical columns; this pass added text normalization, vertical punctuation classes, diagnostic vertical columns, and fit/layout integration. | Font-specific vertical alternates still depend on Qt/font behavior. | Publishing-grade vertical shaping remains deferred for optional native shaping dependency evaluation. | `utils/text_rendering.py`, `ui/scene_textlayout.py`, `ui/textitem.py`, `tests/test_text_rendering.py`. |
+| Script-aware wrapping/fitting | CJK kinsoku wrapping, line balancing, vertical columns, shrink/expand/preserve/balance fit modes, and fit diagnostics are implemented and tested. | The canvas layout still has older heuristic paths for bubble masks; the new helper is integrated before those paths rather than replacing them wholesale. | Knuth-Plass/ICU segmentation is deferred to avoid adding heavy dependencies. | `utils/text_rendering.py`, `ui/scenetext_manager.py`, `tests/test_text_rendering.py`. |
+| Font fallback | Per-script fallback chains, chain merging/deduplication, missing-glyph diagnostics, config UI, layout review warnings, and automation issue listing are implemented. | Actual multi-font glyph-run substitution is still limited by Qt document behavior. | Full fallback shaping per glyph is deferred until a cross-platform shaping/font stack is chosen. | `utils/text_rendering.py`, `utils/config.py`, `ui/configpanel.py`, `ui/scenetext_manager.py`, `ui/textitem.py`. |
+| Manga effects/presets | Presets now set font size, stroke, spacing, alignment, writing mode, and padding; defaults for stroke/shadow/padding are configurable; existing stroke/shadow/gradient/path/warp remain connected. | Live preview is limited to the selected canvas text item plus optional diagnostics overlay. | Separate mini preview widget deferred because canvas already provides live rendering and avoids fake/unconnected UI. | `utils/text_rendering.py`, `ui/text_panel.py`, `ui/fontformat_commands.py`, `utils/config.py`, `docs/RENDERING_TEXT_FORMATTING.md`. |
+| Precise bounds/placement | Text item bounds now expand for stroke and shadow; diagnostics include measured bounds, overflow, missing glyphs, and fallback chain; quick action can recenter text in its box. | Bounds estimates are renderer-independent approximations; final Qt ink metrics can still differ by platform/font. | Pixel-perfect HarfBuzz ink-bounds deferred. | `ui/textitem.py`, `utils/text_rendering.py`, `ui/canvas.py`, `ui/scenetext_manager.py`. |
+| Renderer diagnostics | Config toggle and canvas overlay show text box, measured bounds, overflow, writing mode, and missing glyphs; automation can list issues. | Overlay is intended for QA and not exported. | None for current QA scope. | `ui/textitem.py`, `ui/configpanel.py`, `ui/mainwindow.py`. |
+| Layout review agent | Selected and whole-page review use persisted settings, provider fallback, user report, style-aware snapshots, and new actions: shrink, balance, writing-mode switch, recenter, padding, preset, missing-glyph flag. | Remote provider response parsing remains conservative and falls back to heuristics on provider errors. | Rich multimodal critique is deferred to provider availability. | `utils/layout_review_agent.py`, `ui/scenetext_manager.py`, `ui/mainwindow.py`, `ui/layout_review_report_dialog.py`. |
+| PSD/export | Current-page image export has status feedback; structured OCR exists; new layered PSD handoff exports original/inpainted/mask/final helper layers, editable text JSON, JSX rebuild script, and warnings. | It is a PSD handoff package rather than native `.psd` binary creation. | Native editable PSD writing deferred because available pure-Python libraries do not reliably write Photoshop text layers cross-platform. | `utils/layered_psd_export.py`, `ui/mainwindowbars.py`, `ui/mainwindow.py`, `docs/RENDERING_TEXT_FORMATTING.md`. |
+| Settings/config | Dedicated Rendering/Text Formatting config section added with font, default writing/fit mode, stroke/shadow/padding defaults, overflow/diagnostic toggles, fallback chains, and a clearly labeled web-font future stub. | Google/web fonts are not exposed as an active renderer control. | Web font download/cache integration deferred to avoid dead UI and Program Files permission issues. | `utils/config.py`, `ui/configpanel.py`. |
+| Keyboard/tool UX | Shortcut schema now includes text eraser and brush size; single-key shortcut firing is guarded while typing; hard duplicate conflict test added; tooltips show shortcuts. | Existing QAction menu shortcuts still exist for menu actions where appropriate. | A full shortcut ownership registry migration is deferred; current changes avoid adding ambiguity. | `utils/shortcuts.py`, `ui/mainwindow.py`, `ui/drawingpanel.py`, `tests/test_shortcuts_rendering.py`. |
+| Automation/API | Local API now supports layout review, render current page, list rendering issues, page state, and structured OCR export. | Long-running render/pipeline progress still uses existing UI events rather than streaming HTTP events. | Headless server expansion is deferred to avoid duplicating existing local API infrastructure. | `ui/mainwindow.py`, `utils/local_automation_api.py`. |
+
+### Deferred Koharu items and reasons
+
+- **Native PSD editable text-layer writer**: deferred because this Python stack does not currently include a reliable cross-platform PSD text-layer writer. The handoff package preserves editability via manifest and Photoshop JSX instead of silently producing raster-only PSDs.
+- **Full HarfBuzz/OpenType shaping pipeline**: deferred because adding and packaging a shaping stack requires dependency and platform validation. Current implementation uses PyQt text layout plus explicit vertical/CJK heuristics and diagnostics.
+- **Google/web font renderer integration**: deferred as a labeled future stub. Font downloads require cache, licensing, offline behavior, and Windows Program Files write-safety work.
+- **Full shortcut ownership rewrite**: deferred because existing QAction/QShortcut menu integration is broad. This pass adds guards and conflict tests without destabilizing menu accelerators.

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -1,0 +1,60 @@
+# Renderer and Text Formatting Controls
+
+BallonsTranslator-Pro now exposes manga-lettering controls in the text format panel, context menu, config panel, layout review agent, and local automation API.
+
+## Per-textbox controls
+
+Use the text/style panel while one or more text boxes are selected:
+
+- **Writing mode**: Auto, Horizontal LTR, Vertical RL, or RTL. Auto uses the translated script plus box geometry: CJK text in a tall box becomes vertical-rl, Arabic/Hebrew becomes RTL, and other text stays horizontal.
+- **Fit mode**: Shrink, Expand, Preserve, or Balance lines. Auto-layout and layout review use the selected policy when fitting text to a constrained box.
+- **Manga preset**: Default manga bubble, Vertical JP/CN bubble, SFX bold, Caption/narration box, and Small aside text. Presets set font size, stroke, spacing, alignment, writing mode, and padding.
+- **Text padding**: Insets text inside the box so strokes, shadows, and vertical punctuation are less likely to clip.
+
+Right-click selected text boxes and use **Format → Writing mode** or **Format → Recenter text in box** for quick lettering fixes.
+
+## Renderer diagnostics
+
+Config → General → **Rendering / Text Formatting** includes:
+
+- default writing and fit modes,
+- default render font and manga effect defaults,
+- per-script fallback font chains for Latin, CJK, Korean, Arabic/Hebrew, and emoji/symbols,
+- overflow warnings,
+- an optional diagnostics overlay.
+
+The diagnostics overlay draws the text box, estimated rendered bounds, overflow status, writing mode, and missing-glyph warnings directly on the canvas. It is intended for QA and should be disabled for normal export.
+
+## Layout review integration
+
+The layout review agent sees writing mode, measured bounds, overflow status, style fields, fallback warnings, stroke, padding, and spacing. It can propose and apply:
+
+- shrink-to-fit,
+- balance-lines,
+- switch writing mode,
+- increase padding,
+- recenter,
+- manga preset application,
+- missing-glyph/font mismatch flags.
+
+## Export handoff
+
+**Tools → Export → Export layered PSD handoff...** writes helper layers and editable text metadata to a folder:
+
+- original image,
+- inpainted/clean image when available,
+- mask when available,
+- final composite when renderable,
+- JSON manifest with translated text layer geometry and style,
+- Photoshop JSX script that rebuilds editable text layers in an open document.
+
+This is a safe handoff format rather than a fake PSD. If native editable PSD writing is unavailable, warnings are written to the manifest and shown in the UI.
+
+## Automation
+
+When the local automation API is enabled, the rendering additions expose:
+
+- `POST /layout_review` for selected/page review and optional apply,
+- `POST /render_current_page` to render and save the current page,
+- `POST /list_rendering_issues` to list overflow/missing-glyph/writing-mode diagnostics,
+- existing structured OCR/page-state endpoints for QA workflows.

--- a/icons/page_completion.svg
+++ b/icons/page_completion.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#6c7cff" d="M5 3h10l4 4v14H5z"/><path fill="#fff" opacity=".9" d="M14 3v5h5z"/><path fill="#fff" d="m10.4 16.2-2.6-2.6-1.4 1.4 4 4 7-7-1.4-1.4z"/></svg>

--- a/icons/structured_ocr_export.svg
+++ b/icons/structured_ocr_export.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path fill="#23a6d5" d="M4 3h11l5 5v13H4z"/><path fill="#fff" opacity=".9" d="M14 3v6h6z"/><path fill="#fff" d="M7 11h10v2H7zm0 4h7v2H7z"/><path fill="#1d4ed8" d="M6 6h5v3H6z"/></svg>

--- a/tests/test_proj_page_completion.py
+++ b/tests/test_proj_page_completion.py
@@ -1,0 +1,37 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.__file__ = getattr(cv2_stub, "__file__", "cv2_stub.py")
+cv2_stub.IMREAD_COLOR = getattr(cv2_stub, "IMREAD_COLOR", 1)
+
+def _cv2_missing_attr(name):
+    if name.startswith("__"):
+        raise AttributeError(name)
+    return 1
+
+cv2_stub.__getattr__ = _cv2_missing_attr
+sys.modules["cv2"] = cv2_stub
+
+from utils.proj_imgtrans import ProjImgTrans
+
+
+def test_page_completion_state_defaults_validates_and_serializes():
+    p = ProjImgTrans()
+    p.directory = "/tmp/nonexistent"
+    p.pages = {"p1.png": []}
+    p._image_info = {"p1.png": {"finish_code": 0, "ignored": False}}
+
+    assert p.get_page_completion_state("p1.png") == "todo"
+    p.set_page_completion_state("p1.png", "reviewed")
+    assert p.get_page_completion_state("p1.png") == "reviewed"
+    p.set_page_completion_state("p1.png", "bad-state")
+    assert p.get_page_completion_state("p1.png") == "todo"
+    p.set_page_completion_state("p1.png", "exported")
+
+    d = p.to_dict()
+    assert d["image_info"]["p1.png"]["completion_state"] == "exported"
+
+    p2 = ProjImgTrans()
+    p2.load_from_dict({"pages": {"p1.png": []}, "image_info": d["image_info"]})
+    assert p2.get_page_completion_state("p1.png") == "exported"

--- a/tests/test_shortcuts_rendering.py
+++ b/tests/test_shortcuts_rendering.py
@@ -1,0 +1,12 @@
+from utils.shortcuts import classify_shortcut_conflicts, get_default_shortcuts, is_single_key_sequence
+
+
+def test_default_shortcuts_have_no_hard_conflicts():
+    conflicts = classify_shortcut_conflicts(get_default_shortcuts())
+    assert conflicts["hard"] == {}
+
+
+def test_single_key_detection_for_tool_shortcuts():
+    assert is_single_key_sequence("B") is True
+    assert is_single_key_sequence("Ctrl+B") is False
+    assert is_single_key_sequence("PageDown") is False

--- a/tests/test_structured_ocr_export.py
+++ b/tests/test_structured_ocr_export.py
@@ -1,0 +1,43 @@
+import sys
+import types
+
+cv2_stub = sys.modules.get("cv2") or types.ModuleType("cv2")
+cv2_stub.__file__ = getattr(cv2_stub, "__file__", "cv2_stub.py")
+cv2_stub.__getattr__ = lambda name: (_ for _ in ()).throw(AttributeError(name)) if name.startswith("__") else 1
+sys.modules["cv2"] = cv2_stub
+
+from utils.fontformat import FontFormat
+from utils.structured_ocr_export import build_structured_ocr_export
+
+
+class Block:
+    xyxy = [1, 2, 30, 40]
+    lines = [[[1, 2], [30, 2]]]
+    angle = 0
+    translation = "Hello"
+    label = "speech"
+    confidence = 0.75
+    fontformat = FontFormat(font_family="Arial", font_size=24, alignment=1)
+
+    def get_text(self):
+        return "こんにちは"
+
+
+class Project:
+    directory = "/tmp/proj"
+    current_img = "p1.png"
+    pages = {"p1.png": [Block()]}
+    _image_info = {"p1.png": {"width": 100, "height": 200, "ignored": False, "finish_code": 15, "completion_state": "reviewed"}}
+
+    def get_page_completion_state(self, page):
+        return self._image_info[page]["completion_state"]
+
+
+def test_structured_ocr_export_contains_page_block_geometry_and_font():
+    out = build_structured_ocr_export(Project())
+    assert out["schema"] == "ballonstranslator.structured_ocr.v1"
+    page = out["pages"][0]
+    assert page["completion_state"] == "reviewed"
+    assert page["blocks"][0]["source_text"] == "こんにちは"
+    assert page["blocks"][0]["font"]["alignment"] == 1
+    assert page["blocks"][0]["xyxy"] == [1.0, 2.0, 30.0, 40.0]

--- a/tests/test_text_rendering.py
+++ b/tests/test_text_rendering.py
@@ -1,0 +1,67 @@
+from utils.text_rendering import (
+    FIT_MODE_EXPAND,
+    FIT_MODE_PRESERVE,
+    WRITING_MODE_HORIZONTAL_LTR,
+    WRITING_MODE_RTL,
+    WRITING_MODE_VERTICAL_RL,
+    fit_font_size_to_box,
+    kinsoku_wrap,
+    merge_font_fallback_chain,
+    normalize_vertical_punctuation,
+    resolve_writing_mode,
+    vertical_columns,
+    vertical_punctuation_class,
+)
+
+
+def test_resolve_writing_mode_auto_cjk_tall_box_vertical():
+    assert resolve_writing_mode("auto", "こんにちは世界", (60, 180)) == WRITING_MODE_VERTICAL_RL
+
+
+def test_resolve_writing_mode_auto_rtl():
+    assert resolve_writing_mode("auto", "مرحبا", (180, 60)) == WRITING_MODE_RTL
+
+
+def test_resolve_writing_mode_auto_ltr_default():
+    assert resolve_writing_mode("auto", "Hello world", (60, 180)) == WRITING_MODE_HORIZONTAL_LTR
+
+
+def test_vertical_punctuation_normalizes_repeated_marks():
+    assert normalize_vertical_punctuation("え?! 本当??") == "え⁈ 本当⁇"
+
+
+def test_kinsoku_wrap_keeps_closing_punctuation_off_line_start():
+    lines = kinsoku_wrap("これは（テスト）です。", 4)
+    assert all(not line[0] in "）】」』、。" for line in lines)
+    assert all(not line[-1] in "（【「『" for line in lines)
+
+
+def test_vertical_columns_flow_top_to_bottom_then_right_to_left():
+    cols = vertical_columns("これはテストです?!", 4)
+    assert cols == ["これはテ", "ストです⁈"]
+    assert vertical_punctuation_class("、") == "center"
+
+
+def test_fit_font_size_shrink_and_preserve_report_overflow():
+    shrunk, _text, diag = fit_font_size_to_box("A very long sentence", 32, (80, 30), "shrink")
+    assert shrunk < 32
+    preserved, _text, preserve_diag = fit_font_size_to_box("A very long sentence", 32, (80, 30), FIT_MODE_PRESERVE)
+    assert preserved == 32
+    assert preserve_diag.overflow is True
+
+
+def test_fit_font_size_expand_uses_available_room():
+    expanded, _text, diag = fit_font_size_to_box("Hi", 10, (180, 80), FIT_MODE_EXPAND, max_font_size=40)
+    assert expanded > 10
+    assert diag.overflow is False
+
+
+def test_merge_font_fallback_chain_deduplicates_script_chain():
+    class Cfg:
+        render_fallback_fonts_latin = "Arial, DejaVu Sans"
+        render_fallback_fonts_cjk = "Noto Sans CJK JP, Arial"
+        render_fallback_fonts_korean = "Noto Sans CJK KR"
+        render_fallback_fonts_rtl = "Noto Naskh Arabic"
+        render_fallback_fonts_emoji = "Noto Color Emoji"
+
+    assert merge_font_fallback_chain("Arial", "かな", Cfg(), "Noto Sans CJK JP") == ["Arial", "Noto Sans CJK JP"]

--- a/ui/canvas.py
+++ b/ui/canvas.py
@@ -212,6 +212,8 @@ class Canvas(QGraphicsScene):
     set_balloon_shape_signal = Signal(str)
     resize_to_fit_content_signal = Signal()
     center_in_bubble_signal = Signal()
+    set_writing_mode_signal = Signal(str)
+    recenter_text_in_box_signal = Signal()
     reset_angle = Signal()
     squeeze_blk = Signal()
 
@@ -1272,6 +1274,7 @@ class Canvas(QGraphicsScene):
 
             # --- Format ---
             format_act = layout_act = fit_to_bubble_act = auto_fit_act = auto_fit_binary_act = angle_act = squeeze_act = None
+            writing_auto_act = writing_ltr_act = writing_vertical_act = writing_rtl_act = recenter_text_in_box_act = None
             resize_to_fit_content_act = center_in_bubble_act = None
             balloon_shape_round_act = balloon_shape_elongated_act = balloon_shape_narrow_act = balloon_shape_diamond_act = None
             balloon_shape_square_act = balloon_shape_bevel_act = balloon_shape_pentagon_act = balloon_shape_point_act = balloon_shape_auto_act = None
@@ -1327,6 +1330,19 @@ class Canvas(QGraphicsScene):
                 if center_in_bubble_act is not None:
                     center_in_bubble_act.setToolTip(self.tr("Move the text box so its center aligns with the bubble center (no resize)."))
                 actions_map['format_center_in_bubble'] = center_in_bubble_act
+            if context_menu_visible('format_writing_mode') and n_sel >= 1:
+                if format_menu is None: format_menu = menu.addMenu(self.tr("Format"))
+                writing_sub = format_menu.addMenu(self.tr("Writing mode"))
+                writing_auto_act = writing_sub.addAction(self.tr("Auto"))
+                writing_ltr_act = writing_sub.addAction(self.tr("Horizontal LTR"))
+                writing_vertical_act = writing_sub.addAction(self.tr("Vertical RL"))
+                writing_rtl_act = writing_sub.addAction(self.tr("RTL"))
+                actions_map['format_writing_mode'] = writing_sub
+            if context_menu_visible('format_recenter_text_in_box') and n_sel >= 1:
+                if format_menu is None: format_menu = menu.addMenu(self.tr("Format"))
+                recenter_text_in_box_act = format_menu.addAction(self.tr("Recenter text in box"))
+                recenter_text_in_box_act.setToolTip(self.tr("Recenter the rendered ink inside the current text box without moving the box."))
+                actions_map['format_recenter_text_in_box'] = recenter_text_in_box_act
             if context_menu_visible('format_angle'):
                 if format_menu is None: format_menu = menu.addMenu(self.tr("Format"))
                 angle_act = format_menu.addAction(self.tr("Reset Angle"))
@@ -1639,6 +1655,16 @@ class Canvas(QGraphicsScene):
                 self.resize_to_fit_content_signal.emit()
             elif rst == center_in_bubble_act:
                 self.center_in_bubble_signal.emit()
+            elif rst == writing_auto_act:
+                self.set_writing_mode_signal.emit("auto")
+            elif rst == writing_ltr_act:
+                self.set_writing_mode_signal.emit("horizontal_ltr")
+            elif rst == writing_vertical_act:
+                self.set_writing_mode_signal.emit("vertical_rl")
+            elif rst == writing_rtl_act:
+                self.set_writing_mode_signal.emit("rtl")
+            elif rst == recenter_text_in_box_act:
+                self.recenter_text_in_box_signal.emit()
             elif rst == angle_act:
                 self.reset_angle.emit()
             elif rst == squeeze_act:

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -757,6 +757,16 @@ class ConfigPanel(Widget):
             discription=self.tr('When on, full run and batch queue skip pages marked as "Ignore in run" in the page list context menu.')
         )
         self.skip_ignored_in_run_checker.stateChanged.connect(self.on_skip_ignored_in_run_changed)
+        self.skip_satisfied_pipeline_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Skip already-satisfied pipeline pages'),
+            discription=self.tr('When on, full runs keep pages whose saved finish state already satisfies the enabled stages instead of resetting and rerunning them.')
+        )
+        self.skip_satisfied_pipeline_checker.stateChanged.connect(self.on_skip_satisfied_pipeline_changed)
+        self.auto_mark_translated_pages_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Auto-mark completed pipeline pages as translated'),
+            discription=self.tr('When a run finishes, pages whose saved finish state satisfies the enabled stages are marked Translated in the page list.')
+        )
+        self.auto_mark_translated_pages_checker.stateChanged.connect(self.on_auto_mark_translated_pages_changed)
         generalConfigPanel.addTextLabel(self.tr('Runtime HTTP controls'))
         self.runtime_http_timeout_spin = QDoubleSpinBox()
         self.runtime_http_timeout_spin.setRange(2.0, 300.0)
@@ -821,6 +831,79 @@ class ConfigPanel(Widget):
             discription=self.tr('Apply manga-style hanging for pause/stop punctuation in vertical CJK.')
         )
         self.vertical_cjk_punctuation_hang_checker.stateChanged.connect(self.on_vertical_cjk_punctuation_hang_changed)
+
+        generalConfigPanel.addTextLabel(self.tr('Rendering / Text Formatting'))
+        self.render_default_font_edit = QLineEdit(self)
+        self.render_default_font_edit.setPlaceholderText(self.tr('Empty = use project/default font'))
+        self.render_default_font_edit.textChanged.connect(self.on_render_default_font_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.render_default_font_edit,
+            self.tr('Rendering font'),
+            discription=self.tr('Default translated-text font family used by new manga presets and batch rendering helpers.')
+        ))
+        self.render_default_writing_mode_combo = QComboBox(self)
+        for label, value in [(self.tr('Auto'), 'auto'), (self.tr('Horizontal LTR'), 'horizontal_ltr'), (self.tr('Vertical RL'), 'vertical_rl'), (self.tr('RTL'), 'rtl')]:
+            self.render_default_writing_mode_combo.addItem(label, value)
+        self.render_default_writing_mode_combo.currentIndexChanged.connect(self.on_render_default_writing_mode_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.render_default_writing_mode_combo,
+            self.tr('Default writing mode'),
+            discription=self.tr('Auto uses script plus text-box geometry; per-textbox settings can override it.')
+        ))
+        self.render_default_fit_mode_combo = QComboBox(self)
+        for label, value in [(self.tr('Shrink to fit'), 'shrink'), (self.tr('Expand to fill'), 'expand'), (self.tr('Preserve size'), 'preserve'), (self.tr('Balance lines'), 'balance')]:
+            self.render_default_fit_mode_combo.addItem(label, value)
+        self.render_default_fit_mode_combo.currentIndexChanged.connect(self.on_render_default_fit_mode_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.render_default_fit_mode_combo,
+            self.tr('Default fit mode'),
+            discription=self.tr('Controls whether auto-layout shrinks, expands, preserves, or balances text in boxes.')
+        ))
+        self.render_default_stroke_width_spin = QDoubleSpinBox(self)
+        self.render_default_stroke_width_spin.setRange(0.0, 1.0)
+        self.render_default_stroke_width_spin.setSingleStep(0.01)
+        self.render_default_stroke_width_spin.setDecimals(3)
+        self.render_default_stroke_width_spin.valueChanged.connect(self.on_render_default_stroke_width_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_default_stroke_width_spin, self.tr('Default stroke width'), discription=self.tr('Relative manga outline width for presets/new styles.')))
+        self.render_default_shadow_radius_spin = QDoubleSpinBox(self)
+        self.render_default_shadow_radius_spin.setRange(0.0, 1.0)
+        self.render_default_shadow_radius_spin.setSingleStep(0.01)
+        self.render_default_shadow_radius_spin.setDecimals(3)
+        self.render_default_shadow_radius_spin.valueChanged.connect(self.on_render_default_shadow_radius_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_default_shadow_radius_spin, self.tr('Default shadow/glow radius'), discription=self.tr('Relative shadow/glow radius used by new text styles.')))
+        self.render_default_text_padding_spin = QDoubleSpinBox(self)
+        self.render_default_text_padding_spin.setRange(0.0, 64.0)
+        self.render_default_text_padding_spin.setSingleStep(1.0)
+        self.render_default_text_padding_spin.setDecimals(1)
+        self.render_default_text_padding_spin.valueChanged.connect(self.on_render_default_text_padding_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_default_text_padding_spin, self.tr('Default text padding'), discription=self.tr('Inset in image pixels to avoid clipped strokes/punctuation.')))
+        self.render_overflow_warnings_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Enable renderer overflow warnings'),
+            discription=self.tr('Layout review and diagnostics flag text whose measured bounds exceed the box.')
+        )
+        self.render_overflow_warnings_checker.stateChanged.connect(self.on_render_overflow_warnings_changed)
+        self.render_diagnostics_overlay_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Renderer diagnostics overlay'),
+            discription=self.tr('Draw text box, measured bounds, writing mode, and missing-glyph warnings on the canvas.')
+        )
+        self.render_diagnostics_overlay_checker.stateChanged.connect(self.on_render_diagnostics_overlay_changed)
+        self.render_fallback_latin_edit = QLineEdit(self)
+        self.render_fallback_latin_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_latin', text))
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_latin_edit, self.tr('Latin fallback fonts'), discription=self.tr('Comma-separated fallback font families.')))
+        self.render_fallback_cjk_edit = QLineEdit(self)
+        self.render_fallback_cjk_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_cjk', text))
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_cjk_edit, self.tr('CJK fallback fonts'), discription=self.tr('Comma-separated JP/CN fallback font families.')))
+        self.render_fallback_korean_edit = QLineEdit(self)
+        self.render_fallback_korean_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_korean', text))
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_korean_edit, self.tr('Korean fallback fonts'), discription=self.tr('Comma-separated Hangul fallback font families.')))
+        self.render_fallback_rtl_edit = QLineEdit(self)
+        self.render_fallback_rtl_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_rtl', text))
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_rtl_edit, self.tr('Arabic/Hebrew fallback fonts'), discription=self.tr('Comma-separated RTL fallback font families.')))
+        self.render_fallback_emoji_edit = QLineEdit(self)
+        self.render_fallback_emoji_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_emoji', text))
+        generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_emoji_edit, self.tr('Emoji/symbol fallback fonts'), discription=self.tr('Comma-separated emoji/symbol fallback font families.')))
+        google_stub = QLabel(self.tr('Google/Web fonts: planned; use local installed fonts or the existing font installer for now.'))
+        generalConfigPanel.addSublock(ConfigSubBlock(google_stub, self.tr('Web font support'), discription=self.tr('Future stub only: no network font UI is exposed until download/cache handling is complete.')))
 
         self.auto_region_merge_combobox = QComboBox()
         self.auto_region_merge_combobox.addItem(self.tr('Never'), 'never')
@@ -1386,6 +1469,12 @@ class ConfigPanel(Widget):
     def on_skip_ignored_in_run_changed(self):
         pcfg.skip_ignored_in_run = self.skip_ignored_in_run_checker.isChecked()
 
+    def on_skip_satisfied_pipeline_changed(self):
+        pcfg.skip_satisfied_pipeline_steps = self.skip_satisfied_pipeline_checker.isChecked()
+
+    def on_auto_mark_translated_pages_changed(self):
+        pcfg.auto_mark_translated_pages = self.auto_mark_translated_pages_checker.isChecked()
+
     def _open_context_menu_config(self):
         dlg = ContextMenuConfigDialog(self)
         dlg.exec()
@@ -1725,6 +1814,26 @@ class ConfigPanel(Widget):
     def on_vertical_cjk_punctuation_hang_changed(self):
         pcfg.vertical_cjk_punctuation_hang = self.vertical_cjk_punctuation_hang_checker.isChecked()
 
+
+    def on_render_default_font_changed(self, text: str):
+        pcfg.render_default_font_family = (text or '').strip()
+    def on_render_default_writing_mode_changed(self):
+        pcfg.render_default_writing_mode = str(self.render_default_writing_mode_combo.currentData() or 'auto')
+    def on_render_default_fit_mode_changed(self):
+        pcfg.render_default_fit_mode = str(self.render_default_fit_mode_combo.currentData() or 'shrink')
+    def on_render_default_stroke_width_changed(self):
+        pcfg.render_default_stroke_width = float(self.render_default_stroke_width_spin.value())
+    def on_render_default_shadow_radius_changed(self):
+        pcfg.render_default_shadow_radius = float(self.render_default_shadow_radius_spin.value())
+    def on_render_default_text_padding_changed(self):
+        pcfg.render_default_text_padding = float(self.render_default_text_padding_spin.value())
+    def on_render_overflow_warnings_changed(self):
+        pcfg.render_overflow_warnings = self.render_overflow_warnings_checker.isChecked()
+    def on_render_diagnostics_overlay_changed(self):
+        pcfg.render_diagnostics_overlay = self.render_diagnostics_overlay_checker.isChecked()
+    def on_render_fallback_changed(self, attr: str, text: str):
+        setattr(pcfg, attr, text or '')
+
     def on_fontcolor_flag_changed(self):
         pcfg.let_fntcolor_flag = self.let_fntcolor_combox.currentIndex()
 
@@ -1931,6 +2040,23 @@ class ConfigPanel(Widget):
             self.vertical_cjk_rotate_latin_checker.setChecked(bool(getattr(pcfg, 'vertical_cjk_rotate_latin', True)))
         if hasattr(self, 'vertical_cjk_punctuation_hang_checker'):
             self.vertical_cjk_punctuation_hang_checker.setChecked(bool(getattr(pcfg, 'vertical_cjk_punctuation_hang', True)))
+
+        if hasattr(self, 'render_default_font_edit'):
+            self.render_default_font_edit.setText(str(getattr(pcfg, 'render_default_font_family', '') or ''))
+            idx = self.render_default_writing_mode_combo.findData(getattr(pcfg, 'render_default_writing_mode', 'auto'))
+            self.render_default_writing_mode_combo.setCurrentIndex(max(0, idx))
+            idx = self.render_default_fit_mode_combo.findData(getattr(pcfg, 'render_default_fit_mode', 'shrink'))
+            self.render_default_fit_mode_combo.setCurrentIndex(max(0, idx))
+            self.render_default_stroke_width_spin.setValue(float(getattr(pcfg, 'render_default_stroke_width', 0.08)))
+            self.render_default_shadow_radius_spin.setValue(float(getattr(pcfg, 'render_default_shadow_radius', 0.0)))
+            self.render_default_text_padding_spin.setValue(float(getattr(pcfg, 'render_default_text_padding', 2.0)))
+            self.render_overflow_warnings_checker.setChecked(bool(getattr(pcfg, 'render_overflow_warnings', True)))
+            self.render_diagnostics_overlay_checker.setChecked(bool(getattr(pcfg, 'render_diagnostics_overlay', False)))
+            self.render_fallback_latin_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_latin', '') or ''))
+            self.render_fallback_cjk_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_cjk', '') or ''))
+            self.render_fallback_korean_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_korean', '') or ''))
+            self.render_fallback_rtl_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_rtl', '') or ''))
+            self.render_fallback_emoji_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_emoji', '') or ''))
         self.selectext_minimenu_checker.setChecked(pcfg.textselect_mini_menu)
         self.let_uppercase_checker.setChecked(pcfg.let_uppercase_flag)
         self.let_textstyle_indep_checker.setChecked(pcfg.let_textstyle_indep_flag)
@@ -2001,6 +2127,10 @@ class ConfigPanel(Widget):
             self.manual_mode_checker.setChecked(getattr(pcfg, 'manual_mode', False))
         if hasattr(self, 'skip_ignored_in_run_checker'):
             self.skip_ignored_in_run_checker.setChecked(getattr(pcfg, 'skip_ignored_in_run', True))
+        if hasattr(self, 'skip_satisfied_pipeline_checker'):
+            self.skip_satisfied_pipeline_checker.setChecked(getattr(pcfg, 'skip_satisfied_pipeline_steps', False))
+        if hasattr(self, 'auto_mark_translated_pages_checker'):
+            self.auto_mark_translated_pages_checker.setChecked(getattr(pcfg, 'auto_mark_translated_pages', True))
         if hasattr(self, 'smooth_scroll_spin'):
             self.smooth_scroll_spin.setValue(getattr(pcfg, 'smooth_scroll_duration_ms', 0))
             if hasattr(self, 'configContent') and hasattr(self.configContent, 'setSmoothScrollDuration'):

--- a/ui/context_menu_config_dialog.py
+++ b/ui/context_menu_config_dialog.py
@@ -91,6 +91,8 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("format_balloon_shape", "Balloon shape (submenu)"),
         ("format_resize_to_fit_content", "Resize to fit content"),
         ("format_center_in_bubble", "Center in bubble"),
+        ("format_writing_mode", "Writing mode (submenu)"),
+        ("format_recenter_text_in_box", "Recenter text in box"),
         ("format_angle", "Reset Angle"),
         ("format_squeeze", "Squeeze"),
         ("format_layout_review_selected", "Layout review selected textboxes"),
@@ -237,7 +239,7 @@ class ContextMenuConfigDialog(QDialog):
             'text_trim','text_upper','text_lower','format_apply','format_layout','format_fit_to_bubble','create_textbox'
         }
         pipeline_keys = {'run_detect_region','run_detect_page','run_translate','run_ocr','run_ocr_translate','run_ocr_translate_inpaint','run_inpaint'}
-        layout_keys = {'format_apply','format_layout','format_fit_to_bubble','format_auto_fit','format_auto_fit_binary','format_balloon_shape','format_resize_to_fit_content','format_center_in_bubble','format_angle','format_squeeze'}
+        layout_keys = {'format_apply','format_layout','format_fit_to_bubble','format_auto_fit','format_auto_fit_binary','format_balloon_shape','format_resize_to_fit_content','format_center_in_bubble','format_writing_mode','format_recenter_text_in_box','format_angle','format_squeeze'}
         chosen = editing_keys if profile == 'editing' else pipeline_keys if profile == 'pipeline' else layout_keys
         for key, cb in self._checkboxes.items():
             cb.setChecked(key in chosen)

--- a/ui/drawingpanel.py
+++ b/ui/drawingpanel.py
@@ -438,7 +438,8 @@ class DrawingPanel(Widget):
         try:
             tool = f'{tool_name}Tool'
             tool: QStackedWidget = getattr(self, tool)
-            tool.setToolTip(f'{shortcut}')
+            base = tool.toolTip().split(' — ')[0] if tool.toolTip() else tool_name
+            tool.setToolTip(f'{base} — {shortcut}')
         except:
             LOGGER.error(f'{tool} not found in drawing panel')
 

--- a/ui/fontformat_commands.py
+++ b/ui/fontformat_commands.py
@@ -127,6 +127,79 @@ def ffmt_change_vertical(param_name: str, values: bool, act_ffmt: FontFormat, is
     for blkitem, value in zip(blkitems, values):
         blkitem.setVertical(value)
 
+
+@font_formating(push_undostack=True)
+def ffmt_change_writing_mode(param_name: str, values: str, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
+    from utils.text_rendering import resolve_writing_mode, normalize_writing_mode
+    for blkitem, value in zip(blkitems, values):
+        mode = normalize_writing_mode(value)
+        blkitem.fontformat.writing_mode = mode
+        text = blkitem.toPlainText() if hasattr(blkitem, "toPlainText") else ""
+        rect = blkitem.absBoundingRect(qrect=True) if hasattr(blkitem, "absBoundingRect") else None
+        box = (rect.width(), rect.height()) if rect is not None else None
+        resolved = resolve_writing_mode(mode, text, box)
+        blkitem.setVertical(resolved == "vertical_rl")
+        if hasattr(blkitem, "blk") and blkitem.blk is not None:
+            blkitem.blk.fontformat.writing_mode = mode
+            blkitem.blk.fontformat.vertical = resolved == "vertical_rl"
+
+@font_formating(push_undostack=True)
+def ffmt_change_fit_mode(param_name: str, values: str, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
+    from utils.text_rendering import normalize_fit_mode
+    for blkitem, value in zip(blkitems, values):
+        mode = normalize_fit_mode(value)
+        blkitem.fontformat.fit_mode = mode
+        if hasattr(blkitem, "blk") and blkitem.blk is not None:
+            blkitem.blk.fontformat.fit_mode = mode
+
+@font_formating(push_undostack=True)
+def ffmt_change_text_padding(param_name: str, values: float, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
+    for blkitem, value in zip(blkitems, values):
+        value = max(0.0, float(value or 0.0))
+        blkitem.fontformat.text_padding = value
+        blkitem.setPadding(value)
+        if hasattr(blkitem, "blk") and blkitem.blk is not None:
+            blkitem.blk.fontformat.text_padding = value
+
+@font_formating(push_undostack=True)
+def ffmt_change_fallback_font_chain(param_name: str, values: str, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
+    for blkitem, value in zip(blkitems, values):
+        blkitem.fontformat.fallback_font_chain = str(value or "")
+        if hasattr(blkitem, "blk") and blkitem.blk is not None:
+            blkitem.blk.fontformat.fallback_font_chain = blkitem.fontformat.fallback_font_chain
+
+@font_formating(push_undostack=True)
+def ffmt_change_manga_preset(param_name: str, values: str, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
+    from utils.text_rendering import MANGA_PRESETS, normalize_writing_mode, resolve_writing_mode
+    for blkitem, value in zip(blkitems, values):
+        preset_id = str(value or "")
+        preset = MANGA_PRESETS.get(preset_id)
+        if not preset:
+            continue
+        for key, preset_value in preset.items():
+            if key == "label":
+                continue
+            if hasattr(blkitem.fontformat, key):
+                setattr(blkitem.fontformat, key, preset_value)
+        blkitem.fontformat.manga_preset = preset_id
+        # Apply renderer-facing fields immediately.
+        mode = normalize_writing_mode(preset.get("writing_mode", "auto"))
+        blkitem.fontformat.writing_mode = mode
+        rect = blkitem.absBoundingRect(qrect=True) if hasattr(blkitem, "absBoundingRect") else None
+        box = (rect.width(), rect.height()) if rect is not None else None
+        resolved = resolve_writing_mode(mode, blkitem.toPlainText() if hasattr(blkitem, "toPlainText") else "", box)
+        blkitem.setVertical(resolved == "vertical_rl")
+        if "stroke_width" in preset:
+            blkitem.setStrokeWidth(float(preset["stroke_width"]))
+        if "text_padding" in preset:
+            blkitem.setPadding(float(preset["text_padding"]))
+        if "alignment" in preset:
+            blkitem.setAlignment(int(preset["alignment"]))
+        if hasattr(blkitem, "set_fontformat"):
+            blkitem.set_fontformat(blkitem.fontformat)
+        if hasattr(blkitem, "blk") and blkitem.blk is not None:
+            blkitem.blk.fontformat = blkitem.fontformat.deepcopy()
+
 @font_formating()
 def ffmt_change_frgb(param_name: str, values: tuple, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
     set_kwargs = global_default_set_kwargs if is_global else local_default_set_kwargs

--- a/ui/layout_review_report_dialog.py
+++ b/ui/layout_review_report_dialog.py
@@ -1,0 +1,110 @@
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFrame,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QVBoxLayout,
+)
+
+
+class LayoutReviewReportDialog(QDialog):
+    """Human-in-the-loop report for layout review proposals."""
+
+    def __init__(self, result, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("Layout Review Agent Report"))
+        self.setMinimumSize(620, 420)
+        self._result = result
+        self._action_items = []
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(10)
+
+        summary = self._summarize(result)
+        title = QLabel(
+            self.tr("{issues} issue(s), {actions} proposed fix(es), average score {score:.0f}%").format(
+                issues=summary["issues"], actions=summary["actions"], score=summary["score"] * 100.0
+            ),
+            self,
+        )
+        title.setObjectName("LayoutReviewReportTitle")
+        layout.addWidget(title)
+
+        hint = QLabel(
+            self.tr("Review the deterministic changes below. Choose Apply Fixes to mutate text boxes through the undo stack, or Close to keep the page unchanged."),
+            self,
+        )
+        hint.setWordWrap(True)
+        hint.setObjectName("LayoutReviewReportHint")
+        layout.addWidget(hint)
+
+        self.list_widget = QListWidget(self)
+        self.list_widget.setFrameShape(QFrame.NoFrame)
+        self.list_widget.setAlternatingRowColors(True)
+        self._populate(result)
+        layout.addWidget(self.list_widget, 1)
+
+        if self.list_widget.count() == 0:
+            empty = QListWidgetItem(self.tr("No layout issues were detected for the selected scope."))
+            empty.setFlags(empty.flags() & ~Qt.ItemFlag.ItemIsSelectable)
+            self.list_widget.addItem(empty)
+
+        self.buttons = QDialogButtonBox(self)
+        self.apply_button = self.buttons.addButton(self.tr("Apply Fixes"), QDialogButtonBox.ButtonRole.AcceptRole)
+        self.close_button = self.buttons.addButton(QDialogButtonBox.StandardButton.Close)
+        self.apply_button.setEnabled(summary["actions"] > 0)
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        layout.addWidget(self.buttons)
+
+    def _summarize(self, result):
+        blocks = list(getattr(result, "blocks", []) or [])
+        issue_count = sum(len(getattr(b, "issues", []) or []) for b in blocks)
+        action_count = sum(len(getattr(b, "actions", []) or []) for b in blocks)
+        if blocks:
+            score = sum(float(getattr(b, "score_after", 1.0) or 0.0) for b in blocks) / len(blocks)
+        else:
+            score = 1.0
+        return {"issues": issue_count, "actions": action_count, "score": max(0.0, min(1.0, score))}
+
+    def _populate(self, result):
+        for block in getattr(result, "blocks", []) or []:
+            issues = getattr(block, "issues", []) or []
+            actions = getattr(block, "actions", []) or []
+            if not issues and not actions:
+                continue
+            parts = [self.tr("Block #{0}").format(int(getattr(block, "block_index", -1)) + 1)]
+            if issues:
+                issue_text = "; ".join(
+                    f"{getattr(issue, 'severity', 'info')}:{getattr(issue, 'code', 'issue')} — {getattr(issue, 'message', '')}"
+                    for issue in issues
+                )
+                parts.append(issue_text)
+            if actions:
+                action_text = "; ".join(
+                    f"{getattr(action, 'action', 'fix')} ({getattr(action, 'reason', '')})".strip()
+                    for action in actions
+                )
+                parts.append(self.tr("Fixes: ") + action_text)
+            item = QListWidgetItem("\n".join(parts))
+            item.setToolTip("\n".join(parts))
+            if actions:
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+                item.setCheckState(Qt.CheckState.Checked)
+                item.setData(Qt.ItemDataRole.UserRole, list(actions))
+                self._action_items.append(item)
+            else:
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsUserCheckable)
+            self.list_widget.addItem(item)
+
+    def selected_actions(self):
+        """Return only actions checked by the user in the report."""
+        selected = []
+        for item in self._action_items:
+            if item.checkState() == Qt.CheckState.Checked:
+                selected.extend(item.data(Qt.ItemDataRole.UserRole) or [])
+        return selected

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -18,7 +18,7 @@ from urllib import error as urlerror
 from tqdm import tqdm
 from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QProgressBar, QLabel, QWidget, QInputDialog, QFormLayout, QDialogButtonBox, QLineEdit, QDoubleSpinBox, QSpinBox, QCheckBox, QComboBox
 from qtpy.QtCore import Qt, QPoint, QSize, QEvent, Signal, QTimer
-from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QKeyEvent, QPainter, QClipboard, QImage, QShowEvent, QCursor, QPixmap
+from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QKeyEvent, QPainter, QClipboard, QImage, QShowEvent, QCursor, QPixmap, QBrush, QColor
 
 from utils.logger import logger as LOGGER
 from utils.text_processing import is_cjk, full_len, half_len
@@ -35,7 +35,7 @@ from .misc import parse_stylesheet, set_html_family, QKEY, pixmap2ndarray
 from .custom_widget.animated_stack import AnimatedStackWidget
 from utils.config import ProgramConfig, pcfg, save_config, text_styles, save_text_styles, load_textstyle_from, FontFormat, log_diagnostic_event
 from utils.layout_review_agent import ReviewModelConfig, PageReviewResult, BlockReviewResult, ReviewIssue, ReviewAction
-from utils.shortcuts import get_shortcut
+from utils.shortcuts import get_shortcut, is_single_key_sequence, shortcut_should_ignore_text_input
 from utils.proj_imgtrans import ProjImgTrans
 from utils.zip_batch import ZipBatchManager
 from .canvas import Canvas
@@ -67,7 +67,11 @@ from .mask_diagnostics_widget import MaskDiagnosticsWidget
 from .ocr_crop_inspector_widget import OcrCropInspectorWidget
 from .project_ops_dialog import ProjectOpsDialog
 from .reading_order_editor_dialog import ReadingOrderEditorDialog
+from .layout_review_report_dialog import LayoutReviewReportDialog
+from utils.fontformat import pt2px
 from utils.image_colorization import apply_colorization
+from utils.structured_ocr_export import build_structured_ocr_export
+from utils.layered_psd_export import build_layered_psd_handoff
 from utils.local_automation_api import LocalAutomationApiServer
 from utils.google_fonts import install_google_font_family
 from utils.model_manager import get_available_module_keys
@@ -86,6 +90,7 @@ class PageListView(QListWidget):
     run_inpaint_images = Signal(list)
     run_detect_images = Signal(list)
     toggle_ignore_requested = Signal(list, bool)  # (pagenames, ignored)
+    set_completion_requested = Signal(list, str)  # (pagenames, todo|translated|reviewed|exported)
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -121,6 +126,12 @@ class PageListView(QListWidget):
             include_act = menu.addAction(self.tr('Include in run'))
             include_act.setToolTip(self.tr('Do not skip these pages in full run and batch.'))
             menu.addSeparator()
+            completion_menu = menu.addMenu(QIcon(osp.join(shared.PROGRAM_PATH, 'icons', 'page_completion.svg')), self.tr('Page completion state'))
+            mark_todo_act = completion_menu.addAction(self.tr('Needs work'))
+            mark_translated_act = completion_menu.addAction(self.tr('Translated'))
+            mark_reviewed_act = completion_menu.addAction(self.tr('Reviewed'))
+            mark_exported_act = completion_menu.addAction(self.tr('Exported'))
+            menu.addSeparator()
             remove_act = menu.addAction(self.tr('Remove from Project'))
         rst = menu.exec_(e.globalPos())
 
@@ -142,6 +153,14 @@ class PageListView(QListWidget):
             self.toggle_ignore_requested.emit([item.text() for item in selected_items], True)
         elif selected_items and rst == include_act:
             self.toggle_ignore_requested.emit([item.text() for item in selected_items], False)
+        elif selected_items and rst == mark_todo_act:
+            self.set_completion_requested.emit([item.text() for item in selected_items], 'todo')
+        elif selected_items and rst == mark_translated_act:
+            self.set_completion_requested.emit([item.text() for item in selected_items], 'translated')
+        elif selected_items and rst == mark_reviewed_act:
+            self.set_completion_requested.emit([item.text() for item in selected_items], 'reviewed')
+        elif selected_items and rst == mark_exported_act:
+            self.set_completion_requested.emit([item.text() for item in selected_items], 'exported')
         elif selected_items and rst == remove_act:
             self.remove_images.emit([item.text() for item in selected_items])
 
@@ -394,6 +413,7 @@ class MainWindow(mainwindow_cls):
         self.pageList.remove_images.connect(self.on_remove_images)
         self.pageList.translate_images.connect(self.on_translate_images)
         self.pageList.toggle_ignore_requested.connect(self.on_toggle_page_ignored)
+        self.pageList.set_completion_requested.connect(self.on_set_page_completion_state)
         self.pageList.run_ocr_images.connect(self.on_run_ocr_images)
         self.pageList.run_translate_images.connect(self.on_run_translate_images)
         self.pageList.run_inpaint_images.connect(self.on_run_inpaint_images)
@@ -536,6 +556,7 @@ class MainWindow(mainwindow_cls):
         self.pipelineInsightsPanel.open_ocr_crop_inspector_requested.connect(self.on_open_ocr_crop_inspector_requested)
         self.pipelineInsightsPanel.open_reading_order_editor_requested.connect(self.on_open_reading_order_editor_requested)
         self.pipelineInsightsPanel.run_layout_review_requested.connect(self.on_run_layout_review_requested)
+        self.pipelineInsightsPanel.open_batch_style_requested.connect(self.on_open_batch_style_override)
         self.rightComicTransStackPanel.addWidget(self.pipelineInsightsPanel)
         self.maskDiagnosticsPanel = MaskDiagnosticsWidget(self)
         self.rightComicTransStackPanel.addWidget(self.maskDiagnosticsPanel)
@@ -838,6 +859,10 @@ class MainWindow(mainwindow_cls):
             'redo': self._api_redo,
             'export': self._api_export,
             'layout_review': self._api_layout_review,
+            'page_state': self._api_page_state,
+            'export_structured_ocr': self._api_export_structured_ocr,
+            'render_current_page': self._api_render_current_page,
+            'list_rendering_issues': self._api_list_rendering_issues,
         }
         try:
             self._automation_api = LocalAutomationApiServer('127.0.0.1', int(getattr(pcfg, 'automation_api_port', 39542)), handlers, api_key=str(getattr(pcfg, 'automation_api_key', '') or ''))
@@ -903,11 +928,101 @@ class MainWindow(mainwindow_cls):
 
     def _api_layout_review_ui(self, body: dict):
         mode = str((body or {}).get('mode', 'page')).strip().lower()
-        if mode == 'selected':
-            self.shortcutLayoutReviewSelected()
-        else:
-            self.shortcutLayoutReviewPage()
-        return {'ok': True, 'mode': mode}
+        apply = bool((body or {}).get('apply', True))
+        result, target_indices = self._layout_review_result_for_scope(mode)
+        summary = self._summarize_layout_review_result(result)
+        applied = 0
+        if apply and summary['actions'] > 0:
+            applied = self.st_manager.apply_review_result(result, target_block_indices=target_indices)
+            if self.imgtrans_proj and self.imgtrans_proj.directory:
+                self.imgtrans_proj.save()
+        return {'ok': True, 'mode': mode, 'applied_actions': applied, 'summary': summary}
+
+
+    def _api_render_current_page(self, body: dict):
+        return self._api_call_ui(self._api_render_current_page_ui, body)
+
+    def _api_render_current_page_ui(self, body: dict):
+        from utils.io_utils import imwrite
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+            raise ValueError('open a project and select a page first')
+        qimg = self.canvas.render_result_img()
+        if qimg is None or qimg.isNull():
+            raise RuntimeError('render produced no image')
+        path = str((body or {}).get('path', '') or '').strip()
+        if not path:
+            base = osp.splitext(self.imgtrans_proj.current_img)[0]
+            path = osp.join(self.imgtrans_proj.result_dir(), base + (pcfg.imgsave_ext or '.png'))
+        arr = pixmap2ndarray(qimg, keep_alpha=False)
+        ext = osp.splitext(path)[1].lower() or pcfg.imgsave_ext or '.png'
+        imwrite(path, arr, ext=ext, quality=pcfg.imgsave_quality)
+        self.pipelineInsightsPanel.add_event('API', self.tr('Rendered current page to {0}').format(path))
+        return {'ok': True, 'page': self.imgtrans_proj.current_img, 'path': path}
+
+    def _api_list_rendering_issues(self, body: dict):
+        return self._api_call_ui(self._api_list_rendering_issues_ui, body)
+
+    def _api_list_rendering_issues_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        from utils.text_rendering import estimate_text_bounds, first_missing_glyphs, merge_font_fallback_chain, resolve_writing_mode
+        pages = list((body or {}).get('pages') or [self.imgtrans_proj.current_img] or [])
+        out = []
+        for page in pages:
+            if not page or page not in self.imgtrans_proj.pages:
+                continue
+            for idx, blk in enumerate(self.imgtrans_proj.pages.get(page, []) or []):
+                ff = getattr(blk, 'fontformat', None)
+                if ff is None:
+                    continue
+                text = getattr(blk, 'translation', '') or '\n'.join(getattr(blk, 'text', []) or [])
+                x1, y1, x2, y2 = getattr(blk, 'xyxy', [0, 0, 1, 1])
+                box = (max(1.0, float(x2) - float(x1)), max(1.0, float(y2) - float(y1)))
+                mode = resolve_writing_mode(getattr(ff, 'writing_mode', 'auto'), text, box)
+                measured = estimate_text_bounds(text, getattr(ff, 'font_size', 24.0), mode, box[0], box[1], getattr(ff, 'line_spacing', 1.15), getattr(ff, 'letter_spacing', 1.0), getattr(ff, 'text_padding', 0.0), getattr(ff, 'stroke_width', 0.0), getattr(ff, 'shadow_radius', 0.0), getattr(ff, 'shadow_offset', [0.0, 0.0]))
+                missing = first_missing_glyphs(getattr(ff, 'font_family', ''), text) if text else []
+                overflow = measured[0] > box[0] or measured[1] > box[1]
+                if overflow or missing or bool((body or {}).get('include_ok', False)):
+                    out.append({
+                        'page': page, 'index': idx, 'writing_mode': getattr(ff, 'writing_mode', 'auto'),
+                        'resolved_writing_mode': mode, 'box': list(box), 'measured': [measured[0], measured[1]],
+                        'overflow': overflow, 'missing_glyphs': missing,
+                        'fallback_chain': merge_font_fallback_chain(getattr(ff, 'font_family', ''), text, pcfg, getattr(ff, 'fallback_font_chain', '')),
+                    })
+        return {'ok': True, 'issues': out, 'count': len(out)}
+
+    def _api_page_state(self, body: dict):
+        return self._api_call_ui(self._api_page_state_ui, body)
+
+    def _api_page_state_ui(self, body: dict):
+        action = str((body or {}).get('action', 'list')).strip().lower()
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        pages = list((body or {}).get('pages') or self.imgtrans_proj.pages.keys())
+        if action == 'set':
+            state = str((body or {}).get('state', 'todo')).strip().lower()
+            for page in pages:
+                self.imgtrans_proj.set_page_completion_state(page, state)
+            self.imgtrans_proj.save()
+            self._update_page_list_state_style()
+        return {
+            'ok': True,
+            'states': {page: self.imgtrans_proj.get_page_completion_state(page) for page in pages if page in self.imgtrans_proj.pages},
+        }
+
+    def _api_export_structured_ocr(self, body: dict):
+        return self._api_call_ui(self._api_export_structured_ocr_ui, body)
+
+    def _api_export_structured_ocr_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        pages = (body or {}).get('pages')
+        payload = build_structured_ocr_export(self.imgtrans_proj, pages=pages)
+        path = str((body or {}).get('path', '') or '').strip()
+        if path:
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+        return {'ok': True, 'path': path, 'page_count': len(payload.get('pages', [])), 'payload': payload if not path else None}
 
     def _update_run_button_tooltip(self):
         base = self.tr('Run pipeline (same as Pipeline → Run).')
@@ -1029,6 +1144,81 @@ class MainWindow(mainwindow_cls):
     def on_run_layout_review_requested(self):
         self.shortcutLayoutReviewPage()
         self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Layout review agent run on current page'))
+
+    def on_open_batch_style_override(self):
+        """Apply Koharu-inspired fixed font/alignment options across a page/project."""
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            self.pipelineInsightsPanel.add_warning('BATCH_STYLE', self.tr('Open a project before applying a batch text style override.'))
+            return
+        dlg = QDialog(self)
+        dlg.setWindowTitle(self.tr('Batch Text Style Override'))
+        dlg.setMinimumWidth(460)
+        outer = QVBoxLayout(dlg)
+        form = QFormLayout()
+        outer.addLayout(form)
+
+        scope = QComboBox(dlg)
+        scope.addItems([self.tr('Current page'), self.tr('Whole project')])
+
+        font_family = QLineEdit(dlg)
+        font_family.setPlaceholderText(self.tr('Leave blank to keep current font family'))
+
+        font_size = QDoubleSpinBox(dlg)
+        font_size.setRange(0.0, 300.0)
+        font_size.setDecimals(1)
+        font_size.setSingleStep(0.5)
+        font_size.setSpecialValueText(self.tr('Keep'))
+        font_size.setValue(0.0)
+
+        alignment = QComboBox(dlg)
+        alignment.addItem(self.tr('Keep'), -1)
+        alignment.addItem(self.tr('Left'), 0)
+        alignment.addItem(self.tr('Center'), 1)
+        alignment.addItem(self.tr('Right'), 2)
+
+        auto_fit = QCheckBox(self.tr('Enable auto-fit after override'), dlg)
+        auto_fit.setChecked(True)
+
+        form.addRow(self.tr('Scope'), scope)
+        form.addRow(self.tr('Font family'), font_family)
+        form.addRow(self.tr('Fixed font size (pt)'), font_size)
+        form.addRow(self.tr('Alignment'), alignment)
+        form.addRow('', auto_fit)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel, dlg)
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        outer.addWidget(buttons)
+        exec_fn = getattr(dlg, 'exec', None) or dlg.exec_
+        if int(exec_fn()) != int(QDialog.Accepted):
+            return
+
+        page_names = [self.imgtrans_proj.current_img] if scope.currentIndex() == 0 else list(self.imgtrans_proj.pages.keys())
+        family = font_family.text().strip()
+        size_pt = float(font_size.value())
+        align_value = int(alignment.currentData())
+        changed = 0
+        for page in page_names:
+            for blk in self.imgtrans_proj.pages.get(page, []) or []:
+                fmt = getattr(blk, 'fontformat', None)
+                if fmt is None:
+                    continue
+                if family:
+                    fmt.font_family = family
+                if size_pt > 0:
+                    fmt.font_size = pt2px(size_pt)
+                    fmt.auto_fit_font_size = False
+                if align_value >= 0:
+                    fmt.alignment = align_value
+                if auto_fit.isChecked():
+                    fmt.auto_fit_font_size = True
+                changed += 1
+        if self.imgtrans_proj.current_img in page_names:
+            self.st_manager.updateSceneTextitems()
+        self.imgtrans_proj.save()
+        self.canvas.setProjSaveState(False)
+        self.pipelineInsightsPanel.add_event('BATCH_STYLE', self.tr('Updated {0} text block style(s).').format(changed))
+        self.statusBar().showMessage(self.tr('Batch style override updated {0} text block(s).').format(changed), 5000)
 
     def _has_open_project(self) -> bool:
         return (
@@ -1291,7 +1481,7 @@ class MainWindow(mainwindow_cls):
             self.pageList.addItem(lstitem)
             if imgname == self.imgtrans_proj.current_img:
                 self.pageList.setCurrentItem(lstitem)
-        self._update_page_list_ignored_style()
+        self._update_page_list_state_style()
 
     def _ensure_first_page_loaded_and_autolayout(self):
         """After opening a project, ensure the first page is displayed. Use saved layout (no re-run of auto layout)."""
@@ -1466,6 +1656,9 @@ class MainWindow(mainwindow_cls):
         self.titleBar.batch_export_trigger.connect(self.on_batch_export)
         self.titleBar.batch_export_as_trigger.connect(self.on_batch_export_as)
         self.titleBar.export_lptxt_trigger.connect(self.on_export_lptxt)
+        self.titleBar.export_structured_ocr_trigger.connect(self.on_export_structured_ocr_json)
+        if hasattr(self.titleBar, "export_layered_psd_handoff_trigger"):
+            self.titleBar.export_layered_psd_handoff_trigger.connect(self.on_export_layered_psd_handoff)
         self.titleBar.validate_project_trigger.connect(self.on_validate_project)
         self.titleBar.show_batch_report_trigger.connect(self._show_batch_report_dialog)
         self.titleBar.manga_source_trigger.connect(self.on_open_manga_source)
@@ -1512,7 +1705,12 @@ class MainWindow(mainwindow_cls):
             key = get_shortcut(action_id, sc) or default_key
             q = QShortcut(QKeySequence.fromString(key) if key else QKeySequence(), self)
             q.setContext(context)
-            q.activated.connect(slot)
+            def _guarded_slot(fn=slot, shortcut=q):
+                k = shortcut.key().toString()
+                if is_single_key_sequence(k) and shortcut_should_ignore_text_input(QApplication.focusWidget()):
+                    return
+                return fn()
+            q.activated.connect(_guarded_slot)
             self._shortcuts_list.append((action_id, default_key, q))
             return q
 
@@ -1561,13 +1759,32 @@ class MainWindow(mainwindow_cls):
             ("draw.hand", "H", "hand"),
             ("draw.inpaint", "J", "inpaint"),
             ("draw.pen", "B", "pen"),
+            ("draw.text_eraser", "E", "textEraser"),
             ("draw.rect", "R", "rect"),
         ]
         for action_id, default_key, tool_name in drawpanel_shortcuts:
             key = get_shortcut(action_id, sc) or default_key
             shortcut = QShortcut(QKeySequence.fromString(key) if key else QKeySequence(), self)
-            shortcut.activated.connect(partial(self.drawingPanel.shortcutSetCurrentToolByName, tool_name))
+            def _guarded_draw(name=tool_name, shortcut=shortcut):
+                k = shortcut.key().toString()
+                if is_single_key_sequence(k) and shortcut_should_ignore_text_input(QApplication.focusWidget()):
+                    return
+                return self.drawingPanel.shortcutSetCurrentToolByName(name)
+            shortcut.activated.connect(_guarded_draw)
             self.drawingPanel.setShortcutTip(tool_name, key or default_key)
+            self._shortcuts_list.append((action_id, default_key, shortcut))
+        for action_id, default_key, slot in [
+            ("draw.brush_size_up", "]", self.drawingPanel.on_incre_pensize),
+            ("draw.brush_size_down", "[", self.drawingPanel.on_decre_pensize),
+        ]:
+            key = get_shortcut(action_id, sc) or default_key
+            shortcut = QShortcut(QKeySequence.fromString(key) if key else QKeySequence(), self)
+            def _guarded_brush(fn=slot, shortcut=shortcut):
+                k = shortcut.key().toString()
+                if is_single_key_sequence(k) and shortcut_should_ignore_text_input(QApplication.focusWidget()):
+                    return
+                return fn()
+            shortcut.activated.connect(_guarded_brush)
             self._shortcuts_list.append((action_id, default_key, shortcut))
         self._draw_shortcut_tools = drawpanel_shortcuts
 
@@ -2083,39 +2300,84 @@ class MainWindow(mainwindow_cls):
             self.canvas.resize_to_fit_content_signal.emit()
 
     def shortcutLayoutReviewSelected(self):
-        """Run layout review/fix for selected textboxes."""
-        if self.centralStackWidget.currentIndex() != 1 or not self.canvas.gv.isVisible():
-            return
-        if not self.canvas.selected_text_items():
-            return
-        cfg = self._get_layout_review_config()
-        loops = self.st_manager.review_and_fix_selected_textboxes_with_provider(
-            config=cfg,
-            max_iters=2,
-        )
-        if loops <= 0:
-            self.statusBar().showMessage(self.tr("Layout review: no issues detected in selection."), 4000)
-            return
-        self.statusBar().showMessage(self.tr(f"Layout review applied to selection ({loops} iteration(s))."), 5000)
+        """Run layout review/fix for selected textboxes with a reviewable report."""
+        self._show_layout_review_report('selected')
 
     def shortcutLayoutReviewPage(self):
-        """Run layout review/fix for all textboxes on current page."""
+        """Run layout review/fix for all textboxes on current page with a reviewable report."""
+        self._show_layout_review_report('page')
+
+    def _layout_review_result_for_scope(self, mode: str):
         if self.centralStackWidget.currentIndex() != 1 or not self.canvas.gv.isVisible():
-            return
+            raise RuntimeError('No editable page is visible.')
+        mode = (mode or 'page').strip().lower()
+        if mode == 'selected':
+            if not self.canvas.selected_text_items():
+                raise RuntimeError('No selected text boxes.')
+            target_indices = None
+        else:
+            target_indices = [
+                blk.idx for blk in self.st_manager.textblk_item_list
+                if blk is not None
+            ]
+            if not target_indices:
+                raise RuntimeError('No text boxes on this page.')
         cfg = self._get_layout_review_config()
-        target_indices = [
-            blk.idx for blk in self.st_manager.textblk_item_list
-            if blk is not None and not getattr(blk.fontformat, "vertical", False)
-        ]
-        loops = self.st_manager.review_and_fix_selected_textboxes_with_provider(
+        result = self.st_manager.review_selected_textboxes_with_provider(
             config=cfg,
             target_block_indices=target_indices,
-            max_iters=2,
         )
-        if loops <= 0:
-            self.statusBar().showMessage(self.tr("Layout review: no page-level issues detected."), 4000)
+        return result, target_indices
+
+    def _summarize_layout_review_result(self, result: PageReviewResult) -> dict:
+        blocks = list(getattr(result, 'blocks', []) or [])
+        issues = sum(len(getattr(b, 'issues', []) or []) for b in blocks)
+        actions = sum(len(getattr(b, 'actions', []) or []) for b in blocks)
+        score = (sum(float(getattr(b, 'score_after', 1.0) or 0.0) for b in blocks) / len(blocks)) if blocks else 1.0
+        return {'blocks': len(blocks), 'issues': issues, 'actions': actions, 'score_after': max(0.0, min(1.0, score))}
+
+    def _layout_review_result_with_actions(self, result: PageReviewResult, selected_actions: list) -> PageReviewResult:
+        selected_ids = {id(action) for action in (selected_actions or [])}
+        blocks = []
+        for block in getattr(result, 'blocks', []) or []:
+            actions = [a for a in (getattr(block, 'actions', []) or []) if id(a) in selected_ids]
+            blocks.append(
+                BlockReviewResult(
+                    block_index=block.block_index,
+                    score_before=block.score_before,
+                    score_after=block.score_after if actions else block.score_before,
+                    issues=list(getattr(block, 'issues', []) or []),
+                    actions=actions,
+                )
+            )
+        return PageReviewResult(page_name=result.page_name, blocks=blocks)
+
+    def _show_layout_review_report(self, mode: str):
+        try:
+            result, target_indices = self._layout_review_result_for_scope(mode)
+        except Exception as e:
+            self.pipelineInsightsPanel.add_warning('LAYOUT_REVIEW', str(e))
+            self.statusBar().showMessage(self.tr('Layout review unavailable: {0}').format(str(e)), 5000)
             return
-        self.statusBar().showMessage(self.tr(f"Layout review applied to page ({loops} iteration(s))."), 5000)
+        summary = self._summarize_layout_review_result(result)
+        dlg = LayoutReviewReportDialog(result, self)
+        exec_fn = getattr(dlg, 'exec', None) or dlg.exec_
+        if int(exec_fn()) != int(QDialog.Accepted):
+            self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Layout review closed without applying fixes.'))
+            return
+        selected_actions = dlg.selected_actions()
+        apply_result = self._layout_review_result_with_actions(result, selected_actions)
+        applied = self.st_manager.apply_review_result(apply_result, target_block_indices=target_indices)
+        if applied > 0:
+            if self.imgtrans_proj and self.imgtrans_proj.directory:
+                self.imgtrans_proj.save()
+            self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Applied {0} layout fix action(s).').format(applied))
+            self.statusBar().showMessage(self.tr('Layout review applied {0} fix action(s).').format(applied), 5000)
+        else:
+            self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Layout review found no applicable fixes.'))
+            self.statusBar().showMessage(self.tr('Layout review: no applicable fixes.'), 4000)
+        if summary['issues'] > 0:
+            self.pipelineInsightsPanel.add_warning('LAYOUT_REVIEW', self.tr('{0} issue(s), {1} proposed fix(es).').format(summary['issues'], summary['actions']))
 
     def _get_layout_review_config(self) -> ReviewModelConfig:
         return self._layout_review_config_from_pcfg()
@@ -3784,6 +4046,28 @@ class MainWindow(mainwindow_cls):
         if page_key == self.imgtrans_proj.current_img:
             self.st_manager.updateTranslation()
 
+    def _auto_mark_translated_pages_after_run(self):
+        if not getattr(pcfg, 'auto_mark_translated_pages', True):
+            return
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            return
+        pages = getattr(self, '_last_pages_to_process', None) or list(self.imgtrans_proj.pages.keys())
+        changed = 0
+        required_code = int(getattr(self, '_last_run_finish_code', 0) or getattr(pcfg.module, 'finish_code', 0) or 0)
+        for page in pages:
+            if page not in self.imgtrans_proj.pages:
+                continue
+            info = self.imgtrans_proj._ensure_image_info_entry(page)
+            finish_code = int(info.get('finish_code', 0) or 0)
+            if required_code and (finish_code & required_code) == required_code:
+                if self.imgtrans_proj.get_page_completion_state(page) in ('todo', 'translated'):
+                    self.imgtrans_proj.set_page_completion_state(page, 'translated')
+                    changed += 1
+        if changed:
+            self.imgtrans_proj.save()
+            self._update_page_list_state_style()
+            self.pipelineInsightsPanel.add_event('PAGE_STATE', self.tr('Auto-marked {0} page(s) as translated.').format(changed))
+
     def on_imgtrans_pipeline_finished(self):
         if getattr(self, '_detection_only_restore', None) is not None:
             det, ocr, trans, inp = self._detection_only_restore
@@ -3806,6 +4090,7 @@ class MainWindow(mainwindow_cls):
         self.backup_blkstyles.clear()
         self._run_imgtrans_wo_textstyle_update = False
         self.postprocess_mt_toggle = True
+        self._auto_mark_translated_pages_after_run()
         if pcfg.module.empty_runcache and not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
             self.module_manager.unload_all_models()
             try:
@@ -4168,7 +4453,14 @@ class MainWindow(mainwindow_cls):
                 pages_to_process = list(self.imgtrans_proj.pages.keys())
                 if skip_ignored:
                     pages_to_process = [p for p in pages_to_process if not self.imgtrans_proj.is_page_ignored(p)]
+                if getattr(pcfg, 'skip_satisfied_pipeline_steps', False):
+                    before_count = len(pages_to_process)
+                    pages_to_process = [p for p in pages_to_process if not self.imgtrans_proj.get_page_progress(p)]
+                    skipped_count = before_count - len(pages_to_process)
+                    if skipped_count > 0 and hasattr(self, 'pipelineInsightsPanel'):
+                        self.pipelineInsightsPanel.add_event('SKIP', self.tr('Skipped {0} already-satisfied page(s).').format(skipped_count))
                 if not pages_to_process:
+                    self.statusBar().showMessage(self.tr('All pages already satisfy the enabled pipeline stages.'), 5000)
                     return
                 for page_name in pages_to_process:
                     self.imgtrans_proj.set_page_progress(page_name, 0)
@@ -4207,6 +4499,8 @@ class MainWindow(mainwindow_cls):
                     textblk.vertical = textblk.src_is_vertical
         
         # 如果有指定pages_to_process或者是continue_mode，则传递页面列表
+        self._last_pages_to_process = list(pages_to_process) if pages_to_process else None
+        self._last_run_finish_code = int(getattr(pcfg.module, 'finish_code', 0) or 0)
         self.module_manager.runImgtransPipeline(pages_to_process if (pages_to_process or continue_mode) else None)
 
     def on_transpanel_changed(self):
@@ -4387,6 +4681,53 @@ class MainWindow(mainwindow_cls):
         except Exception as e:
             create_error_dialog(e, self.tr('Failed to export as TEXT file'))
 
+
+    def on_export_layered_psd_handoff(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+            QMessageBox.information(self, self.tr('Export'), self.tr('Open a project and select a page first.'))
+            return
+        default_dir = osp.join(self.imgtrans_proj.directory, 'psd_handoff')
+        out_dir = QFileDialog.getExistingDirectory(self, self.tr('Export layered PSD handoff'), default_dir)
+        if not out_dir:
+            return
+        try:
+            final_arr = None
+            qimg = self.canvas.render_result_img()
+            if qimg is not None and not qimg.isNull():
+                final_arr = pixmap2ndarray(qimg, keep_alpha=False)
+            manifest = build_layered_psd_handoff(self.imgtrans_proj, self.imgtrans_proj.current_img, out_dir, final_image=final_arr)
+            warn = '\n'.join(manifest.get('warnings', []) or [])
+            msg = self.tr('Layered PSD handoff exported to {0}.').format(out_dir)
+            msg += '\n' + self.tr('Manifest: {0}').format(manifest.get('manifest_path', ''))
+            msg += '\n' + self.tr('Photoshop script: {0}').format(manifest.get('photoshop_jsx_path', ''))
+            if warn:
+                msg += '\n\n' + self.tr('Warnings:') + '\n' + warn
+            QMessageBox.information(self, self.tr('Export'), msg)
+            self.pipelineInsightsPanel.add_event('EXPORT', self.tr('Layered PSD handoff exported for {0}.').format(self.imgtrans_proj.current_img))
+        except Exception as e:
+            LOGGER.exception(e)
+            create_error_dialog(e, self.tr('Layered PSD handoff export failed'))
+
+    def on_export_structured_ocr_json(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Export'), self.tr('Open a project first.'))
+            return
+        default_path = osp.join(self.imgtrans_proj.directory, 'structured_ocr_export.json')
+        savep = QFileDialog.getSaveFileName(self, self.tr('Export structured OCR JSON'), default_path, self.tr('JSON (*.json)'))
+        if not isinstance(savep, str):
+            savep = savep[0]
+        if not savep:
+            return
+        if Path(savep).suffix.lower() != '.json':
+            savep += '.json'
+        try:
+            payload = build_structured_ocr_export(self.imgtrans_proj)
+            with open(savep, 'w', encoding='utf-8') as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+            create_info_dialog({'title': self.tr('Structured OCR exported'), 'text': self.tr('Exported {0} page(s) to {1}').format(len(payload.get('pages', [])), savep)})
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to export structured OCR JSON'))
+
     def on_export_lptxt(self):
         """Export translations to LPtxt format (for auto-labeling tools)."""
         if not self.imgtrans_proj or not self.imgtrans_proj.directory:
@@ -4540,34 +4881,62 @@ class MainWindow(mainwindow_cls):
         if self.imgtrans_proj.directory:
             self.imgtrans_proj.save()
             self.canvas.setProjSaveState(False)
-        self._update_page_list_ignored_style()
+        self._update_page_list_state_style()
 
-    def _update_page_list_ignored_style(self):
-        """Update page list items to show ignored state: tooltip, muted text, and darkened/lightened row background."""
-        from qtpy.QtGui import QBrush, QColor
+    def on_set_page_completion_state(self, pagenames: list, state: str):
+        """Persist user-visible completion state for selected pages."""
+        if not pagenames or self.imgtrans_proj.is_empty:
+            return
+        for name in pagenames:
+            self.imgtrans_proj.set_page_completion_state(name, state)
+        if self.imgtrans_proj.directory:
+            self.imgtrans_proj.save()
+            self.canvas.setProjSaveState(False)
+        self._update_page_list_state_style()
+        self.pipelineInsightsPanel.add_event('PAGE_STATE', self.tr('Set {0} page(s) to {1}.').format(len(pagenames), state))
+
+    def _update_page_list_state_style(self):
+        """Update page list items for ignored + completion state visibility."""
         default_fg = self.pageList.palette().brush(self.pageList.foregroundRole())
         default_bg = self.pageList.palette().brush(self.pageList.backgroundRole())
-        # Ignored: muted foreground and distinct row background (darkened in light theme, lightened in dark theme)
         if getattr(pcfg, 'darkmode', False):
             ignored_fg = QBrush(QColor(120, 120, 120))
-            ignored_bg = QBrush(QColor(45, 45, 48))  # darker than list bg
+            ignored_bg = QBrush(QColor(45, 45, 48))
+            state_bg = {
+                'translated': QBrush(QColor(35, 58, 74)),
+                'reviewed': QBrush(QColor(43, 74, 50)),
+                'exported': QBrush(QColor(74, 61, 36)),
+            }
         else:
             ignored_fg = QBrush(QColor(100, 100, 100))
-            ignored_bg = QBrush(QColor(232, 232, 234))  # light gray row
+            ignored_bg = QBrush(QColor(232, 232, 234))
+            state_bg = {
+                'translated': QBrush(QColor(225, 244, 255)),
+                'reviewed': QBrush(QColor(224, 246, 228)),
+                'exported': QBrush(QColor(255, 241, 214)),
+            }
+        labels = {
+            'todo': self.tr('Needs work'),
+            'translated': self.tr('Translated'),
+            'reviewed': self.tr('Reviewed'),
+            'exported': self.tr('Exported'),
+        }
         for i in range(self.pageList.count()):
             item = self.pageList.item(i)
             if item is None:
                 continue
             name = item.text()
             is_ignored = self.imgtrans_proj.is_page_ignored(name) if not self.imgtrans_proj.is_empty else False
+            state = self.imgtrans_proj.get_page_completion_state(name) if not self.imgtrans_proj.is_empty else 'todo'
+            tips = [self.tr('Completion: {0}').format(labels.get(state, state))]
             if is_ignored:
-                item.setToolTip(self.tr('Ignored in run (right-click → Include in run to process)'))
+                tips.append(self.tr('Ignored in run (right-click → Include in run to process)'))
                 item.setForeground(ignored_fg)
                 item.setBackground(ignored_bg)
             else:
-                item.setToolTip('')
                 item.setForeground(default_fg)
-                item.setBackground(default_bg)
+                item.setBackground(state_bg.get(state, default_bg))
+            item.setToolTip('\n'.join(tips))
 
     def on_remove_images(self, image_names: list):
         if not image_names:

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -787,6 +787,14 @@ class TitleBar(Widget):
         exportLptxtAction.setToolTip(self.tr('Export translations in LPtxt format for auto-labeling tools (e.g. 气泡翻译器自动打标).'))
         self.export_lptxt_trigger = exportLptxtAction.triggered
         exportMenuTools.addAction(exportLptxtAction)
+        layeredPsdHandoffAction = QAction(self.tr('Export layered PSD handoff...'), self)
+        layeredPsdHandoffAction.setToolTip(self.tr('Export original/inpainted/mask/final helper layers plus editable text metadata and a Photoshop JSX rebuild script.'))
+        self.export_layered_psd_handoff_trigger = layeredPsdHandoffAction.triggered
+        exportMenuTools.addAction(layeredPsdHandoffAction)
+        structuredOcrExportAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'structured_ocr_export.svg')), self.tr('Export structured OCR JSON...'), self)
+        structuredOcrExportAction.setToolTip(self.tr('Export page/block geometry, OCR text, translations, completion state, and font hints as JSON for LLM/tooling workflows.'))
+        self.export_structured_ocr_trigger = structuredOcrExportAction.triggered
+        exportMenuTools.addAction(structuredOcrExportAction)
         sourcesMenu = QMenu(self.tr('Sources'), self)
         sourcesMenu.addAction(mangaSourceAction)
         queueMenu = QMenu(self.tr('Queue'), self)

--- a/ui/pipeline_insights_widget.py
+++ b/ui/pipeline_insights_widget.py
@@ -10,6 +10,7 @@ class PipelineInsightsWidget(QWidget):
     open_ocr_crop_inspector_requested = Signal()
     open_reading_order_editor_requested = Signal()
     run_layout_review_requested = Signal()
+    open_batch_style_requested = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -61,12 +62,20 @@ class PipelineInsightsWidget(QWidget):
         self.reading_order_btn.clicked.connect(self.open_reading_order_editor_requested.emit)
         lay.addWidget(self.reading_order_btn)
         self.layout_review_btn = QPushButton(self.tr('Layout Review Agent'), self)
+        self.layout_review_btn.setObjectName('PipelinePrimaryAction')
         self.layout_review_btn.clicked.connect(self.run_layout_review_requested.emit)
         lay.addWidget(self.layout_review_btn)
+        self.batch_style_btn = QPushButton(self.tr('Batch Text Style Override'), self)
+        self.batch_style_btn.clicked.connect(self.open_batch_style_requested.emit)
+        lay.addWidget(self.batch_style_btn)
         self.api_status_label = QLabel(self.tr('Automation API: off'), self)
         self.api_status_label.setObjectName('PipelineApiStatus')
         lay.addWidget(self.api_status_label)
 
+        self.empty_state = QLabel(self.tr('No warnings yet. Run the pipeline or layout review to populate actionable checks.'), self)
+        self.empty_state.setWordWrap(True)
+        self.empty_state.setObjectName('PipelineEmptyState')
+        lay.addWidget(self.empty_state)
         self.warning_list = QListWidget(self)
         self.warning_list.setFrameShape(QFrame.NoFrame)
         lay.addWidget(self.warning_list, 1)
@@ -135,6 +144,7 @@ class PipelineInsightsWidget(QWidget):
         item = QListWidgetItem(f'[{code}] {message}')
         item.setToolTip(message)
         self.warning_list.addItem(item)
+        self.empty_state.setVisible(False)
         self.warning_badge.setText(self.tr(f'Warnings: {self.warning_list.count()}'))
         self._anim.stop()
         self._anim.setDuration(140)
@@ -154,6 +164,7 @@ class PipelineInsightsWidget(QWidget):
 
     def reset(self):
         self.warning_list.clear()
+        self.empty_state.setVisible(True)
         self.warning_badge.setText(self.tr('Warnings: 0'))
         self.event_list.clear()
         self.engine_list.clear()

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -30,6 +30,15 @@ from utils.bubble_shape_model import get_bubble_shape_from_model as _bubble_shap
 from utils.box_size_check_model import check_box_size_from_model
 from utils.text_processing import seg_text, is_cjk
 from utils.text_layout import layout_text
+from utils.text_rendering import (
+    balance_lines,
+    fallback_chain_for_text,
+    fit_font_size_to_box,
+    merge_font_fallback_chain,
+    first_missing_glyphs,
+    normalize_vertical_punctuation,
+    resolve_writing_mode,
+)
 from utils.line_breaking import split_long_token_with_hyphenation
 from utils.layout_review_agent import (
     BlockSnapshot,
@@ -609,6 +618,10 @@ class SceneTextManager(QObject):
         self.canvas.set_balloon_shape_signal.connect(self.onSetBalloonShape)
         self.canvas.resize_to_fit_content_signal.connect(self.onResizeToFitContent)
         self.canvas.center_in_bubble_signal.connect(self.onCenterInBubble)
+        if hasattr(self.canvas, "set_writing_mode_signal"):
+            self.canvas.set_writing_mode_signal.connect(self.onSetWritingMode)
+        if hasattr(self.canvas, "recenter_text_in_box_signal"):
+            self.canvas.recenter_text_in_box_signal.connect(self.onRecenterTextInBox)
         self.canvas.reset_angle.connect(self.onResetAngle)
         self.canvas.squeeze_blk.connect(self.onSqueezeBlk)
         self.canvas.incanvas_selection_changed.connect(self.on_incanvas_selection_changed)
@@ -632,6 +645,29 @@ class SceneTextManager(QObject):
 
         self.prev_blkitem: TextBlkItem = None
         self._moving_blur_item: TextBlkItem = None  # reserved for optional drag effect cleanup
+
+
+    def onSetWritingMode(self, mode: str):
+        from ui import fontformat_commands as FC
+        blkitems = self.canvas.selected_text_items()
+        if not blkitems:
+            return
+        FC.ffmt_change_writing_mode('writing_mode', mode, self.formatpanel.global_format, False, blkitems)
+        self.updateSceneTextitems()
+        self.canvas.setProjSaveState(False)
+
+    def onRecenterTextInBox(self):
+        for blkitem in self.canvas.selected_text_items():
+            rect = blkitem.boundingRect()
+            doc_size = blkitem.document().size()
+            dx = (rect.width() - doc_size.width()) / 2.0
+            dy = (rect.height() - doc_size.height()) / 2.0
+            try:
+                blkitem.document().setDocumentMargin(max(0.0, blkitem.document().documentMargin() + min(dx, dy, 8.0)))
+            except Exception:
+                pass
+            blkitem.update()
+        self.canvas.setProjSaveState(False)
 
     def on_switch_textitem(self, switch_delta: int, key_event: QKeyEvent = None, current_editing_widget: Union[SourceTextEdit, TransTextEdit] = None):
         n_blk = len(self.textblk_item_list)
@@ -1286,6 +1322,20 @@ class SceneTextManager(QObject):
                         font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
                         est_text_size=est,
                         bubble_center=bubble_center,
+                        writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
+                        resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
+                        overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
+                        measured_bounds=est,
+                        text_style={
+                            'font_family': getattr(blk.fontformat, 'font_family', ''),
+                            'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
+                            'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
+                            'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
+                            'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
+                            'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
+                            'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
+                        },
+                        font_fallback_warning=', '.join(first_missing_glyphs(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText())),
                     )
                 )
             result = planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
@@ -1322,6 +1372,20 @@ class SceneTextManager(QObject):
                     font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
                     est_text_size=est,
                     bubble_center=self._estimate_block_bubble_center(blk),
+                    writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
+                    resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
+                    overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
+                    measured_bounds=est,
+                    text_style={
+                        'font_family': getattr(blk.fontformat, 'font_family', ''),
+                        'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
+                        'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
+                        'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
+                        'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
+                        'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
+                        'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
+                    },
+                    font_fallback_warning=', '.join(first_missing_glyphs(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText())),
                 )
             )
         return planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
@@ -1353,6 +1417,20 @@ class SceneTextManager(QObject):
                     font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
                     est_text_size=est,
                     bubble_center=self._estimate_block_bubble_center(blk),
+                    writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
+                    resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
+                    overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
+                    measured_bounds=est,
+                    text_style={
+                        'font_family': getattr(blk.fontformat, 'font_family', ''),
+                        'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
+                        'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
+                        'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
+                        'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
+                        'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
+                        'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
+                    },
+                    font_fallback_warning=', '.join(first_missing_glyphs(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText())),
                 )
             )
         provider_impl = provider or self._resolve_review_provider(cfg)
@@ -1399,17 +1477,44 @@ class SceneTextManager(QObject):
         review_result,
         target_block_indices: Optional[List[int]] = None,
     ) -> int:
-        """Apply actions from a precomputed review result and return number of actions applied."""
+        """Apply actions from a precomputed review result and return number of actions applied.
+
+        Provider/page review can target blocks that are not currently selected.  The
+        low-level auto-fit/center helpers intentionally operate on selection, so
+        this method temporarily selects the requested targets to make API/menu
+        invocations behave exactly like user-driven edits and remain undoable.
+        """
         pending_actions = [a for block_result in review_result.blocks for a in block_result.actions]
         if target_block_indices:
             pending_actions = filter_actions_by_block_indices(pending_actions, target_block_indices)
         if not pending_actions:
             return 0
-        selected = self._get_review_target_blocks(target_block_indices)
-        if not selected:
-            return 0
-        self._apply_layout_review_actions(pending_actions, selected)
-        return len(pending_actions)
+
+        selected_before = list(self.canvas.selected_text_items())
+        was_editing = self.canvas.editing_textblkitem
+        try:
+            if target_block_indices:
+                idx_set = set(target_block_indices)
+                for blk in self.textblk_item_list:
+                    if blk is not None:
+                        blk.setSelected(blk.idx in idx_set)
+            selected = self._get_review_target_blocks(target_block_indices)
+            if not selected:
+                return 0
+            self._apply_layout_review_actions(pending_actions, selected)
+            return len(pending_actions)
+        finally:
+            if target_block_indices:
+                for blk in self.textblk_item_list:
+                    if blk is not None:
+                        blk.setSelected(False)
+                for blk in selected_before:
+                    try:
+                        blk.setSelected(True)
+                    except Exception:
+                        continue
+                if was_editing is not None and was_editing in self.textblk_item_list:
+                    self.canvas.editing_textblkitem = was_editing
 
     def review_and_fix_selected_textboxes_with_provider(
         self,
@@ -1574,12 +1679,63 @@ class SceneTextManager(QObject):
             undo_stack.beginMacro("Layout review agent")
         try:
             # Keep existing action handlers first to preserve current behavior.
-            if grouped["auto_fit"]:
+            if grouped["auto_fit"] or grouped["shrink_to_fit"]:
                 self.onAutoFitFontToBox()
             if grouped["resize_to_fit_content"]:
                 self.onResizeToFitContent()
-            if grouped["center_in_bubble"]:
+            if grouped["center_in_bubble"] or grouped["recenter"]:
                 self.onCenterInBubble()
+            for action in grouped["switch_writing_mode"]:
+                blkitem = selected_by_idx.get(action.block_index)
+                if blkitem is None:
+                    continue
+                mode = str(action.args.get("writing_mode", "auto") or "auto")
+                blkitem.fontformat.writing_mode = mode
+                resolved = resolve_writing_mode(mode, blkitem.toPlainText(), (blkitem.absBoundingRect(qrect=True).width(), blkitem.absBoundingRect(qrect=True).height()))
+                blkitem.setVertical(resolved == "vertical_rl")
+                if resolved == "rtl":
+                    blkitem.setAlignment(2, restore_cursor=False)
+                if blkitem.blk is not None:
+                    blkitem.blk.fontformat.writing_mode = mode
+                    blkitem.blk.fontformat.vertical = resolved == "vertical_rl"
+                    blkitem.blk.vertical = resolved == "vertical_rl"
+            for action in grouped["increase_padding"]:
+                blkitem = selected_by_idx.get(action.block_index)
+                if blkitem is None:
+                    continue
+                padding = max(0.0, float(action.args.get("padding", 2.0) or 2.0))
+                blkitem.fontformat.text_padding = max(float(getattr(blkitem.fontformat, 'text_padding', 0.0) or 0.0), padding)
+                blkitem.setPadding(blkitem.fontformat.text_padding)
+                if blkitem.blk is not None:
+                    blkitem.blk.fontformat.text_padding = blkitem.fontformat.text_padding
+            for action in grouped["balance_lines"]:
+                blkitem = selected_by_idx.get(action.block_index)
+                if blkitem is None:
+                    continue
+                rect = blkitem.absBoundingRect(qrect=True)
+                fm = QFontMetricsF(blkitem.font())
+                avg_w = max(1.0, fm.horizontalAdvance('漢A') / 2.0)
+                balanced = balance_lines(blkitem.toPlainText().replace('\n', ''), max(2, int(rect.width() / avg_w)))
+                if balanced and balanced != blkitem.toPlainText():
+                    blkitem.setPlainText(balanced)
+                    if blkitem.blk is not None:
+                        blkitem.blk.translation = balanced
+            for action in grouped["apply_manga_preset"]:
+                blkitem = selected_by_idx.get(action.block_index)
+                if blkitem is None:
+                    continue
+                preset_id = str(action.args.get("preset", "default_manga_bubble") or "default_manga_bubble")
+                from utils.text_rendering import MANGA_PRESETS
+                preset = MANGA_PRESETS.get(preset_id)
+                if not preset:
+                    continue
+                for key, value in preset.items():
+                    if key != 'label' and hasattr(blkitem.fontformat, key):
+                        setattr(blkitem.fontformat, key, value)
+                blkitem.fontformat.manga_preset = preset_id
+                blkitem.set_fontformat(blkitem.fontformat)
+                if blkitem.blk is not None:
+                    blkitem.blk.fontformat = blkitem.fontformat.deepcopy()
             for action in grouped["move"]:
                 blkitem = selected_by_idx.get(action.block_index)
                 if blkitem is None:
@@ -2095,13 +2251,28 @@ class SceneTextManager(QObject):
         src_is_cjk = is_cjk(pcfg.module.translate_source)
         tgt_is_cjk = is_cjk(pcfg.module.translate_target)
 
-        # disable for vertical writing
-        if blkitem.blk.vertical:
-            return
-        
-        old_br = blkitem.absBoundingRect(qrect=True)
-        old_br = [old_br.x(), old_br.y(), old_br.width(), old_br.height()]
+        old_br_q = blkitem.absBoundingRect(qrect=True)
+        old_br = [old_br_q.x(), old_br_q.y(), old_br_q.width(), old_br_q.height()]
         if old_br[2] < 1:
+            return
+
+        # Resolve per-textbox writing mode before deciding whether the horizontal auto-layout path applies.
+        raw_text_for_mode = text if text is not None else blkitem.toPlainText()
+        resolved_mode = resolve_writing_mode(getattr(blkitem.fontformat, 'writing_mode', 'auto'), raw_text_for_mode, (old_br[2], old_br[3]))
+        blkitem.fontformat.vertical = resolved_mode == 'vertical_rl'
+        if blkitem.blk is not None:
+            blkitem.blk.fontformat.writing_mode = getattr(blkitem.fontformat, 'writing_mode', 'auto')
+            blkitem.blk.fontformat.vertical = blkitem.fontformat.vertical
+            blkitem.blk.vertical = blkitem.fontformat.vertical
+        if resolved_mode == 'rtl':
+            blkitem.setAlignment(2, restore_cursor=False)
+        if resolved_mode == 'vertical_rl':
+            new_text = normalize_vertical_punctuation(raw_text_for_mode)
+            if new_text != raw_text_for_mode:
+                blkitem.setPlainText(new_text)
+                if blkitem.blk is not None:
+                    blkitem.blk.translation = new_text
+            blkitem.setVertical(True)
             return
 
         blk_font = blkitem.font()
@@ -2128,6 +2299,23 @@ class SceneTextManager(QObject):
 
         if not text.strip():
             return
+        fit_mode = getattr(fmt, 'fit_mode', 'shrink')
+        if fit_mode in ('shrink', 'expand', 'preserve', 'balance'):
+            fitted_size, fitted_text, fit_diag = fit_font_size_to_box(
+                text, blk_font.pointSizeF(), (old_br[2], old_br[3]), fit_mode,
+                getattr(fmt, 'writing_mode', 'auto'),
+                min_font_size=float(getattr(pcfg.module, 'layout_font_size_min', 8.0)),
+                max_font_size=float(getattr(pcfg.module, 'layout_font_size_max', 72.0)),
+                line_spacing=float(getattr(fmt, 'line_spacing', 1.15) or 1.15),
+                letter_spacing=float(getattr(fmt, 'letter_spacing', 1.0) or 1.0),
+                padding=float(getattr(fmt, 'text_padding', 0.0) or 0.0),
+                stroke_width=float(getattr(fmt, 'stroke_width', 0.0) or 0.0),
+            )
+            if fit_mode in ('shrink', 'expand') and abs(fitted_size - blk_font.pointSizeF()) > 0.2:
+                blk_font.setPointSizeF(max(1.0, fitted_size))
+                blk_font.setPointSize(max(1, int(round(fitted_size))))
+            if fitted_text != text:
+                text = fitted_text
 
         # When mask not passed, try to get block's mask from project so we only run bubble/balloon logic when a bubble was detected
         if mask is None and img is not None:

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -10,6 +10,7 @@ from utils import shared
 from utils import config as C
 from utils.config import pcfg
 from utils.fontformat import FontFormat, px2pt, LineSpacingType
+from utils.text_rendering import MANGA_PRESETS, normalize_fit_mode, normalize_writing_mode
 from .custom_widget import Widget, ColorPickerLabel, ClickableLabel, CheckableLabel, TextCheckerLabel, AlignmentChecker, QFontChecker, SizeComboBox, SizeControlLabel
 from .textitem import TextBlkItem
 from .text_advanced_format import TextAdvancedFormatPanel
@@ -313,6 +314,41 @@ class FontFormatPanel(Widget):
         self.autoFitFontSizeChecker.setToolTip(self.tr("Auto fit font size to block: scale font so text fits the bounding box when layout runs."))
         self.autoFitFontSizeChecker.clicked.connect(lambda : self.on_param_changed('auto_fit_font_size', self.autoFitFontSizeChecker.isChecked()))
 
+        self.writingModeCombo = QComboBox(self)
+        self.writingModeCombo.setObjectName("WritingModeCombo")
+        self.writingModeCombo.addItem(self.tr("Writing: Auto"), "auto")
+        self.writingModeCombo.addItem(self.tr("Horizontal LTR"), "horizontal_ltr")
+        self.writingModeCombo.addItem(self.tr("Vertical RL"), "vertical_rl")
+        self.writingModeCombo.addItem(self.tr("RTL"), "rtl")
+        self.writingModeCombo.setToolTip(self.tr("Per-textbox writing mode. Auto uses script and text-box geometry."))
+        self.writingModeCombo.currentIndexChanged.connect(self._on_writing_mode_changed)
+
+        self.fitModeCombo = QComboBox(self)
+        self.fitModeCombo.setObjectName("FitModeCombo")
+        self.fitModeCombo.addItem(self.tr("Fit: Shrink"), "shrink")
+        self.fitModeCombo.addItem(self.tr("Expand to fill"), "expand")
+        self.fitModeCombo.addItem(self.tr("Preserve size"), "preserve")
+        self.fitModeCombo.addItem(self.tr("Balance lines"), "balance")
+        self.fitModeCombo.setToolTip(self.tr("Text fitting policy used by auto-layout and layout review."))
+        self.fitModeCombo.currentIndexChanged.connect(self._on_fit_mode_changed)
+
+        self.mangaPresetCombo = QComboBox(self)
+        self.mangaPresetCombo.setObjectName("MangaPresetCombo")
+        self.mangaPresetCombo.addItem(self.tr("Preset: none"), "")
+        for preset_id, preset in MANGA_PRESETS.items():
+            self.mangaPresetCombo.addItem(self.tr(preset.get("label", preset_id)), preset_id)
+        self.mangaPresetCombo.setToolTip(self.tr("Apply manga lettering presets: stroke, spacing, writing mode, fit mode, alignment, and padding."))
+        self.mangaPresetCombo.currentIndexChanged.connect(self._on_manga_preset_changed)
+
+        self.textPaddingSpinBox = QDoubleSpinBox(self)
+        self.textPaddingSpinBox.setObjectName("TextPaddingSpinBox")
+        self.textPaddingSpinBox.setRange(0.0, 64.0)
+        self.textPaddingSpinBox.setSingleStep(1.0)
+        self.textPaddingSpinBox.setDecimals(1)
+        self.textPaddingSpinBox.setSuffix(" px")
+        self.textPaddingSpinBox.setToolTip(self.tr("Extra text inset/padding to avoid clipping strokes and punctuation."))
+        self.textPaddingSpinBox.valueChanged.connect(self._on_text_padding_changed)
+
         self.textOnPathCombo = QComboBox(self)
         self.textOnPathCombo.setObjectName("TextOnPathCombo")
         self.textOnPathCombo.addItems([self.tr("Text on path: None"), self.tr("Circular"), self.tr("Arc")])
@@ -491,6 +527,10 @@ class FontFormatPanel(Widget):
         hl2.setContentsMargins(4, 0, 4, 0)
         hl2b = QHBoxLayout()
         hl2b.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        hl2b.addWidget(self.writingModeCombo)
+        hl2b.addWidget(self.fitModeCombo)
+        hl2b.addWidget(self.mangaPresetCombo)
+        hl2b.addWidget(self.textPaddingSpinBox)
         hl2b.addWidget(self.textOnPathCombo)
         hl2b.addWidget(self.textOnPathArcDegreesSpinBox)
         hl2b.addWidget(self.warpStyleCombo)
@@ -576,6 +616,24 @@ class FontFormatPanel(Widget):
         else:
             func(param_name, value, C.active_format, is_global=False, blkitems=self.textblk_item, set_focus=True, **func_kwargs)
 
+    def _set_combo_by_data(self, combo: QComboBox, value):
+        idx = combo.findData(value)
+        combo.setCurrentIndex(idx if idx >= 0 else 0)
+
+    def _on_writing_mode_changed(self, index: int):
+        self.on_param_changed('writing_mode', self.writingModeCombo.itemData(index) or 'auto')
+
+    def _on_fit_mode_changed(self, index: int):
+        self.on_param_changed('fit_mode', self.fitModeCombo.itemData(index) or 'shrink')
+
+    def _on_manga_preset_changed(self, index: int):
+        preset = self.mangaPresetCombo.itemData(index) or ''
+        if preset:
+            self.on_param_changed('manga_preset', preset)
+
+    def _on_text_padding_changed(self, value: float):
+        self.on_param_changed('text_padding', float(value))
+
     def _on_text_on_path_combo_changed(self, index: int):
         self.textOnPathArcDegreesSpinBox.setVisible(index == 2)
         self.on_param_changed('text_on_path', index)
@@ -637,6 +695,18 @@ class FontFormatPanel(Widget):
         self.lineSpacingBox.setValue(font_format.line_spacing)
         self.letterSpacingBox.setValue(font_format.letter_spacing)
         self.verticalChecker.setChecked(font_format.vertical)
+        self.writingModeCombo.blockSignals(True)
+        self._set_combo_by_data(self.writingModeCombo, normalize_writing_mode(getattr(font_format, 'writing_mode', 'auto')))
+        self.writingModeCombo.blockSignals(False)
+        self.fitModeCombo.blockSignals(True)
+        self._set_combo_by_data(self.fitModeCombo, normalize_fit_mode(getattr(font_format, 'fit_mode', 'shrink')))
+        self.fitModeCombo.blockSignals(False)
+        self.mangaPresetCombo.blockSignals(True)
+        self._set_combo_by_data(self.mangaPresetCombo, getattr(font_format, 'manga_preset', '') or '')
+        self.mangaPresetCombo.blockSignals(False)
+        self.textPaddingSpinBox.blockSignals(True)
+        self.textPaddingSpinBox.setValue(float(getattr(font_format, 'text_padding', 0.0) or 0.0))
+        self.textPaddingSpinBox.blockSignals(False)
         self.autoFitFontSizeChecker.setChecked(bool(getattr(font_format, 'auto_fit_font_size', False)))
         self.opacityMainBox.setValue(font_format.opacity)
         text_on_path = getattr(font_format, 'text_on_path', 0)

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -14,6 +14,8 @@ from utils.textblock import TextBlock, FontFormat, TextAlignment, LineSpacingTyp
 from utils.text_layout import _merge_stub_lines_in_string
 from utils.imgproc_utils import xywh2xyxypoly, rotate_polygons
 from utils.fontformat import FontFormat, px2pt, pt2px
+from utils.config import pcfg
+from utils.text_rendering import estimate_text_bounds, first_missing_glyphs, merge_font_fallback_chain, resolve_writing_mode
 from .misc import td_pattern, table_pattern, pixmap2ndarray, ndarray2pixmap
 from .image_edit import ImageEditMode
 from .scene_textlayout import VerticalTextDocumentLayout, HorizontalTextDocumentLayout, SceneTextLayout
@@ -483,6 +485,18 @@ class TextBlkItem(QGraphicsTextItem):
         if self._display_rect is not None:
             br.setHeight(self._display_rect.height())
             br.setWidth(self._display_rect.width())
+        if self.fontformat is not None:
+            try:
+                fs = self.layout.max_font_size(to_px=True) if self.layout is not None else pt2px(self.document().defaultFont().pointSizeF())
+                stroke_pad = fs * max(0.0, float(getattr(self.fontformat, 'stroke_width', 0.0) or 0.0))
+                shadow_pad = fs * max(0.0, float(getattr(self.fontformat, 'shadow_radius', 0.0) or 0.0))
+                off = getattr(self.fontformat, 'shadow_offset', [0.0, 0.0]) or [0.0, 0.0]
+                shadow_pad += fs * max(abs(float(off[0] if len(off) > 0 else 0.0)), abs(float(off[1] if len(off) > 1 else 0.0)))
+                pad = max(0.0, stroke_pad + shadow_pad)
+                if pad > 0:
+                    br = br.adjusted(-pad, -pad, pad, pad)
+            except Exception:
+                pass
         return br
 
     def padding(self) -> float:
@@ -733,6 +747,55 @@ class TextBlkItem(QGraphicsTextItem):
             painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceOver)
         if skew_x != 0 or skew_y != 0:
             painter.restore()
+
+
+    def _render_diagnostics(self):
+        ff = self.fontformat
+        if ff is None:
+            return None
+        br = self.boundingRect()
+        fs = self.layout.max_font_size(to_px=True) if self.layout is not None else pt2px(self.document().defaultFont().pointSizeF())
+        mode = resolve_writing_mode(getattr(ff, 'writing_mode', 'auto'), self.toPlainText(), (br.width(), br.height()))
+        measured = estimate_text_bounds(
+            self.toPlainText(), fs, mode, br.width(), br.height(),
+            line_spacing=float(getattr(ff, 'line_spacing', 1.15) or 1.15),
+            letter_spacing=float(getattr(ff, 'letter_spacing', 1.0) or 1.0),
+            padding=float(getattr(ff, 'text_padding', 0.0) or 0.0),
+            stroke_width=float(getattr(ff, 'stroke_width', 0.0) or 0.0),
+            shadow_radius=float(getattr(ff, 'shadow_radius', 0.0) or 0.0),
+            shadow_offset=getattr(ff, 'shadow_offset', [0.0, 0.0]) or [0.0, 0.0],
+        )
+        families = merge_font_fallback_chain(getattr(ff, 'font_family', ''), self.toPlainText(), pcfg, getattr(ff, 'fallback_font_chain', ''))
+        missing = first_missing_glyphs(getattr(ff, 'font_family', ''), self.toPlainText()) if self.toPlainText() else []
+        return {
+            'mode': mode,
+            'measured': measured,
+            'overflow': measured[0] > br.width() or measured[1] > br.height(),
+            'fallback': ', '.join(families),
+            'missing': ''.join(missing),
+        }
+
+    def _draw_renderer_diagnostics_overlay(self, painter: QPainter):
+        if not bool(getattr(pcfg, 'render_diagnostics_overlay', False)):
+            return
+        diag = self._render_diagnostics()
+        if diag is None:
+            return
+        br = self.boundingRect()
+        painter.save()
+        painter.setCompositionMode(QPainter.CompositionMode.CompositionMode_SourceOver)
+        painter.setPen(QPen(QColor(255, 128, 0, 190) if diag['overflow'] else QColor(0, 180, 255, 160), 1.5 / max(0.01, self.get_scale()), Qt.PenStyle.DashLine))
+        painter.setBrush(QBrush(Qt.GlobalColor.transparent))
+        painter.drawRect(br)
+        measured_w, measured_h = diag['measured'][0], diag['measured'][1]
+        painter.setPen(QPen(QColor(255, 64, 64, 170), 1 / max(0.01, self.get_scale())))
+        painter.drawRect(QRectF(0, 0, measured_w, measured_h))
+        label = f"{diag['mode']} {measured_w:.0f}×{measured_h:.0f}"
+        if diag['missing']:
+            label += f" missing: {diag['missing']}"
+        painter.setPen(QColor(255, 128, 0) if diag['overflow'] else QColor(0, 128, 255))
+        painter.drawText(QPointF(2, max(10.0, 10.0 / max(0.01, self.get_scale()))), label)
+        painter.restore()
 
     def _text_mask_region(self):
         """Build QRegion from blk.text_mask for clipping (#1093 text eraser). Returns None if no mask or mask is full (no clip needed)."""
@@ -1101,6 +1164,20 @@ class TextBlkItem(QGraphicsTextItem):
 
     def set_fontformat(self, ffmat: FontFormat, set_char_format=False, set_stroke_width=True, set_effect=True):
         self.repainting = True
+        try:
+            from utils.text_rendering import normalize_vertical_punctuation, resolve_writing_mode
+            rect = self.absBoundingRect(qrect=True)
+            text = self.toPlainText()
+            resolved_mode = resolve_writing_mode(getattr(ffmat, 'writing_mode', 'auto'), text, (rect.width(), rect.height()))
+            ffmat.vertical = resolved_mode == 'vertical_rl'
+            if ffmat.vertical:
+                new_text = normalize_vertical_punctuation(text)
+                if new_text != text:
+                    self.setPlainText(new_text)
+                    if getattr(self, 'blk', None) is not None:
+                        self.blk.translation = new_text
+        except Exception:
+            pass
         if self.fontformat.vertical != ffmat.vertical:
             self.setVertical(ffmat.vertical)
 
@@ -1151,6 +1228,8 @@ class TextBlkItem(QGraphicsTextItem):
             self.setShadow(ffmat, repaint=False)
         if set_stroke_width:
             self.setStrokeWidth(ffmat.stroke_width, repaint_background=False)
+        if float(getattr(ffmat, 'text_padding', 0.0) or 0.0) > 0:
+            self.setPadding(float(getattr(ffmat, 'text_padding', 0.0) or 0.0))
         self.setOpacity(ffmat.opacity)
         
         alignment_qt_flag = [Qt.AlignmentFlag.AlignLeft, Qt.AlignmentFlag.AlignCenter, Qt.AlignmentFlag.AlignRight][ffmat.alignment]

--- a/utils/config.py
+++ b/utils/config.py
@@ -110,6 +110,7 @@ class ModuleConfig(Config):
     translation_soft_failure_continue: bool = True
     # Skip translation for pages that already have all blocks translated (non-empty translation). Speeds up re-runs.
     skip_already_translated: bool = False
+    skip_satisfied_pipeline_steps: bool = False
     # Optional: merge nearby text blocks using collision-based grouping (Dango-style). Off by default;  for word-level OCR or many small blocks.
     merge_nearby_blocks_collision: bool = False
     merge_nearby_blocks_gap_ratio: float = 1.5  # vertical expansion ratio for horizontal merge; 1.5 = Dango-style
@@ -566,6 +567,23 @@ class ProgramConfig(Config):
     manual_mode: bool = False
     # When True (default), full run and batch skip pages marked as "ignored" in the page list.
     skip_ignored_in_run: bool = True
+    # Automatically mark pages as translated when a pipeline run satisfies the enabled stage finish contract.
+    auto_mark_translated_pages: bool = True
+    # Rendering/text-formatting defaults and diagnostics.
+    render_default_writing_mode: str = "auto"
+    render_default_fit_mode: str = "shrink"
+    render_overflow_warnings: bool = True
+    render_diagnostics_overlay: bool = False
+    render_default_font_family: str = ""
+    render_default_stroke_width: float = 0.08
+    render_default_shadow_radius: float = 0.0
+    render_default_shadow_strength: float = 1.0
+    render_default_text_padding: float = 2.0
+    render_fallback_fonts_latin: str = "Arial, Noto Sans, DejaVu Sans"
+    render_fallback_fonts_cjk: str = "Noto Sans CJK JP, Noto Sans CJK SC, Yu Gothic, Microsoft YaHei"
+    render_fallback_fonts_korean: str = "Noto Sans CJK KR, Malgun Gothic"
+    render_fallback_fonts_rtl: str = "Noto Naskh Arabic, Arial, Segoe UI"
+    render_fallback_fonts_emoji: str = "Noto Color Emoji, Segoe UI Emoji, Apple Color Emoji"
     # Smooth scroll: animate scroll position on wheel (ms). 0 = off. 80–200 = subtle enhanced feel.
     smooth_scroll_duration_ms: int = 0
     # When True, briefly apply motion blur to scroll area viewport during scroll (can be costly).
@@ -685,7 +703,7 @@ CONFIG_KEY_ORDER = (
     "model_packages_enabled", "model_package_preset_ids",
     "dev_mode",
     "diagnostic_mode",
-    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run",
+    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_overflow_warnings", "render_diagnostics_overlay", "render_default_font_family", "render_default_stroke_width", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
     "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_run_macros",
     "huggingface_token", "translator_last_model_by_provider",

--- a/utils/fontformat.py
+++ b/utils/fontformat.py
@@ -69,9 +69,15 @@ class FontFormat(Config):
     italic: bool = False
     alignment: int = 0
     vertical: bool = False
+    # Manga writing mode: auto | horizontal_ltr | vertical_rl | rtl. `vertical` remains the renderer switch for compatibility.
+    writing_mode: str = "auto"
+    # Fit behavior used by layout/review: shrink | expand | preserve | balance.
+    fit_mode: str = "shrink"
     font_weight: int = None
     line_spacing: float = 1.2
     letter_spacing: float = 1.15
+    # Extra inset in image pixels, persisted per style/text box.
+    text_padding: float = 0.0
     opacity: float = 1.
     shadow_radius: float = 0.
     shadow_strength: float = 1.
@@ -107,6 +113,10 @@ class FontFormat(Config):
     text_box_corner_radius: float = 0.0
     # Box outline shape to match balloon: "", "round", "elongated", "narrow", "ellipse", "diamond", "square", "bevel", "pentagon", "point"
     text_box_shape: str = ""
+    # Optional per-style fallback chain. Empty = use renderer config fallback chain.
+    fallback_font_chain: str = ""
+    # Last applied manga preset id, for diagnostics/review.
+    manga_preset: str = ""
     # #35: per-character stroke color (list of [r,g,b], one per character; used for text-on-path)
     stroke_rgb_per_char: List = field(default=None)  # optional
 
@@ -127,6 +137,12 @@ class FontFormat(Config):
             if 'family' in da:
                 self.font_family = da['family']
 
+        try:
+            from utils.text_rendering import normalize_fit_mode, normalize_writing_mode
+            self.writing_mode = normalize_writing_mode(getattr(self, "writing_mode", "auto"))
+            self.fit_mode = normalize_fit_mode(getattr(self, "fit_mode", "shrink"))
+        except Exception:
+            pass
         self.font_weight = fix_fontweight_qt(self.font_weight)
         self.deprecated_attributes = {}
 

--- a/utils/layered_psd_export.py
+++ b/utils/layered_psd_export.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import os.path as osp
+import shutil
+from typing import Dict, List, Tuple
+
+from utils.io_utils import imread, imwrite
+
+
+def _safe_copy(src: str, dst: str) -> bool:
+    if not src or not osp.exists(src):
+        return False
+    os.makedirs(osp.dirname(dst), exist_ok=True)
+    shutil.copy2(src, dst)
+    return True
+
+
+def build_layered_psd_handoff(project, page_name: str, out_dir: str, final_image=None) -> Dict:
+    """Export helper layers + editable text metadata for rebuilding a PSD in Photoshop/GIMP.
+
+    This intentionally avoids writing a fake PSD when native editable PSD writing is unavailable.
+    The manifest and JSX preserve text, geometry, style, and helper layer paths so downstream
+    tools can create editable text layers instead of silently rasterizing text.
+    """
+    if not page_name:
+        raise ValueError("page_name is required")
+    os.makedirs(out_dir, exist_ok=True)
+    base = osp.splitext(osp.basename(page_name))[0]
+    layer_dir = osp.join(out_dir, f"{base}_layers")
+    os.makedirs(layer_dir, exist_ok=True)
+    warnings: List[str] = []
+    layers: Dict[str, str] = {}
+
+    orig = osp.join(project.directory, page_name)
+    if _safe_copy(orig, osp.join(layer_dir, "01_original" + osp.splitext(page_name)[1])):
+        layers["original"] = osp.relpath(osp.join(layer_dir, "01_original" + osp.splitext(page_name)[1]), out_dir)
+    else:
+        warnings.append("Original image was not found.")
+
+    inpainted_path = project.get_inpainted_path(page_name)
+    if _safe_copy(inpainted_path, osp.join(layer_dir, "02_inpainted.png")):
+        layers["inpainted"] = osp.relpath(osp.join(layer_dir, "02_inpainted.png"), out_dir)
+    else:
+        warnings.append("Inpainted/clean layer was not available.")
+
+    mask_path = project.get_mask_path(page_name)
+    if _safe_copy(mask_path, osp.join(layer_dir, "03_mask.png")):
+        layers["mask"] = osp.relpath(osp.join(layer_dir, "03_mask.png"), out_dir)
+    else:
+        warnings.append("Mask layer was not available.")
+
+    if final_image is not None:
+        final_path = osp.join(layer_dir, "05_final_composite.png")
+        imwrite(final_path, final_image, ext=".png")
+        layers["final_composite"] = osp.relpath(final_path, out_dir)
+    else:
+        result_path = project.get_result_path(page_name)
+        if _safe_copy(result_path, osp.join(layer_dir, "05_final_composite.png")):
+            layers["final_composite"] = osp.relpath(osp.join(layer_dir, "05_final_composite.png"), out_dir)
+        else:
+            warnings.append("Final rendered composite was not available; render the page first for a flattened reference layer.")
+
+    text_layers = []
+    for idx, blk in enumerate(project.pages.get(page_name, []) or []):
+        ff = getattr(blk, "fontformat", None)
+        xyxy = list(getattr(blk, "xyxy", [0, 0, 0, 0]) or [0, 0, 0, 0])
+        text_layers.append({
+            "name": f"translated_text_{idx + 1:03d}",
+            "text": getattr(blk, "translation", "") or "\n".join(getattr(blk, "text", []) or []),
+            "xyxy": xyxy,
+            "font_family": getattr(ff, "font_family", "") if ff else "",
+            "font_size_px": getattr(ff, "font_size", 24.0) if ff else 24.0,
+            "fill_rgb": getattr(ff, "frgb", [0, 0, 0]) if ff else [0, 0, 0],
+            "stroke_rgb": getattr(ff, "srgb", [0, 0, 0]) if ff else [0, 0, 0],
+            "stroke_width": getattr(ff, "stroke_width", 0.0) if ff else 0.0,
+            "writing_mode": getattr(ff, "writing_mode", "auto") if ff else "auto",
+            "alignment": getattr(ff, "alignment", 0) if ff else 0,
+            "line_spacing": getattr(ff, "line_spacing", 1.2) if ff else 1.2,
+            "letter_spacing": getattr(ff, "letter_spacing", 1.0) if ff else 1.0,
+            "opacity": getattr(ff, "opacity", 1.0) if ff else 1.0,
+        })
+    if not text_layers:
+        warnings.append("No translated text layers were found for this page.")
+
+    manifest = {
+        "format": "ballonstranslator.layered_psd_handoff.v1",
+        "page": page_name,
+        "layers": layers,
+        "text_layers": text_layers,
+        "warnings": warnings,
+        "notes": [
+            "This package preserves editable text metadata and helper layers.",
+            "Native PSD text-layer writing is not available in this Python build, so use the JSX script or manifest in Photoshop/GIMP.",
+        ],
+    }
+    manifest_path = osp.join(out_dir, f"{base}_psd_handoff.json")
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, ensure_ascii=False, indent=2)
+
+    jsx_path = osp.join(out_dir, f"{base}_rebuild_psd.jsx")
+    with open(jsx_path, "w", encoding="utf-8") as f:
+        f.write(_build_photoshop_jsx(manifest_path, manifest))
+    manifest["manifest_path"] = manifest_path
+    manifest["photoshop_jsx_path"] = jsx_path
+    return manifest
+
+
+def _build_photoshop_jsx(manifest_path: str, manifest: Dict) -> str:
+    lines = [
+        "// BallonsTranslator layered PSD handoff rebuild script",
+        "// Open the original/inpainted layer manually if your Photoshop version blocks file IO.",
+        f"// Manifest: {manifest_path}",
+        "var doc = app.documents.length ? app.activeDocument : null;",
+        "if (!doc) { alert('Open the original or inpainted page image first, then run this script.'); }",
+    ]
+    for layer in manifest.get("text_layers", []):
+        text = json.dumps(layer.get("text", ""))
+        name = json.dumps(layer.get("name", "translated_text"))
+        x1, y1, x2, y2 = (layer.get("xyxy") or [0, 0, 0, 0])[:4]
+        size_pt = max(1.0, float(layer.get("font_size_px", 24.0)) * 0.75)
+        lines.extend([
+            "if (doc) {",
+            "  var lyr = doc.artLayers.add();",
+            "  lyr.kind = LayerKind.TEXT;",
+            f"  lyr.name = {name};",
+            f"  lyr.textItem.contents = {text};",
+            f"  lyr.textItem.position = [{float(x1):.2f}, {float(y1):.2f}];",
+            f"  lyr.textItem.size = {size_pt:.2f};",
+            "}",
+        ])
+    lines.append("if (doc) { alert('Editable text layers created. Save as PSD from Photoshop.'); }")
+    return "\n".join(lines) + "\n"

--- a/utils/layout_review_agent.py
+++ b/utils/layout_review_agent.py
@@ -10,6 +10,13 @@ ActionType = Literal[
     "auto_fit",
     "center_in_bubble",
     "resize_to_fit_content",
+    "shrink_to_fit",
+    "switch_writing_mode",
+    "recenter",
+    "increase_padding",
+    "balance_lines",
+    "apply_manga_preset",
+    "flag_missing_glyphs",
 ]
 
 
@@ -46,6 +53,12 @@ class BlockSnapshot:
     font_size: float
     bubble_center: Optional[Tuple[float, float]] = None
     est_text_size: Optional[Tuple[float, float]] = None
+    writing_mode: str = "auto"
+    resolved_writing_mode: str = "horizontal_ltr"
+    overflow_status: bool = False
+    measured_bounds: Optional[Tuple[float, float]] = None
+    text_style: Dict[str, Any] = field(default_factory=dict)
+    font_fallback_warning: str = ""
 
 
 @dataclass
@@ -121,6 +134,9 @@ class LayoutReviewPlanner:
         est_w, est_h = blk.est_text_size or (0.0, 0.0)
         overflow_x = est_w > bw * 0.98
         overflow_y = est_h > bh * 0.98
+        if blk.overflow_status:
+            overflow_x = overflow_x or est_w > bw * 0.92
+            overflow_y = overflow_y or est_h > bh * 0.92
 
         score_before = 1.0
 
@@ -135,11 +151,26 @@ class LayoutReviewPlanner:
             )
             actions.append(
                 ReviewAction(
-                    action="auto_fit",
+                    action="shrink_to_fit",
                     block_index=blk.block_index,
-                    reason="Reduce font size to fit current box before resizing.",
+                    reason="Reduce font size using the selected fit policy before resizing.",
                 )
             )
+            actions.append(
+                ReviewAction(
+                    action="auto_fit",
+                    block_index=blk.block_index,
+                    reason="Compatibility action: reduce font size to fit current box before resizing.",
+                )
+            )
+            if (blk.text_style or {}).get("fit_mode") == "balance":
+                actions.append(
+                    ReviewAction(
+                        action="balance_lines",
+                        block_index=blk.block_index,
+                        reason="Rebalance line breaks to reduce overflow without changing wording.",
+                    )
+                )
             actions.append(
                 ReviewAction(
                     action="resize_to_fit_content",
@@ -191,6 +222,87 @@ class LayoutReviewPlanner:
             )
             score_before -= 0.15
 
+
+        if blk.font_fallback_warning:
+            issues.append(
+                ReviewIssue(
+                    code="missing_glyphs",
+                    severity="warning",
+                    message=f"Selected font may not render: {blk.font_fallback_warning}",
+                    score_penalty=0.12,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="flag_missing_glyphs",
+                    block_index=blk.block_index,
+                    args={"glyphs": blk.font_fallback_warning},
+                    reason="Flag missing glyphs for font fallback or font-family correction.",
+                )
+            )
+            score_before -= 0.12
+
+        style = blk.text_style or {}
+        padding = float(style.get("text_padding", 0.0) or 0.0)
+        stroke_width = float(style.get("stroke_width", 0.0) or 0.0)
+        if blk.resolved_writing_mode == "vertical_rl" and style.get("fit_mode") in (None, "", "preserve"):
+            issues.append(
+                ReviewIssue(
+                    code="vertical_manga_preset_recommended",
+                    severity="info",
+                    message="Vertical CJK text would benefit from the vertical manga bubble preset.",
+                    score_penalty=0.04,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="apply_manga_preset",
+                    block_index=blk.block_index,
+                    args={"preset": "vertical_cjk_bubble"},
+                    reason="Apply vertical CJK bubble spacing, stroke, alignment, and padding.",
+                )
+            )
+            score_before -= 0.04
+        if stroke_width > 0 and padding < 1.0:
+            issues.append(
+                ReviewIssue(
+                    code="low_padding_with_stroke",
+                    severity="info",
+                    message="Outlined text has little inset and may clip at the box edge.",
+                    score_penalty=0.05,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="increase_padding",
+                    block_index=blk.block_index,
+                    args={"padding": 2.0},
+                    reason="Add inset so stroke/shadow does not clip.",
+                )
+            )
+            score_before -= 0.05
+
+        # Mode sanity: auto-resolved vertical/RTL but persisted style is forced differently.
+        if blk.writing_mode not in ("auto", blk.resolved_writing_mode):
+            if blk.resolved_writing_mode in ("vertical_rl", "rtl"):
+                issues.append(
+                    ReviewIssue(
+                        code="writing_mode_mismatch",
+                        severity="info",
+                        message=f"Text appears better suited to {blk.resolved_writing_mode} writing mode.",
+                        score_penalty=0.08,
+                    )
+                )
+                actions.append(
+                    ReviewAction(
+                        action="switch_writing_mode",
+                        block_index=blk.block_index,
+                        args={"writing_mode": blk.resolved_writing_mode},
+                        reason="Switch writing mode to match script and box geometry.",
+                    )
+                )
+                score_before -= 0.08
+
         score_after = max(score_before + 0.2 * (1 if actions else 0), 0.0)
         return issues, actions, max(score_before, 0.0), min(score_after, 1.0)
 
@@ -204,6 +316,13 @@ def collect_actions_by_type(page_result: PageReviewResult) -> Dict[ActionType, L
         "auto_fit": [],
         "center_in_bubble": [],
         "resize_to_fit_content": [],
+        "shrink_to_fit": [],
+        "switch_writing_mode": [],
+        "recenter": [],
+        "increase_padding": [],
+        "balance_lines": [],
+        "apply_manga_preset": [],
+        "flag_missing_glyphs": [],
     }
     for blk in page_result.blocks:
         for action in blk.actions:
@@ -220,6 +339,13 @@ def collect_actions_from_list(actions: Sequence[ReviewAction]) -> Dict[ActionTyp
         "auto_fit": [],
         "center_in_bubble": [],
         "resize_to_fit_content": [],
+        "shrink_to_fit": [],
+        "switch_writing_mode": [],
+        "recenter": [],
+        "increase_padding": [],
+        "balance_lines": [],
+        "apply_manga_preset": [],
+        "flag_missing_glyphs": [],
     }
     for action in actions:
         grouped[action.action].append(action)

--- a/utils/proj_imgtrans.py
+++ b/utils/proj_imgtrans.py
@@ -205,6 +205,7 @@ class ProjImgTrans:
                 else:
                     img_info['finish_code'] = RunStatus.FIN_ALL
             img_info.setdefault('ignored', False)
+            img_info.setdefault('completion_state', 'todo')
             
         set_img_failed = False
         if 'current_img' in proj_dict:
@@ -223,7 +224,7 @@ class ProjImgTrans:
     def _ensure_image_info_entry(self, pagename: str):
         if pagename not in self._image_info:
             LOGGER.warning(f"Missing page progress entry for {pagename}; creating default progress state.")
-            self._image_info[pagename] = {'finish_code': 0, 'ignored': False}
+            self._image_info[pagename] = {'finish_code': 0, 'ignored': False, 'completion_state': 'todo'}
         return self._image_info[pagename]
 
     def get_page_progress(self, pagename: str):
@@ -232,6 +233,18 @@ class ProjImgTrans:
 
     def set_page_progress(self, pagename, code):
         self._ensure_image_info_entry(pagename)['finish_code'] = code 
+
+    def get_page_completion_state(self, pagename: str) -> str:
+        state = str(self._ensure_image_info_entry(pagename).get('completion_state', 'todo') or 'todo')
+        return state if state in {'todo', 'translated', 'reviewed', 'exported'} else 'todo'
+
+    def set_page_completion_state(self, pagename: str, state: str):
+        if pagename not in self.pages:
+            return
+        state = str(state or 'todo').strip().lower()
+        if state not in {'todo', 'translated', 'reviewed', 'exported'}:
+            state = 'todo'
+        self._ensure_image_info_entry(pagename)['completion_state'] = state
 
     def is_page_ignored(self, pagename: str) -> bool:
         """True if this page is marked to be skipped in full/batch run."""
@@ -366,7 +379,7 @@ class ProjImgTrans:
             self.pages[imgname] = []
             self._pagename2idx[imgname] = ii
             self._idx2pagename[ii] = imgname
-            self._image_info[imgname] = {'finish_code': 0, 'ignored': False}
+            self._image_info[imgname] = {'finish_code': 0, 'ignored': False, 'completion_state': 'todo'}
         self.set_current_img_byidx(0)
         self.save()
         

--- a/utils/shortcuts.py
+++ b/utils/shortcuts.py
@@ -69,7 +69,10 @@ SHORTCUT_SCHEMA: List[Tuple[str, str, str, str]] = [
     ("draw.hand", "H", "Drawing", "Hand tool (pan)"),
     ("draw.inpaint", "J", "Drawing", "Inpaint brush"),
     ("draw.pen", "B", "Drawing", "Pen tool"),
+    ("draw.text_eraser", "E", "Drawing", "Text eraser / repair depth brush"),
     ("draw.rect", "R", "Drawing", "Rectangle select"),
+    ("draw.brush_size_up", "]", "Drawing", "Increase brush size"),
+    ("draw.brush_size_down", "[", "Drawing", "Decrease brush size"),
 ]
 
 
@@ -123,3 +126,26 @@ def auto_resolve_shortcut_conflicts(shortcuts_map: Dict[str, str]) -> Dict[str, 
         for aid in ids[1:]:
             out[aid] = ''
     return out
+
+
+def shortcut_should_ignore_text_input(focus_widget) -> bool:
+    """True when single-key tool/navigation shortcuts should not fire because the user is typing."""
+    if focus_widget is None:
+        return False
+    name = focus_widget.__class__.__name__.lower()
+    if any(token in name for token in ("lineedit", "textedit", "plaintextedit", "spinbox", "combobox", "keysequenceedit")):
+        return True
+    if hasattr(focus_widget, "textInteractionFlags"):
+        try:
+            return bool(int(focus_widget.textInteractionFlags()))
+        except Exception:
+            return True
+    return False
+
+
+def is_single_key_sequence(key: str) -> bool:
+    k = (key or "").strip()
+    if not k:
+        return False
+    lowered = k.lower()
+    return "+" not in k and lowered not in {"pageup", "pagedown", "escape", "space", "delete", "backspace", "tab", "enter", "return"}

--- a/utils/structured_ocr_export.py
+++ b/utils/structured_ocr_export.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Optional
+
+
+def _as_list(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return [float(v) if isinstance(v, (int, float)) else v for v in value]
+    return value
+
+
+def _font_dict(block) -> dict:
+    fmt = getattr(block, "fontformat", None)
+    if fmt is None:
+        return {}
+    return {
+        "family": getattr(fmt, "font_family", ""),
+        "size_px": float(getattr(fmt, "font_size", 0.0) or 0.0),
+        "alignment": int(getattr(fmt, "alignment", 0) or 0),
+        "vertical": bool(getattr(fmt, "vertical", False)),
+        "bold": bool(getattr(fmt, "bold", False)),
+        "italic": bool(getattr(fmt, "italic", False)),
+        "stroke_width": float(getattr(fmt, "stroke_width", 0.0) or 0.0),
+    }
+
+
+def build_structured_ocr_export(project, pages: Optional[Iterable[str]] = None) -> dict:
+    """Build a stable JSON-serializable OCR/layout export for LLM and QA tools.
+
+    The schema intentionally mirrors project state instead of re-running OCR:
+    page metadata, block order, geometry, source/translation text, and render font
+    hints are exported exactly as currently stored.
+    """
+    page_names = list(pages) if pages is not None else list(getattr(project, "pages", {}) or {})
+    out_pages = []
+    image_info = getattr(project, "_image_info", {}) or {}
+    for page_index, page_name in enumerate(page_names):
+        blocks = list((getattr(project, "pages", {}) or {}).get(page_name, []) or [])
+        info = image_info.get(page_name, {}) if isinstance(image_info, dict) else {}
+        out_blocks = []
+        for block_index, block in enumerate(blocks):
+            text = block.get_text() if hasattr(block, "get_text") else getattr(block, "text", "")
+            out_blocks.append(
+                {
+                    "index": block_index,
+                    "xyxy": _as_list(getattr(block, "xyxy", None)),
+                    "lines": _as_list(getattr(block, "lines", None)),
+                    "angle": float(getattr(block, "angle", 0.0) or 0.0),
+                    "source_text": text or "",
+                    "translation": getattr(block, "translation", "") or "",
+                    "font": _font_dict(block),
+                    "label": getattr(block, "label", "") or "",
+                    "confidence": float(getattr(block, "confidence", 0.0) or 0.0),
+                }
+            )
+        completion = "todo"
+        if hasattr(project, "get_page_completion_state"):
+            completion = project.get_page_completion_state(page_name)
+        out_pages.append(
+            {
+                "index": page_index,
+                "name": page_name,
+                "width": int(info.get("width", 0) or 0),
+                "height": int(info.get("height", 0) or 0),
+                "ignored": bool(info.get("ignored", False)),
+                "finish_code": int(info.get("finish_code", 0) or 0),
+                "completion_state": completion,
+                "blocks": out_blocks,
+            }
+        )
+    return {
+        "schema": "ballonstranslator.structured_ocr.v1",
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "project": getattr(project, "directory", "") or "",
+        "current_page": getattr(project, "current_img", None),
+        "pages": out_pages,
+    }

--- a/utils/text_rendering.py
+++ b/utils/text_rendering.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import math
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+
+WRITING_MODE_AUTO = "auto"
+WRITING_MODE_HORIZONTAL_LTR = "horizontal_ltr"
+WRITING_MODE_VERTICAL_RL = "vertical_rl"
+WRITING_MODE_RTL = "rtl"
+WRITING_MODES = {
+    WRITING_MODE_AUTO,
+    WRITING_MODE_HORIZONTAL_LTR,
+    WRITING_MODE_VERTICAL_RL,
+    WRITING_MODE_RTL,
+}
+
+FIT_MODE_SHRINK = "shrink"
+FIT_MODE_EXPAND = "expand"
+FIT_MODE_PRESERVE = "preserve"
+FIT_MODE_BALANCE = "balance"
+FIT_MODES = {FIT_MODE_SHRINK, FIT_MODE_EXPAND, FIT_MODE_PRESERVE, FIT_MODE_BALANCE}
+
+CJK_RE = re.compile(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]")
+KOREAN_RE = re.compile(r"[\u1100-\u11ff\u3130-\u318f\uac00-\ud7af]")
+RTL_RE = re.compile(r"[\u0590-\u05ff\u0600-\u06ff\u0750-\u077f\u08a0-\u08ff]")
+OPENING_PUNCT = set("([{（［｛〈《「『【〔〖〝‘“")
+CLOSING_PUNCT = set(")]},.!?:;、。，．！？：；⁈⁉‼⁇…）］｝〉》」』】〕〗〟’”")
+VERTICAL_PUNCT_MAP = {
+    "?!": "⁈",
+    "!?": "⁉",
+    "!!": "‼",
+    "??": "⁇",
+    "...": "…",
+    "……": "…",
+    "，": "、",
+}
+VERTICAL_CENTER_PUNCT = set("、。，．・：；！？⁈⁉‼⁇…⋯")
+VERTICAL_ROTATE_PUNCT = set("—―ー～-()[]{}<>（）［］｛｝〈〉《》「」『』【】〔〕")
+
+MANGA_PRESETS = {
+    "default_manga_bubble": {
+        "label": "Default manga bubble",
+        "writing_mode": WRITING_MODE_AUTO,
+        "fit_mode": FIT_MODE_SHRINK,
+        "font_size": 24.0,
+        "stroke_width": 0.08,
+        "line_spacing": 1.12,
+        "letter_spacing": 1.05,
+        "alignment": 1,
+        "text_padding": 2.0,
+    },
+    "vertical_cjk_bubble": {
+        "label": "Vertical JP/CN bubble",
+        "writing_mode": WRITING_MODE_VERTICAL_RL,
+        "fit_mode": FIT_MODE_SHRINK,
+        "font_size": 22.0,
+        "stroke_width": 0.06,
+        "line_spacing": 1.08,
+        "letter_spacing": 1.0,
+        "alignment": 1,
+        "text_padding": 2.0,
+    },
+    "sfx_bold": {
+        "label": "SFX bold",
+        "writing_mode": WRITING_MODE_AUTO,
+        "fit_mode": FIT_MODE_EXPAND,
+        "font_size": 36.0,
+        "stroke_width": 0.14,
+        "line_spacing": 1.0,
+        "letter_spacing": 1.08,
+        "alignment": 1,
+        "bold": True,
+        "text_padding": 3.0,
+    },
+    "caption_box": {
+        "label": "Caption/narration box",
+        "writing_mode": WRITING_MODE_HORIZONTAL_LTR,
+        "fit_mode": FIT_MODE_BALANCE,
+        "font_size": 20.0,
+        "stroke_width": 0.0,
+        "line_spacing": 1.18,
+        "letter_spacing": 1.0,
+        "alignment": 0,
+        "text_padding": 4.0,
+    },
+    "small_aside": {
+        "label": "Small aside text",
+        "writing_mode": WRITING_MODE_AUTO,
+        "fit_mode": FIT_MODE_PRESERVE,
+        "font_size": 14.0,
+        "stroke_width": 0.04,
+        "line_spacing": 1.05,
+        "letter_spacing": 1.0,
+        "alignment": 1,
+        "text_padding": 1.0,
+    },
+}
+
+
+@dataclass
+class TextRenderDiagnostics:
+    resolved_writing_mode: str
+    overflow: bool = False
+    measured_bounds: Tuple[float, float] = (0.0, 0.0)
+    box_bounds: Tuple[float, float] = (0.0, 0.0)
+    missing_glyphs: List[str] = None
+    fallback_chain: str = ""
+    fit_mode: str = FIT_MODE_SHRINK
+    adjusted_font_size: float = 0.0
+    line_count: int = 0
+    column_count: int = 0
+
+    def to_dict(self) -> dict:
+        return {
+            "resolved_writing_mode": self.resolved_writing_mode,
+            "overflow": bool(self.overflow),
+            "measured_bounds": list(self.measured_bounds),
+            "box_bounds": list(self.box_bounds),
+            "missing_glyphs": list(self.missing_glyphs or []),
+            "fallback_chain": self.fallback_chain,
+            "fit_mode": self.fit_mode,
+            "adjusted_font_size": self.adjusted_font_size,
+            "line_count": self.line_count,
+            "column_count": self.column_count,
+        }
+
+
+def normalize_writing_mode(mode: Optional[str]) -> str:
+    mode = str(mode or WRITING_MODE_AUTO).strip().lower().replace("-", "_")
+    return mode if mode in WRITING_MODES else WRITING_MODE_AUTO
+
+
+def normalize_fit_mode(mode: Optional[str]) -> str:
+    mode = str(mode or FIT_MODE_SHRINK).strip().lower().replace("-", "_")
+    return mode if mode in FIT_MODES else FIT_MODE_SHRINK
+
+
+def contains_cjk(text: str) -> bool:
+    return bool(CJK_RE.search(text or ""))
+
+
+def contains_korean(text: str) -> bool:
+    return bool(KOREAN_RE.search(text or ""))
+
+
+def contains_rtl(text: str) -> bool:
+    return bool(RTL_RE.search(text or ""))
+
+
+def script_bucket(text: str) -> str:
+    text = text or ""
+    if contains_rtl(text):
+        return "rtl"
+    if contains_korean(text):
+        return "korean"
+    if contains_cjk(text):
+        return "cjk"
+    if any(ord(ch) > 0x1F000 for ch in text):
+        return "emoji"
+    return "latin"
+
+
+def resolve_writing_mode(mode: Optional[str], text: str, box_size: Optional[Tuple[float, float]] = None) -> str:
+    mode = normalize_writing_mode(mode)
+    if mode != WRITING_MODE_AUTO:
+        return mode
+    if contains_rtl(text):
+        return WRITING_MODE_RTL
+    w, h = box_size or (0.0, 0.0)
+    if contains_cjk(text) and h > max(w * 1.15, 1.0):
+        return WRITING_MODE_VERTICAL_RL
+    return WRITING_MODE_HORIZONTAL_LTR
+
+
+def normalize_vertical_punctuation(text: str) -> str:
+    out = text or ""
+    for src, dst in VERTICAL_PUNCT_MAP.items():
+        out = out.replace(src, dst)
+    return out
+
+
+def vertical_punctuation_class(ch: str) -> str:
+    if ch in VERTICAL_CENTER_PUNCT:
+        return "center"
+    if ch in VERTICAL_ROTATE_PUNCT:
+        return "rotate"
+    cat = unicodedata.category(ch or "")
+    if cat.startswith("P"):
+        return "punct"
+    return "normal"
+
+
+def _is_cjk_char(ch: str) -> bool:
+    return bool(CJK_RE.match(ch or ""))
+
+
+def kinsoku_wrap(text: str, max_chars: int) -> List[str]:
+    """CJK-friendly greedy wrap with basic kinsoku punctuation guards."""
+    text = (text or "").strip()
+    if not text:
+        return []
+    max_chars = max(1, int(max_chars or 1))
+    tokens: List[str] = []
+    buf = ""
+    for ch in text:
+        if ch == "\n":
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            tokens.append("\n")
+            continue
+        if ch.isspace():
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            continue
+        if _is_cjk_char(ch) or ch in OPENING_PUNCT or ch in CLOSING_PUNCT:
+            if buf:
+                tokens.append(buf)
+                buf = ""
+            tokens.append(ch)
+        else:
+            buf += ch
+    if buf:
+        tokens.append(buf)
+
+    lines: List[str] = []
+    cur = ""
+    for tok in tokens:
+        if tok == "\n":
+            if cur:
+                lines.append(cur)
+                cur = ""
+            continue
+        candidate = cur + tok
+        if cur and len(candidate) > max_chars:
+            if tok in CLOSING_PUNCT:
+                cur += tok
+                lines.append(cur)
+                cur = ""
+                continue
+            if cur[-1:] in OPENING_PUNCT:
+                cur += tok
+                continue
+            lines.append(cur)
+            cur = tok
+        else:
+            cur = candidate
+    if cur:
+        lines.append(cur)
+
+    for i in range(1, len(lines)):
+        while lines[i] and lines[i][0] in CLOSING_PUNCT and len(lines[i - 1]) < max_chars + 2:
+            lines[i - 1] += lines[i][0]
+            lines[i] = lines[i][1:]
+        if lines[i - 1].endswith(tuple(OPENING_PUNCT)) and lines[i]:
+            lines[i - 1] += lines[i][0]
+            lines[i] = lines[i][1:]
+    return [ln for ln in lines if ln]
+
+
+def balance_lines(text: str, max_chars: int) -> str:
+    lines = kinsoku_wrap(text, max_chars)
+    if len(lines) <= 2:
+        return "\n".join(lines) if lines else (text or "")
+    total = sum(len(ln) for ln in lines)
+    target = max(1, int(math.ceil(total / len(lines))))
+    return "\n".join(kinsoku_wrap(text, min(max_chars, max(target, max_chars // 2))))
+
+
+def vertical_columns(text: str, max_chars_per_column: int) -> List[str]:
+    """Return logical vertical-rl columns. Each string is top-to-bottom; list order is right-to-left."""
+    normalized = normalize_vertical_punctuation(text).replace("\n", "")
+    return kinsoku_wrap(normalized, max_chars_per_column)
+
+
+def estimate_text_bounds(
+    text: str,
+    font_size: float,
+    mode: str = WRITING_MODE_HORIZONTAL_LTR,
+    max_width: float = 0.0,
+    max_height: float = 0.0,
+    line_spacing: float = 1.15,
+    letter_spacing: float = 1.0,
+    padding: float = 0.0,
+    stroke_width: float = 0.0,
+    shadow_radius: float = 0.0,
+    shadow_offset: Sequence[float] | None = None,
+) -> Tuple[float, float, int, int]:
+    """Cheap renderer-independent bounds estimate including stroke/shadow/padding in pixels."""
+    text = text or ""
+    fs = max(1.0, float(font_size or 1.0))
+    mode = normalize_writing_mode(mode)
+    avg = fs * 0.56 * max(0.1, float(letter_spacing or 1.0))
+    cjk_avg = fs * max(0.1, float(letter_spacing or 1.0))
+    leading = fs * max(0.1, float(line_spacing or 1.0))
+    if mode == WRITING_MODE_VERTICAL_RL:
+        usable_h = max(1.0, float(max_height or fs * 8) - 2 * padding)
+        max_chars = max(1, int(usable_h / max(1.0, cjk_avg)))
+        cols = vertical_columns(text, max_chars)
+        measured_w = max(1, len(cols)) * leading
+        measured_h = max((len(c) for c in cols), default=0) * cjk_avg
+        line_count = max((len(c) for c in cols), default=0)
+        col_count = len(cols)
+    else:
+        usable_w = max(1.0, float(max_width or fs * 12) - 2 * padding)
+        max_chars = max(1, int(usable_w / max(1.0, avg)))
+        if mode == WRITING_MODE_RTL:
+            lines = kinsoku_wrap(text, max_chars)
+        elif contains_cjk(text):
+            lines = kinsoku_wrap(text, max_chars)
+        else:
+            raw = text.splitlines() or [text]
+            lines = []
+            for para in raw:
+                words = para.split()
+                cur = ""
+                for word in words or [para]:
+                    cand = word if not cur else cur + " " + word
+                    if cur and len(cand) > max_chars:
+                        lines.append(cur)
+                        cur = word
+                    else:
+                        cur = cand
+                if cur:
+                    lines.append(cur)
+        measured_w = max((len(ln) for ln in lines), default=0) * avg
+        measured_h = max(1, len(lines)) * leading
+        line_count = len(lines)
+        col_count = 0
+    sw_px = fs * max(0.0, float(stroke_width or 0.0))
+    shadow_offset = shadow_offset or (0.0, 0.0)
+    shadow_px = fs * max(0.0, float(shadow_radius or 0.0)) + fs * max(abs(float(shadow_offset[0] if len(shadow_offset) > 0 else 0.0)), abs(float(shadow_offset[1] if len(shadow_offset) > 1 else 0.0)))
+    extra = 2 * padding + 2 * sw_px + shadow_px
+    return measured_w + extra, measured_h + extra, line_count, col_count
+
+
+def fit_font_size_to_box(
+    text: str,
+    font_size: float,
+    box_size: Tuple[float, float],
+    fit_mode: str = FIT_MODE_SHRINK,
+    writing_mode: str = WRITING_MODE_AUTO,
+    min_font_size: float = 6.0,
+    max_font_size: float = 96.0,
+    line_spacing: float = 1.15,
+    letter_spacing: float = 1.0,
+    padding: float = 0.0,
+    stroke_width: float = 0.0,
+) -> Tuple[float, str, TextRenderDiagnostics]:
+    fit_mode = normalize_fit_mode(fit_mode)
+    box_w, box_h = box_size or (0.0, 0.0)
+    resolved = resolve_writing_mode(writing_mode, text, box_size)
+    text_out = text or ""
+    if fit_mode == FIT_MODE_BALANCE and resolved != WRITING_MODE_VERTICAL_RL:
+        avg = max(1.0, max(1.0, font_size) * 0.56 * max(0.1, letter_spacing))
+        text_out = balance_lines(text_out.replace("\n", ""), max(2, int(max(1.0, box_w - 2 * padding) / avg)))
+    if resolved == WRITING_MODE_VERTICAL_RL:
+        text_out = normalize_vertical_punctuation(text_out)
+    lo = max(1.0, float(min_font_size or 1.0))
+    hi = max(lo, float(max_font_size or 96.0))
+    current = max(lo, min(hi, float(font_size or lo)))
+
+    def over(size: float) -> Tuple[bool, Tuple[float, float, int, int]]:
+        b = estimate_text_bounds(text_out, size, resolved, box_w, box_h, line_spacing, letter_spacing, padding, stroke_width)
+        return b[0] > box_w or b[1] > box_h, b
+
+    if fit_mode == FIT_MODE_PRESERVE:
+        is_over, bounds = over(current)
+        diag = TextRenderDiagnostics(resolved, is_over, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, current, bounds[2], bounds[3])
+        return current, text_out, diag
+
+    target_largest = fit_mode in (FIT_MODE_EXPAND, FIT_MODE_BALANCE)
+    low, high = lo, hi if target_largest else current
+    best = current
+    for _ in range(14):
+        mid = (low + high) / 2.0
+        is_over, _ = over(mid)
+        if is_over:
+            high = mid
+        else:
+            best = mid
+            low = mid
+    if fit_mode == FIT_MODE_SHRINK:
+        best = min(current, best)
+    bounds = estimate_text_bounds(text_out, best, resolved, box_w, box_h, line_spacing, letter_spacing, padding, stroke_width)
+    overflow = bounds[0] > box_w or bounds[1] > box_h
+    diag = TextRenderDiagnostics(resolved, overflow, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, best, bounds[2], bounds[3])
+    return best, text_out, diag
+
+
+def first_missing_glyphs(font_family: str, text: str, limit: int = 8) -> List[str]:
+    """Best-effort glyph diagnostic using Qt when available; safe fallback otherwise."""
+    if not text:
+        return []
+    missing: List[str] = []
+    from qtpy.QtGui import QFont, QFontMetrics
+
+    font = QFont(font_family or "")
+    metrics = QFontMetrics(font)
+    for ch in text:
+        if ch.isspace() or ch in missing:
+            continue
+        ok = True
+        if hasattr(metrics, "inFontUcs4"):
+            ok = bool(metrics.inFontUcs4(ord(ch)))
+        elif hasattr(metrics, "inFont"):
+            ok = bool(metrics.inFont(ch))
+        if not ok:
+            missing.append(ch)
+            if len(missing) >= limit:
+                break
+    if not missing:
+        missing = [ch for ch in text if ch in {"□", "�"}][:limit]
+    return missing
+
+
+def fallback_chain_for_text(text: str, config_obj=None) -> str:
+    bucket = script_bucket(text)
+    if config_obj is None:
+        return ""
+    if bucket == "rtl":
+        return getattr(config_obj, "render_fallback_fonts_rtl", "")
+    if bucket == "korean":
+        return getattr(config_obj, "render_fallback_fonts_korean", "")
+    if bucket == "cjk":
+        return getattr(config_obj, "render_fallback_fonts_cjk", "")
+    if bucket == "emoji":
+        return getattr(config_obj, "render_fallback_fonts_emoji", "")
+    return getattr(config_obj, "render_fallback_fonts_latin", "")
+
+
+def merge_font_fallback_chain(primary_family: str, text: str, config_obj=None, override_chain: str = "") -> List[str]:
+    families: List[str] = []
+    for chunk in [primary_family, override_chain, fallback_chain_for_text(text, config_obj)]:
+        for family in str(chunk or "").split(','):
+            fam = family.strip()
+            if fam and fam not in families:
+                families.append(fam)
+    return families


### PR DESCRIPTION
### Motivation

- Bring BallonsTranslator Pro closer to Koharu's local-first staged workflow by adding auditable layout review, persistent page completion states, renderer-aware text controls, and safer automation endpoints. 
- Reduce unnecessary work by allowing runs to skip pages that already satisfy the enabled pipeline stages and by auto-marking pages as translated when appropriate. 
- Improve typesetting/QA for manga: explicit writing-mode, fit-mode, fallback diagnostics, vertical-CJK handling, and manga presets. 

### Description

- Added a renderer/text formatting utility module `utils/text_rendering.py` implementing writing-mode resolution, fit policies, vertical punctuation normalization, bounds estimation, fallback helpers, and manga presets. 
- Implemented auditable layout review flows with a user report dialog and selectable fixes via `ui/layout_review_report_dialog.py`, planner/provider enhancements in `utils/layout_review_agent.py`, and safe apply logic in `ui/scenetext_manager.py` so provider-driven fixes run through selection/undoable commands. 
- Persisted per-page `completion_state` in `ProjImgTrans` (todo/translated/reviewed/exported) and exposed page-list UI actions and styling for completion state in `ui/mainwindow.py` and `icons/page_completion.svg`. 
- Added option and UI to `ConfigPanel` to `skip_satisfied_pipeline_steps` and `auto_mark_translated_pages`, and implemented logic in the pipeline runner to skip already-satisfied pages and optionally auto-mark pages after a run. 
- Added batch text style override tooling (UI + backend) to apply fixed font family/size/alignment and optional auto-fit across page or project in `ui/mainwindow.py`. 
- Added structured OCR JSON export (`utils/structured_ocr_export.py`) plus menu/automation hooks and an icon `icons/structured_ocr_export.svg`. 
- Added a layered PSD handoff exporter (`utils/layered_psd_export.py`) and UI action to produce helper layers + editable text metadata + JSX rebuild script. 
- Extended local automation API handlers (`LocalAutomationApiServer`) with new endpoints: `render_current_page`, `list_rendering_issues`, `page_state`, and `export_structured_ocr`. 
- Extended font-formatting command handlers (`ui/fontformat_commands.py`) and font format model (`utils/fontformat.py`) with writing-mode, fit-mode, text padding, fallback chain, and manga preset support; added UI controls in `ui/text_panel.py` and renderer diagnostics overlay in `ui/textitem.py`. 
- Improved shortcut behavior to avoid firing single-key tools while typing and added drawing tool shortcuts and brush-size shortcuts in `utils/shortcuts.py` and `ui/mainwindow.py`. 
- Added docs: updated `docs/KOHARU_GAP_ANALYSIS.md` and new `docs/RENDERING_TEXT_FORMATTING.md` describing renderer/text formatting controls. 
- Added unit tests covering page completion, structured OCR export, text rendering helpers, and shortcut conflict detection in `tests/`.

### Testing

- Added and ran unit tests: `tests/test_proj_page_completion.py`, `tests/test_structured_ocr_export.py`, `tests/test_text_rendering.py`, and `tests/test_shortcuts_rendering.py`, and they passed locally. 
- Exercised the new UI flows (layout review report/apply, batch style override, structured OCR export, layered PSD handoff) via the main application automation hooks and confirmed the new automation endpoints return structured results during manual API calls. 
- Existing pipeline observability and automation tests were preserved and remain functional after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fa51d6e1b0832cbd1f982cc2b6968c)