### PR TITLE
Locale-aware uppercase, ink-clip/preset fit diagnostics, editor padding, recent_projects API, and layout QA enhancements

### DIFF
--- a/docs/KOHARU_GAP_ANALYSIS.md
+++ b/docs/KOHARU_GAP_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Koharu Gap Analysis and Implementation Audit
 
-_Last audited: 2026-05-07 against BallonsTranslator-Pro current branch and public `mayocream/koharu` issues via GitHub REST API (651 all-state issues/PRs scanned, including #660 through #1)._
+_Last audited: 2026-05-07 against BallonsTranslator-Pro current branch and public `mayocream/koharu` issues via GitHub REST API (652 all-state issues/PRs scanned, including #660 through #1)._
 
 ## Audit scope
 
@@ -16,6 +16,17 @@ The repository already had substantial Koharu-inspired foundations before this p
 | Effect-aware fit diagnostics | Fit-to-box now accounts for shadow radius/offset as well as stroke/padding, and diagnostics include recommended box size plus a scale hint for resize/review actions. | #630 centering/fitting inconsistencies, #637 mask/collision-aware sizing groundwork, #640 fixed font options | `utils/text_rendering.py`, `utils/rendering_qa.py`, `tests/test_text_rendering.py` |
 | QA/API export metadata | Rendering QA now exposes recommended box size/scale hints, while structured OCR exports include writing mode, fit mode, line-break strategy, source order, and resolved reading order for headless agents. | #649/#648 project-wide text fixes, #660 reading order, #612 API workflow | `utils/rendering_qa.py`, `utils/structured_ocr_export.py`, `ui/mainwindow.py` |
 | Archive export workflow | Batch export dialog now supports manga-reader CBZ archives in addition to ZIP, with clearer archive wording and backend status messages. | #626 streaming ZIP export, #610 bulk comic/archive workflow, #591 export/interoperability requests | `ui/export_dialog.py`, `ui/mainwindow.py` |
+
+## Latest implementation pass (2026-05-07 continued again)
+
+| Area | Implemented | Koharu issue inspiration | Files |
+| --- | --- | --- | --- |
+| Text editor comfort / onboarding polish | Added persistent side text-editor viewport top padding with a live Config control, fixing the first/selected visible textbox feeling pressed into the top edge while preserving compact list density even after scrolling. | #519 workflow/editor polish, #612 fewer-friction setup/API workflow | `ui/textedit_area.py`, `ui/configpanel.py`, `utils/config.py` |
+| Script-aware uppercase lettering | Replaced raw `.upper()` usage in translation post-processing and selected-block uppercase actions with dependency-free locale/script-aware casing that preserves CJK/RTL text and handles Turkish/Azeri dotted-i. | #572/#567 universal locale-aware uppercase conversion | `utils/text_rendering.py`, `ui/mainwindow.py`, `tests/test_text_rendering.py` |
+| Ink-safe typography diagnostics | Renderer fit diagnostics now report `ink_clip_risk` plus `preset_suggestion`; Typography QA and layout review can propose/apply padding and preset actions when strokes/shadows may clip or geometry suggests SFX/caption/vertical presets. | #594 advanced formatting, #630 centering/fitting, #649/#648 project-wide style repair | `utils/text_rendering.py`, `utils/rendering_qa.py`, `utils/layout_review_agent.py`, `ui/scenetext_manager.py`, `tests/test_text_rendering.py` |
+| Configurable vertical punctuation behavior | Vertical layout plans now carry and honor runtime `rotate_latin` and `punctuation_hang` toggles, and QA forwards Config settings into the plan metadata for API/export parity. | #624 advanced typesetting/kinsoku, #602/#583 RTL/CJK layout fidelity | `utils/text_rendering.py`, `utils/rendering_qa.py`, `tests/test_text_rendering.py` |
+| Automation onboarding workflow | Added `POST /recent_projects` with path/existence/project-json metadata so local tools and first-run helpers can list reopenable projects before running pipeline actions. | #612 granular workflow/API, #610 project workflow, #519 fewer manual processing steps | `ui/mainwindow.py` |
+
 
 ## Follow-up implementation pass (2026-05-07 continued)
 
@@ -38,13 +49,13 @@ The repository already had substantial Koharu-inspired foundations before this p
 
 | Workstream | Status | Implemented | Partial / deferred |
 | --- | --- | --- | --- |
-| Advanced manga text rendering / formatting | **Partially implemented and advanced this pass** | Writing modes, vertical CJK plans, kinsoku/balanced wrapping, tate-chu-yoko hints, vertical punctuation offset/rotation/bracket hints, fallback chains, manga presets, fit clamps, effect-aware safe bounds, shadow-aware fit diagnostics, recommended resize hints, and live QA. | Full HarfBuzz/ICU shaping, OpenType vertical alternates, and true ink-bound measurement remain deferred pending optional dependency/runtime design. |
+| Advanced manga text rendering / formatting | **Partially implemented and advanced this pass** | Writing modes, vertical CJK plans, kinsoku/balanced wrapping, tate-chu-yoko hints, configurable latin-rotation/punctuation-hang metadata, vertical punctuation offset/rotation/bracket hints, fallback chains, manga presets, script-aware uppercase conversion, fit clamps, ink-clip risk diagnostics, effect-aware safe bounds, shadow-aware fit diagnostics, recommended resize hints, and live QA. | Full HarfBuzz/ICU shaping, OpenType vertical alternates, and true ink-bound measurement remain deferred pending optional dependency/runtime design. |
 | Layout review agent | **Implemented/verified and advanced** | Selected/page review, heuristic fallback, settings, action application, recommended-box resize, vertical punctuation normalization, RTL alignment, contrast stroke, and richer QA metadata are present. | Visual before/after previews and true mask-aware squeezing still need rendered snapshots/mask geometry. |
 | PSD/export | **Partially implemented and improved** | Layered PSD handoff manifests/Photoshop JSX, editable text metadata, export manifests, current-page render API, ZIP/CBZ batch archive workflow, and optional clean/mask helper image export. | Native PSD text layer writer and streaming archive writer remain deferred. |
 | Settings/config | **Implemented and improved** | Dedicated rendering defaults include font, writing mode, fit mode, line break, reading order, effects, overflow warnings, diagnostics overlay, and script fallback chains. | Per-project profile presets and model/provider wizard remain future work. |
 | Keyboard/tool UX | **Partially implemented** | Existing shortcut conflict tests and text-field guard behavior remain in place; no shortcut ambiguity changes were introduced in this pass. | Broader one-owner QAction/QShortcut cleanup is deferred to a focused shortcut pass. |
-| Automation/API/headless | **Implemented and improved** | Existing local API supports project open/run/edit/export/review/render/QA/fixes; new `list_pages` route exposes page states and ordered textboxes for agents. | Event streaming/progress subscription and MCP server parity are deferred. |
-| Workflow enhancements from issues | **Improved this pass** | Reading-order-aware exports/API reduce manual agent cleanup; ZIP/CBZ archive export reduces comic delivery steps. | Bulk parent/child CBZ project processing and provider/model setup wizard are next candidates. |
+| Automation/API/headless | **Implemented and improved** | Existing local API supports project open/run/edit/export/review/render/QA/fixes; `list_pages` exposes page states and ordered textboxes, and `recent_projects` exposes reopenable project metadata for agents/onboarding flows. | Event streaming/progress subscription and MCP server parity are deferred. |
+| Workflow enhancements from issues | **Improved this pass** | Reading-order-aware exports/API reduce manual agent cleanup; ZIP/CBZ archive export reduces comic delivery steps; the side text editor now has configurable comfort padding; `recent_projects` helps agents/onboarding flows reopen projects safely. | Bulk parent/child CBZ project processing and provider/model setup wizard are next candidates. |
 
 ## Issue-inspired items implemented in this pass
 
@@ -54,7 +65,9 @@ The repository already had substantial Koharu-inspired foundations before this p
 - **#649 / #648 project-wide style cleanup**: extended batch style override and automation so users can adjust font/style/fitting fields across current page or project while optionally limiting changes to auto-sized boxes.
 - **#587 / #558 helper export handoff**: batch export can now include clean/inpainted pages and masks beside rendered pages for downstream PSD/GIMP review.
 - **#591 SVG/XCF interop request**: added an SVG text handoff path with editable translated text, vertical/RTL attributes, and companion diagnostics manifest.
-- **#637/#630/#624 review fixes**: layout review can now turn fit diagnostics into targeted resize actions and apply vertical punctuation, RTL alignment, and contrast-stroke fixes.
+- **#637/#630/#624 review fixes**: layout review can now turn fit diagnostics into targeted resize actions and apply vertical punctuation, RTL alignment, contrast-stroke, ink-safe padding, and preset-suggestion fixes.
+- **#572/#567 locale uppercase**: uppercase post-processing and context actions are now script-aware instead of applying raw uppercase to every character.
+- **#612/#519 workflow polish**: automation can list recent projects and the side text editor has configurable breathing room for faster editing.
 
 ## Deferred with reasons
 

--- a/docs/KOHARU_ISSUE_BACKLOG.md
+++ b/docs/KOHARU_ISSUE_BACKLOG.md
@@ -1,6 +1,17 @@
 # Koharu Issue Backlog for BallonsTranslator-Pro
 
-_Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issues/PRs, 651 all-state items scanned. This backlog is maintained as an implementation source, not a one-time audit._
+_Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issues/PRs, 652 all-state items scanned. This backlog is maintained as an implementation source, not a one-time audit._
+
+## Newly implemented / advanced in this pass (continued 2026-05-07)
+
+| Issue | Title | Category | Relevant labels | Maps to BT-Pro? | Implemented here? | Priority | Implementation notes | Deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [#572](https://github.com/mayocream/koharu/pull/572) / [#567](https://github.com/mayocream/koharu/pull/567) | Universal locale-aware uppercase conversion | Text rendering / typography / fonts | area: renderer | yes | **yes for dependency-free script-aware path** | P0 | Added `locale_aware_upper()` and wired translation post-processing plus selected-text uppercase actions through it so Latin/Greek/Cyrillic text uppercases without damaging CJK/RTL runs; Turkish/Azeri dotted-i is handled explicitly. | Full ICU locale casing remains deferred until optional dependency policy is settled. |
+| [#594](https://github.com/mayocream/koharu/issues/594) | Advanced text formatting (gradients, line spacing, kerning) | Text rendering / typography / fonts; Text fitting / layout / overflow | renderer, feature request, font | yes | **advanced** | P0 | Fit diagnostics now expose `ink_clip_risk` and `preset_suggestion`; QA/layout review convert those into padding and manga-preset actions for safer outlined/shadowed lettering. | Native kerning/gradient text paint remains a renderer pass. |
+| [#624](https://github.com/mayocream/koharu/pull/624) | Advanced Typesetting / Kinsoku Shori | Vertical CJK / RTL / punctuation | dependencies, area: renderer | yes | **advanced** | P0 | Vertical layout plans now honor configurable latin rotation and punctuation-hanging toggles, and QA forwards the runtime settings into diagnostics/API output. | OpenType vertical alternates and HarfBuzz shaping remain deferred. |
+| [#612](https://github.com/mayocream/koharu/pull/612) | Granular pipeline control and batch process dialog | Automation/API/headless/MCP; UI/UX/editor workflow | area: ui | yes | **advanced** | P1 | Added `POST /recent_projects` so headless/onboarding clients can list valid recent projects with existence metadata before opening/running. | Event streaming and full MCP parity remain deferred. |
+| [#519](https://github.com/mayocream/koharu/issues/519) | Shortcuts for processing | Settings/config/keybinds; UI/UX/editor workflow | ui, feature request, workflow | yes | partial → **workflow polish advanced** | P1 | Fixed the side text editor comfort issue with persistent viewport top padding and a live settings control, improving editing ergonomics without adding shortcut ambiguity. | Broader shortcut ownership cleanup remains a focused future pass. |
+
 
 ## Implemented / advanced in this pass
 
@@ -76,11 +87,12 @@ _Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issue
 
 ## Next batch candidates
 
-1. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
-2. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
-3. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
-4. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
-5. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
-6. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
-7. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
-8. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).
+1. True ink-bound glyph measurement / OpenType shaping for clipping-free advanced formatting (#594/#572/#624).
+2. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
+3. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
+4. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
+5. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
+6. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
+7. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
+8. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
+9. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -138,3 +138,12 @@ For vector-editor interoperability, **Tools → Export → Export SVG text hando
 ## Layout review resize and punctuation actions
 
 The layout review agent now consumes effect-aware `recommended_box_size` diagnostics. When text cannot fit safely after stroke/shadow/padding are considered, review can propose a targeted **resize to recommended box** action instead of only running generic auto-fit. It also proposes vertical punctuation normalization, RTL right-alignment, low-contrast outline application, and low-quality-score flags so the same conservative fixes are available from UI review, project QA, and automation.
+
+
+## Latest text-formatting and workflow additions
+
+- **Script-aware uppercase:** automatic uppercase post-processing and the selected-block **To uppercase** action now use `locale_aware_upper()`. Latin/Greek/Cyrillic runs are uppercased, CJK/RTL/emoji runs are preserved, and Turkish/Azeri dotted-i casing is handled without requiring ICU.
+- **Ink-safe diagnostics:** fit diagnostics include `ink_clip_risk` when stroke, glow, shadow, or padding leaves too little safe edge margin. Typography QA and layout review can turn that into an **increase padding** action. Diagnostics also include a `preset_suggestion` so SFX, caption, and vertical CJK boxes can be surfaced as one-click preset fixes.
+- **Configurable vertical plans:** `vertical_layout_plan()` now records whether latin glyph rotation and punctuation hanging were enabled, and Typography QA uses the live Config values. This makes UI, API, SVG/PSD handoff, and tests agree on vertical punctuation intent.
+- **Editor comfort setting:** Config → General → Rendering / Text Formatting includes **Text editor top padding**. It updates the side text editor list immediately, fixing the cramped first-visible-row feel even after scrolling while keeping dense manga editing workflows fast.
+- **Automation workflow helper:** local automation clients can call `POST /recent_projects` to retrieve recent project paths, existence checks, and JSON/folder type before opening or running a project.

--- a/tests/test_text_rendering.py
+++ b/tests/test_text_rendering.py
@@ -185,3 +185,33 @@ def test_split_long_word_respects_soft_hyphen_boundaries():
     parts = split_long_word("extra­ordinary", 7)
     assert len(parts) >= 2
     assert all("­" not in p for p in parts)
+
+
+def test_locale_aware_upper_keeps_cjk_and_handles_turkish_i():
+    from utils.text_rendering import locale_aware_upper
+    assert locale_aware_upper("hello 魔法 i", "en") == "HELLO 魔法 I"
+    assert locale_aware_upper("istanbul ı", "tr") == "İSTANBUL I"
+
+
+def test_suggest_manga_preset_and_ink_clip_risk():
+    from utils.text_rendering import suggest_manga_preset, ink_clip_risk
+    assert suggest_manga_preset("ドン!!", (80, 180), "auto") == "vertical_cjk_bubble"
+    assert suggest_manga_preset("BOOM!!", (90, 70), "horizontal_ltr") == "sfx_bold"
+    assert ink_clip_risk((100, 40), (99, 39), 4) is True
+
+
+def test_vertical_layout_plan_respects_rotate_and_hang_toggles():
+    plan = vertical_layout_plan("A、", 4, font_size=18, rotate_latin=False, punctuation_hang=False)
+    latin = next(g for g in plan["glyphs"] if g["char"] == "A")
+    comma = next(g for g in plan["glyphs"] if g["char"] == "、")
+    assert latin["rotate"] is False
+    assert comma["hang"] is False
+    assert plan["rotate_latin"] is False
+    assert plan["punctuation_hang"] is False
+
+
+def test_fit_diagnostics_expose_clip_risk_and_preset_suggestion():
+    _size, _text, diag = fit_font_size_to_box("BOOM!!", 36, (80, 30), FIT_MODE_PRESERVE, stroke_width=0.2, padding=0)
+    d = diag.to_dict()
+    assert d["ink_clip_risk"] is True
+    assert d["preset_suggestion"] in {"sfx_bold", "caption_box", "default_manga_bubble"}

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -919,6 +919,15 @@ class ConfigPanel(Widget):
             discription=self.tr('Draw text box, measured bounds, writing mode, and missing-glyph warnings on the canvas.')
         )
         self.render_diagnostics_overlay_checker.stateChanged.connect(self.on_render_diagnostics_overlay_changed)
+        self.text_editor_top_padding_spin = QSpinBox(self)
+        self.text_editor_top_padding_spin.setRange(0, 80)
+        self.text_editor_top_padding_spin.setSingleStep(2)
+        self.text_editor_top_padding_spin.valueChanged.connect(self.on_text_editor_top_padding_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.text_editor_top_padding_spin,
+            self.tr('Text editor top padding'),
+            discription=self.tr('Adds breathing room above the left text editor list so the first textbox is not pressed against the window edge.')
+        ))
         self.render_fallback_latin_edit = QLineEdit(self)
         self.render_fallback_latin_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_latin', text))
         generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_latin_edit, self.tr('Latin fallback fonts'), discription=self.tr('Comma-separated fallback font families.')))
@@ -1869,6 +1878,16 @@ class ConfigPanel(Widget):
         pcfg.render_diagnostics_overlay = self.render_diagnostics_overlay_checker.isChecked()
     def on_render_fallback_changed(self, attr: str, text: str):
         setattr(pcfg, attr, text or '')
+    def on_text_editor_top_padding_changed(self):
+        pcfg.text_editor_top_padding = int(self.text_editor_top_padding_spin.value())
+        try:
+            parent = self.parent()
+            while parent is not None and not hasattr(parent, 'textPanel'):
+                parent = parent.parent()
+            if parent is not None and hasattr(parent.textPanel, 'textEditList'):
+                parent.textPanel.textEditList.refreshComfortPadding()
+        except Exception:
+            pass
 
     def on_fontcolor_flag_changed(self):
         pcfg.let_fntcolor_flag = self.let_fntcolor_combox.currentIndex()
@@ -2093,6 +2112,8 @@ class ConfigPanel(Widget):
             self.render_default_text_padding_spin.setValue(float(getattr(pcfg, 'render_default_text_padding', 2.0)))
             self.render_overflow_warnings_checker.setChecked(bool(getattr(pcfg, 'render_overflow_warnings', True)))
             self.render_diagnostics_overlay_checker.setChecked(bool(getattr(pcfg, 'render_diagnostics_overlay', False)))
+            if hasattr(self, 'text_editor_top_padding_spin'):
+                self.text_editor_top_padding_spin.setValue(int(getattr(pcfg, 'text_editor_top_padding', 14) or 0))
             self.render_fallback_latin_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_latin', '') or ''))
             self.render_fallback_cjk_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_cjk', '') or ''))
             self.render_fallback_korean_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_korean', '') or ''))

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -74,6 +74,7 @@ from utils.image_colorization import apply_colorization
 from utils.structured_ocr_export import build_structured_ocr_export
 from utils.layered_psd_export import build_layered_psd_handoff
 from utils.svg_text_export import build_svg_text_handoff
+from utils.text_rendering import locale_aware_upper
 from utils.local_automation_api import LocalAutomationApiServer
 from utils.model_manager import get_available_module_keys
 from modules.llm_quality import enforce_glossary, back_translation_drift_score
@@ -863,6 +864,7 @@ class MainWindow(mainwindow_cls):
             'layout_review': self._api_layout_review,
             'page_state': self._api_page_state,
             'list_pages': self._api_list_pages,
+            'recent_projects': self._api_recent_projects,
             'export_structured_ocr': self._api_export_structured_ocr,
             'render_current_page': self._api_render_current_page,
             'list_rendering_issues': self._api_list_rendering_issues,
@@ -888,6 +890,23 @@ class MainWindow(mainwindow_cls):
             raise ValueError('path is required')
         self.OpenProj(path)
         return {'opened': path}
+
+    def _api_recent_projects(self, body: dict):
+        return self._api_call_ui(self._api_recent_projects_ui, body)
+
+    def _api_recent_projects_ui(self, body: dict):
+        import os.path as _osp
+        max_items = int((body or {}).get('limit', getattr(pcfg, 'recent_proj_list_max', 14)) or 14)
+        entries = []
+        for path in list(getattr(self.leftBar, 'recent_proj_list', []) or [])[:max(0, max_items)]:
+            path = str(path or '')
+            entries.append({
+                'path': path,
+                'exists': bool(_osp.exists(path)),
+                'is_project_json': path.lower().endswith('.json'),
+                'name': _osp.basename(path.rstrip(_osp.sep)) or path,
+            })
+        return {'recent_projects': entries, 'count': len(entries)}
 
     def _api_run_pipeline(self, body: dict):
         return self._api_call_ui(self._api_run_pipeline_ui, body)
@@ -4545,7 +4564,7 @@ class MainWindow(mainwindow_cls):
         for blk in blk_list:
             blk.translation = self.mtSubWidget.sub_text(blk.translation)
             if pcfg.let_uppercase_flag:
-                blk.translation = blk.translation.upper()
+                blk.translation = locale_aware_upper(blk.translation, getattr(pcfg.module, 'translate_target', ''))
 
     def on_pagtrans_finished(self, page_index: int):
         blk_list = self.imgtrans_proj.get_blklist_byidx(page_index)
@@ -5604,10 +5623,10 @@ class MainWindow(mainwindow_cls):
         for blkitem in blks:
             blk = blkitem.blk
             pw = self.st_manager.pairwidget_list[blkitem.idx]
-            src = pw.e_source.toPlainText().upper()
-            trans = pw.e_trans.toPlainText().upper()
+            src = locale_aware_upper(pw.e_source.toPlainText(), getattr(pcfg.module, 'translate_source', ''))
+            trans = locale_aware_upper(pw.e_trans.toPlainText(), getattr(pcfg.module, 'translate_target', ''))
             if getattr(blk, "text", None) and isinstance(blk.text, list):
-                blk.text = [line.upper() for line in blk.text]
+                blk.text = [locale_aware_upper(line, getattr(pcfg.module, 'translate_source', '')) for line in blk.text]
             blk.translation = trans
             pw.e_source.setPlainText(src)
             pw.e_trans.setPlainText(trans)

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1299,6 +1299,67 @@ class SceneTextManager(QObject):
             self._scale_font_to_fit_box(blkitem)
         self.canvas.push_undo_command(AutoLayoutCommand(selected_blks, old_rect_lst, old_html_lst, trans_widget_lst))
 
+    def _layout_review_snapshot_for_item(self, blk: TextBlkItem) -> BlockSnapshot:
+        """Build a renderer-aware snapshot for the layout review agent."""
+        abr = blk.absBoundingRect(qrect=True)
+        doc = blk.document()
+        est = None
+        if doc is not None:
+            ds = doc.size()
+            est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
+        text = blk.toPlainText()
+        ff = blk.fontformat
+        box_size = (max(1.0, float(abr.width())), max(1.0, float(abr.height())))
+        try:
+            _fit_size, _fit_text, fit_diag = fit_font_size_to_box(
+                text,
+                max(1.0, float(getattr(ff, 'font_size', blk.font().pointSizeF() or blk.font().pointSize() or 1.0) or 1.0)),
+                box_size,
+                getattr(ff, 'fit_mode', 'shrink'),
+                getattr(ff, 'writing_mode', 'auto'),
+                padding=float(getattr(ff, 'text_padding', 0.0) or 0.0),
+                stroke_width=float(getattr(ff, 'stroke_width', 0.0) or 0.0),
+                line_spacing=float(getattr(ff, 'line_spacing', 1.2) or 1.2),
+                letter_spacing=float(getattr(ff, 'letter_spacing', 1.0) or 1.0),
+                line_break_strategy=getattr(ff, 'line_break_strategy', 'auto'),
+                shadow_radius=float(getattr(ff, 'shadow_radius', 0.0) or 0.0),
+                shadow_offset=getattr(ff, 'shadow_offset', [0.0, 0.0]) or [0.0, 0.0],
+            )
+            fit_dict = fit_diag.to_dict()
+        except Exception:
+            fit_dict = {}
+        style = {
+            'font_family': getattr(ff, 'font_family', ''),
+            'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(ff, 'font_family', ''), text, pcfg, getattr(ff, 'fallback_font_chain', ''))),
+            'fit_mode': getattr(ff, 'fit_mode', 'shrink'),
+            'stroke_width': getattr(ff, 'stroke_width', 0.0),
+            'text_padding': getattr(ff, 'text_padding', 0.0),
+            'line_spacing': getattr(ff, 'line_spacing', 1.2),
+            'letter_spacing': getattr(ff, 'letter_spacing', 1.0),
+            'line_break_strategy': getattr(ff, 'line_break_strategy', 'auto'),
+            'alignment': getattr(ff, 'alignment', 0),
+            'recommended_box_size': fit_dict.get('recommended_box_size', []),
+            'box_scale_hint': fit_dict.get('box_scale_hint', 1.0),
+            'ink_clip_risk': fit_dict.get('ink_clip_risk', False),
+            'preset_suggestion': fit_dict.get('preset_suggestion', ''),
+            'safe_inner_bounds': fit_dict.get('safe_inner_bounds', []),
+        }
+        return BlockSnapshot(
+            block_index=blk.idx,
+            xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
+            text=text,
+            font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
+            est_text_size=est,
+            bubble_center=self._estimate_block_bubble_center(blk),
+            writing_mode=getattr(ff, 'writing_mode', 'auto'),
+            resolved_writing_mode=resolve_writing_mode(getattr(ff, 'writing_mode', 'auto'), text, box_size),
+            overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
+            measured_bounds=est,
+            text_style=style,
+            font_fallback_warning=', '.join(missing_glyphs_after_fallback(getattr(ff, 'font_family', ''), text, pcfg, getattr(ff, 'fallback_font_chain', ''))),
+            quality_score=float(fit_dict.get('quality_score', 1.0) or 1.0),
+        )
+
     def review_and_fix_selected_textboxes(
         self,
         max_iters: int = 2,
@@ -1317,39 +1378,7 @@ class SceneTextManager(QObject):
         for i in range(max(1, int(max_iters))):
             snapshots: List[BlockSnapshot] = []
             for blk in selected:
-                abr = blk.absBoundingRect(qrect=True)
-                doc = blk.document()
-                est = None
-                if doc is not None:
-                    ds = doc.size()
-                    est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
-                bubble_center = self._estimate_block_bubble_center(blk)
-                snapshots.append(
-                    BlockSnapshot(
-                        block_index=blk.idx,
-                        xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
-                        text=blk.toPlainText(),
-                        font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
-                        est_text_size=est,
-                        bubble_center=bubble_center,
-                        writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
-                        resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
-                        overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
-                        measured_bounds=est,
-                        text_style={
-                            'font_family': getattr(blk.fontformat, 'font_family', ''),
-                            'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                            'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
-                            'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
-                            'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
-                            'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
-                            'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
-                        'line_break_strategy': getattr(blk.fontformat, 'line_break_strategy', 'auto'),
-                        'alignment': getattr(blk.fontformat, 'alignment', 0),
-                        },
-                        font_fallback_warning=', '.join(missing_glyphs_after_fallback(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                    )
-                )
+                snapshots.append(self._layout_review_snapshot_for_item(blk))
             result = planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
             pending_actions = [a for block_result in result.blocks for a in block_result.actions]
             if not pending_actions:
@@ -1370,38 +1399,7 @@ class SceneTextManager(QObject):
         planner = LayoutReviewPlanner()
         snapshots: List[BlockSnapshot] = []
         for blk in selected:
-            abr = blk.absBoundingRect(qrect=True)
-            doc = blk.document()
-            est = None
-            if doc is not None:
-                ds = doc.size()
-                est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
-            snapshots.append(
-                BlockSnapshot(
-                    block_index=blk.idx,
-                    xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
-                    text=blk.toPlainText(),
-                    font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
-                    est_text_size=est,
-                    bubble_center=self._estimate_block_bubble_center(blk),
-                    writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
-                    resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
-                    overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
-                    measured_bounds=est,
-                    text_style={
-                        'font_family': getattr(blk.fontformat, 'font_family', ''),
-                        'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                        'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
-                        'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
-                        'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
-                        'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
-                        'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
-                        'line_break_strategy': getattr(blk.fontformat, 'line_break_strategy', 'auto'),
-                        'alignment': getattr(blk.fontformat, 'alignment', 0),
-                    },
-                    font_fallback_warning=', '.join(missing_glyphs_after_fallback(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                )
-            )
+            snapshots.append(self._layout_review_snapshot_for_item(blk))
         return planner.review_page(getattr(self.imgtrans_proj, "current_img", ""), snapshots)
 
     def review_selected_textboxes_with_provider(
@@ -1417,38 +1415,7 @@ class SceneTextManager(QObject):
         selected = self._get_review_target_blocks(target_block_indices)
         snapshots: List[BlockSnapshot] = []
         for blk in selected:
-            abr = blk.absBoundingRect(qrect=True)
-            doc = blk.document()
-            est = None
-            if doc is not None:
-                ds = doc.size()
-                est = (max(0.0, float(ds.width())), max(0.0, float(ds.height())))
-            snapshots.append(
-                BlockSnapshot(
-                    block_index=blk.idx,
-                    xyxy=(abr.x(), abr.y(), abr.x() + abr.width(), abr.y() + abr.height()),
-                    text=blk.toPlainText(),
-                    font_size=max(1.0, float(blk.font().pointSizeF() or blk.font().pointSize() or 1.0)),
-                    est_text_size=est,
-                    bubble_center=self._estimate_block_bubble_center(blk),
-                    writing_mode=getattr(blk.fontformat, 'writing_mode', 'auto'),
-                    resolved_writing_mode=resolve_writing_mode(getattr(blk.fontformat, 'writing_mode', 'auto'), blk.toPlainText(), (abr.width(), abr.height())),
-                    overflow_status=bool(est and (est[0] > abr.width() * 0.98 or est[1] > abr.height() * 0.98)),
-                    measured_bounds=est,
-                    text_style={
-                        'font_family': getattr(blk.fontformat, 'font_family', ''),
-                        'fallback_chain': ', '.join(merge_font_fallback_chain(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                        'fit_mode': getattr(blk.fontformat, 'fit_mode', 'shrink'),
-                        'stroke_width': getattr(blk.fontformat, 'stroke_width', 0.0),
-                        'text_padding': getattr(blk.fontformat, 'text_padding', 0.0),
-                        'line_spacing': getattr(blk.fontformat, 'line_spacing', 1.2),
-                        'letter_spacing': getattr(blk.fontformat, 'letter_spacing', 1.0),
-                        'line_break_strategy': getattr(blk.fontformat, 'line_break_strategy', 'auto'),
-                        'alignment': getattr(blk.fontformat, 'alignment', 0),
-                    },
-                    font_fallback_warning=', '.join(missing_glyphs_after_fallback(getattr(blk.fontformat, 'font_family', ''), blk.toPlainText(), pcfg, getattr(blk.fontformat, 'fallback_font_chain', ''))),
-                )
-            )
+            snapshots.append(self._layout_review_snapshot_for_item(blk))
         provider_impl = provider or self._resolve_review_provider(cfg)
         return provider_impl.review(getattr(self.imgtrans_proj, "current_img", ""), snapshots, cfg)
 

--- a/ui/textedit_area.py
+++ b/ui/textedit_area.py
@@ -539,6 +539,18 @@ class TextEditListScrollArea(QScrollArea):
 
         self.setSizePolicy(self.sizePolicy().horizontalPolicy(), QSizePolicy.Policy.Expanding)
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
+        self.refreshComfortPadding()
+
+    def _comfort_top_padding(self) -> int:
+        return max(0, int(getattr(pcfg, 'text_editor_top_padding', 14) or 0))
+
+    def refreshComfortPadding(self):
+        # Reserve breathing room inside the scroll area viewport, not just at
+        # content position 0. This keeps the first visible text pair from
+        # touching the format panel even when the text list is scrolled.
+        top_pad = self._comfort_top_padding()
+        self.setViewportMargins(0, top_pad, 0, 0)
+        self.vlayout.setContentsMargins(0, 0, 3, 0)
 
     def mouseReleaseEvent(self, e: QMouseEvent):
         if e.button() == Qt.MouseButton.RightButton:

--- a/utils/config.py
+++ b/utils/config.py
@@ -586,6 +586,7 @@ class ProgramConfig(Config):
     render_fallback_fonts_korean: str = "Noto Sans CJK KR, Malgun Gothic"
     render_fallback_fonts_rtl: str = "Noto Naskh Arabic, Arial, Segoe UI"
     render_fallback_fonts_emoji: str = "Noto Color Emoji, Segoe UI Emoji, Apple Color Emoji"
+    text_editor_top_padding: int = 14
     # Smooth scroll: animate scroll position on wheel (ms). 0 = off. 80–200 = subtle enhanced feel.
     smooth_scroll_duration_ms: int = 0
     # When True, briefly apply motion blur to scroll area viewport during scroll (can be costly).
@@ -705,7 +706,7 @@ CONFIG_KEY_ORDER = (
     "model_packages_enabled", "model_package_preset_ids",
     "dev_mode",
     "diagnostic_mode",
-    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_default_line_break_strategy", "render_default_reading_order", "render_overflow_warnings", "render_diagnostics_overlay", "render_default_font_family", "render_default_stroke_width", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji",
+    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_default_line_break_strategy", "render_default_reading_order", "render_overflow_warnings", "render_diagnostics_overlay", "render_default_font_family", "render_default_stroke_width", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji", "text_editor_top_padding",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
     "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_run_macros",
     "huggingface_token", "translator_last_model_by_provider",

--- a/utils/layout_review_agent.py
+++ b/utils/layout_review_agent.py
@@ -331,6 +331,46 @@ class LayoutReviewPlanner:
             )
             score_before -= 0.10
 
+        if bool((blk.text_style or {}).get("ink_clip_risk", False)):
+            issues.append(
+                ReviewIssue(
+                    code="ink_clip_risk",
+                    severity="warning",
+                    message="Estimated ink bounds may clip stroke, glow, or shadow at the text box edge.",
+                    score_penalty=0.06,
+                )
+            )
+            actions.append(
+                ReviewAction(
+                    action="increase_padding",
+                    block_index=blk.block_index,
+                    args={"padding": max(2.0, float((blk.text_style or {}).get("text_padding", 0.0) or 0.0) + 1.0)},
+                    reason="Increase inset before final render so manga effects have safe ink margin.",
+                )
+            )
+            score_before -= 0.06
+
+        suggested_preset = str((blk.text_style or {}).get("preset_suggestion", "") or "")
+        if suggested_preset and suggested_preset != str((blk.text_style or {}).get("preset", "") or ""):
+            if suggested_preset in {"vertical_cjk_bubble", "sfx_bold", "caption_box"}:
+                issues.append(
+                    ReviewIssue(
+                        code="preset_suggestion",
+                        severity="info",
+                        message=f"Renderer diagnostics suggest the {suggested_preset} manga lettering preset.",
+                        score_penalty=0.03,
+                    )
+                )
+                actions.append(
+                    ReviewAction(
+                        action="apply_manga_preset",
+                        block_index=blk.block_index,
+                        args={"preset": suggested_preset},
+                        reason="Apply the preset suggested by script, geometry, and lettering diagnostics.",
+                    )
+                )
+                score_before -= 0.03
+
         if float(getattr(blk, "quality_score", 1.0) or 1.0) < 0.7:
             issues.append(
                 ReviewIssue(

--- a/utils/rendering_qa.py
+++ b/utils/rendering_qa.py
@@ -131,9 +131,16 @@ def analyze_text_block(blk, page: str, index: int, config_obj=None) -> Dict:
     recommended_box = list(getattr(fit_diag, "recommended_box_size", (box_w, box_h)))
     if overflow and (recommended_box[0] > box_w * 1.02 or recommended_box[1] > box_h * 1.02):
         suggestions.append({"action": "resize_to_recommended_box", "recommended_box_size": recommended_box, "box_scale_hint": getattr(fit_diag, "box_scale_hint", 1.0), "reason": "Effect-aware fit diagnostics recommend a larger text box."})
+    if getattr(fit_diag, "ink_clip_risk", False):
+        warnings.append("ink_clip_risk")
+        suggestions.append({"action": "increase_padding", "padding": max(2.0, float(getattr(fmt, "text_padding", 0.0) or 0.0) + 1.0), "reason": "Estimated ink bounds leave too little room for stroke/shadow at the edge."})
     if (inner_bounds[0] < box_w * 0.62 or inner_bounds[1] < box_h * 0.62) and effect_margin > 0:
         warnings.append("unsafe_effect_bounds")
         suggestions.append({"action": "increase_box_or_reduce_effect", "effect_margin": effect_margin, "safe_inner_bounds": list(inner_bounds), "recommended_box_size": recommended_box, "reason": "Stroke/shadow/padding leave little safe text area inside this box."})
+    preset_suggestion = getattr(fit_diag, "preset_suggestion", "") or ""
+    if preset_suggestion and preset_suggestion != getattr(fmt, "preset", ""):
+        if preset_suggestion in {"vertical_cjk_bubble", "sfx_bold", "caption_box"}:
+            suggestions.append({"action": "apply_manga_preset", "preset": preset_suggestion, "reason": "Script/geometry heuristics suggest this manga lettering preset."})
 
     quality_score = lettering_quality_score(overflow, missing, float(effect_suggestion.get("contrast_ratio", 7.0) or 7.0), effect_margin, (box_w, box_h))
 
@@ -141,7 +148,16 @@ def analyze_text_block(blk, page: str, index: int, config_obj=None) -> Dict:
     break_ops = []
     if mode == "vertical_rl":
         max_chars = max(1, int(max(1.0, box_h) / max(1.0, float(getattr(fmt, "font_size", 24.0) or 24.0))))
-        vertical_plan = vertical_layout_plan(text, max_chars, getattr(fmt, "font_size", 24.0), getattr(fmt, "line_spacing", 1.15), getattr(fmt, "letter_spacing", 1.0), getattr(fmt, "line_break_strategy", "auto"))
+        vertical_plan = vertical_layout_plan(
+            text,
+            max_chars,
+            getattr(fmt, "font_size", 24.0),
+            getattr(fmt, "line_spacing", 1.15),
+            getattr(fmt, "letter_spacing", 1.0),
+            getattr(fmt, "line_break_strategy", "auto"),
+            rotate_latin=bool(getattr(config_obj, "vertical_cjk_rotate_latin", True)),
+            punctuation_hang=bool(getattr(config_obj, "vertical_cjk_punctuation_hang", True)),
+        )
     else:
         break_ops = line_break_opportunities(text, getattr(fmt, "line_break_strategy", "auto"))[:24]
 
@@ -172,6 +188,8 @@ def analyze_text_block(blk, page: str, index: int, config_obj=None) -> Dict:
         "suggested_font_size": fitted_size,
         "recommended_box_size": recommended_box,
         "box_scale_hint": getattr(fit_diag, "box_scale_hint", 1.0),
+        "ink_clip_risk": bool(getattr(fit_diag, "ink_clip_risk", False)),
+        "preset_suggestion": preset_suggestion,
         "suggested_text": fitted_text if fitted_text != text else "",
         "contrast_effect": effect_suggestion,
         "vertical_layout_plan": vertical_plan,
@@ -342,7 +360,7 @@ def apply_project_rendering_fixes(project, pages: Optional[Sequence[str]] = None
             if "rtl_left_alignment" in diag["warnings"] and wants("set_alignment"):
                 fmt.alignment = 2
                 changed.append("alignment")
-            if "low_padding_with_stroke" in diag["warnings"] and wants("increase_padding"):
+            if ("low_padding_with_stroke" in diag["warnings"] or "ink_clip_risk" in diag["warnings"]) and wants("increase_padding"):
                 fmt.text_padding = max(float(getattr(fmt, "text_padding", 0.0) or 0.0), 2.0)
                 changed.append("text_padding")
             if "horizontal_cjk_in_tall_box" in diag["warnings"] and wants("switch_writing_mode"):

--- a/utils/text_rendering.py
+++ b/utils/text_rendering.py
@@ -141,6 +141,8 @@ class TextRenderDiagnostics:
     quality_score: float = 1.0
     recommended_box_size: Tuple[float, float] = (0.0, 0.0)
     box_scale_hint: float = 1.0
+    ink_clip_risk: bool = False
+    preset_suggestion: str = ""
 
     def to_dict(self) -> dict:
         return {
@@ -162,6 +164,8 @@ class TextRenderDiagnostics:
             "quality_score": self.quality_score,
             "recommended_box_size": list(self.recommended_box_size),
             "box_scale_hint": self.box_scale_hint,
+            "ink_clip_risk": bool(self.ink_clip_risk),
+            "preset_suggestion": self.preset_suggestion,
         }
 
 
@@ -273,6 +277,63 @@ def resolve_writing_mode(mode: Optional[str], text: str, box_size: Optional[Tupl
     if contains_cjk(text) and h > max(w * 1.15, 1.0):
         return WRITING_MODE_VERTICAL_RL
     return WRITING_MODE_HORIZONTAL_LTR
+
+
+def locale_aware_upper(text: str, locale: str = "") -> str:
+    """Uppercase text without damaging scripts that have no useful uppercase form.
+
+    Koharu issue #572/#567 focused on universal uppercase behavior. Python's
+    `str.upper()` is acceptable for Latin/Greek/Cyrillic, but applying it to
+    manga text containing Japanese/Chinese/Korean, Arabic, Hebrew, or emoji can
+    change punctuation expectations without improving lettering. This helper
+    uppercases only contiguous cased-script runs and keeps other scripts as-is.
+    Turkish/Azeri dotted-i is handled explicitly when requested.
+    """
+    text = text or ""
+    loc = (locale or "").lower()
+    turkic = loc.startswith(("tr", "az"))
+    out: List[str] = []
+    for ch in text:
+        if not ch:
+            continue
+        cat = unicodedata.category(ch)
+        name = unicodedata.name(ch, "")
+        if turkic and ch == "i":
+            out.append("İ")
+        elif turkic and ch == "ı":
+            out.append("I")
+        elif cat.startswith("L") and not (_is_cjk_char(ch) or KOREAN_RE.match(ch) or RTL_RE.match(ch)) and any(script in name for script in ("LATIN", "GREEK", "CYRILLIC")):
+            out.append(ch.upper())
+        else:
+            out.append(ch)
+    return "".join(out)
+
+
+def suggest_manga_preset(text: str, box_size: Tuple[float, float] = (0.0, 0.0), writing_mode: str = WRITING_MODE_AUTO) -> str:
+    """Suggest a lettering preset from script, geometry, and SFX-like content."""
+    text = text or ""
+    w, h = box_size or (0.0, 0.0)
+    resolved = resolve_writing_mode(writing_mode, text, box_size)
+    stripped = re.sub(r"\s+", "", text)
+    emph = sum(1 for ch in stripped if ch in "!！?？⁈⁉‼⁇~～ー—―")
+    if resolved == WRITING_MODE_VERTICAL_RL:
+        return "vertical_cjk_bubble"
+    if len(stripped) <= 8 and (emph >= 2 or stripped.isupper()):
+        return "sfx_bold"
+    if w > 0 and h > 0 and w > h * 2.5:
+        return "caption_box"
+    if len(stripped) <= 12 and max(w, h) < 140:
+        return "small_aside"
+    return "default_manga_bubble"
+
+
+def ink_clip_risk(box_size: Tuple[float, float], measured_bounds: Tuple[float, float], effect_margin: float, threshold_px: float = 1.0) -> bool:
+    """True when stroke/shadow/padding likely clips at the text box edge."""
+    bw, bh = box_size or (0.0, 0.0)
+    mw, mh = measured_bounds or (0.0, 0.0)
+    spare_x = float(bw or 0.0) - float(mw or 0.0)
+    spare_y = float(bh or 0.0) - float(mh or 0.0)
+    return effect_margin > 0 and (spare_x < max(threshold_px, effect_margin * 0.3) or spare_y < max(threshold_px, effect_margin * 0.3))
 
 
 def normalize_vertical_punctuation(text: str) -> str:
@@ -680,6 +741,8 @@ def vertical_layout_plan(
     line_spacing: float = 1.1,
     letter_spacing: float = 1.0,
     strategy: str = LINE_BREAK_CJK_STRICT,
+    rotate_latin: bool = True,
+    punctuation_hang: bool = True,
 ) -> Dict[str, object]:
     """Build a renderer-independent vertical-RL glyph placement plan.
 
@@ -706,8 +769,8 @@ def vertical_layout_plan(
                 "y": row_idx * glyph_advance,
                 "punctuation_class": cls,
                 "center": cls in {"center", "punct"},
-                "rotate": cls == "rotate",
-                "hang": bool(adjust.get("hang")) or (cls == "center" and ch in {"、", "。", "，", "．"}),
+                "rotate": (cls == "rotate") or (rotate_latin and ch.isascii() and ch.isalpha()),
+                "hang": bool(punctuation_hang) and (bool(adjust.get("hang")) or (cls == "center" and ch in {"、", "。", "，", "．"})),
                 "offset": {"dx": adjust.get("dx", 0.0), "dy": adjust.get("dy", 0.0)},
                 "rotate_degrees": adjust.get("rotate_degrees", 0.0),
                 "scale": adjust.get("scale", 1.0),
@@ -729,6 +792,8 @@ def vertical_layout_plan(
         "strategy": normalize_line_break_strategy(strategy),
         "tate_chu_yoko_groups": tcy_groups,
         "bracket_pairs": vertical_bracket_pair_hints(text),
+        "rotate_latin": bool(rotate_latin),
+        "punctuation_hang": bool(punctuation_hang),
     }
 
 
@@ -867,7 +932,11 @@ def fit_font_size_to_box(
         quality = lettering_quality_score(is_over, [], 7.0, margin, (box_w, box_h))
         scale_hint = max(bounds[0] / max(1.0, box_w), bounds[1] / max(1.0, box_h), 1.0)
         rec_box = (round(max(box_w, bounds[0] + 2 * margin), 2), round(max(box_h, bounds[1] + 2 * margin), 2))
-        diag = TextRenderDiagnostics(resolved, is_over, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, current, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3))
+        clip = ink_clip_risk((box_w, box_h), (bounds[0], bounds[1]), margin)
+        if clip and "increase_padding" not in actions:
+            actions.append("increase_padding")
+        preset = suggest_manga_preset(text_out, (box_w, box_h), resolved)
+        diag = TextRenderDiagnostics(resolved, is_over, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, current, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3), clip, preset)
         return current, text_out, diag
 
     target_largest = fit_mode in (FIT_MODE_EXPAND, FIT_MODE_BALANCE)
@@ -903,7 +972,11 @@ def fit_font_size_to_box(
     rec_box = (round(max(box_w, bounds[0] + 2 * margin), 2), round(max(box_h, bounds[1] + 2 * margin), 2))
     if overflow and "resize_to_fit_content" not in actions:
         actions.append("resize_to_fit_content")
-    diag = TextRenderDiagnostics(resolved, overflow, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, best, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3))
+    clip = ink_clip_risk((box_w, box_h), (bounds[0], bounds[1]), margin)
+    if clip and "increase_padding" not in actions:
+        actions.append("increase_padding")
+    preset = suggest_manga_preset(text_out, (box_w, box_h), resolved)
+    diag = TextRenderDiagnostics(resolved, overflow, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, best, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3), clip, preset)
     return best, text_out, diag
 
 


### PR DESCRIPTION
### Motivation

- Improve manga-focused lettering/workflow parity with Koharu by adding script-aware casing, safer effect-aware fit diagnostics, and automation/onboarding helpers. 
- Make layout review and rendering QA actionable for ink/outline/shadow clipping and preset-suggestion fixes while improving editor comfort for dense manga workflows.

### Description

- Added `locale_aware_upper()`, `suggest_manga_preset()` and `ink_clip_risk()` to `utils/text_rendering.py` and replaced raw `.upper()` uses with `locale_aware_upper()` in translation post-processing and the selected-block uppercase action (files: `utils/text_rendering.py`, `ui/mainwindow.py`).
- Extended `TextRenderDiagnostics` and `fit_font_size_to_box()` to expose `ink_clip_risk` and `preset_suggestion`, and propagated those fields through rendering QA and structured diagnostics (files: `utils/text_rendering.py`, `utils/rendering_qa.py`).
- Layout review planner now recognizes ink-clip risk and preset suggestions and proposes conservative automatic fixes (actions like `increase_padding` and `apply_manga_preset`) (file: `utils/layout_review_agent.py`).
- Added configurable side text-editor top padding with a live Config control and viewport margin refresh to avoid the first-row feeling pressed to the edge (files: `ui/configpanel.py`, `ui/textedit_area.py`, `utils/config.py`).
- Added `POST /recent_projects` automation route that returns recent project path, existence and basic metadata for onboarding/headless clients (file: `ui/mainwindow.py`).
- Refactored layout-review snapshot creation to include new fit diagnostics and font-fallback warnings and wired snapshots into planner flows (file: `ui/scenetext_manager.py`).
- Documentation updates to `docs/KOHARU_GAP_ANALYSIS.md`, `docs/KOHARU_ISSUE_BACKLOG.md`, and `docs/RENDERING_TEXT_FORMATTING.md` recording new behaviors and mappings to issue inspirations.
- Tests updated and added to validate locale-aware uppercase, ink-clip/preset heuristics, vertical-plan toggles, and fit diagnostic outputs (file: `tests/test_text_rendering.py`).

### Testing

- Ran the unit tests covering text rendering diagnostics and new helpers with `pytest tests/test_text_rendering.py -q`, which executed the new tests `test_locale_aware_upper_keeps_cjk_and_handles_turkish_i`, `test_suggest_manga_preset_and_ink_clip_risk`, `test_vertical_layout_plan_respects_rotate_and_hang_toggles`, and `test_fit_diagnostics_expose_clip_risk_and_preset_suggestion`, and they passed.
- Executed the repository test suite (`pytest -q`) including the updated diagnostics and layout-review related tests and observed no regressions in the modified areas (CI/local run passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcc7fe2298832c8326d71468664f17)