### PR TITLE
Add reusable manga lettering presets, favorite/recent fonts, visual-fit diagnostics, and archive/export API

### DIFF
--- a/docs/KOHARU_GAP_ANALYSIS.md
+++ b/docs/KOHARU_GAP_ANALYSIS.md
@@ -17,6 +17,25 @@ The repository already had substantial Koharu-inspired foundations before this p
 | QA/API export metadata | Rendering QA now exposes recommended box size/scale hints, while structured OCR exports include writing mode, fit mode, line-break strategy, source order, and resolved reading order for headless agents. | #649/#648 project-wide text fixes, #660 reading order, #612 API workflow | `utils/rendering_qa.py`, `utils/structured_ocr_export.py`, `ui/mainwindow.py` |
 | Archive export workflow | Batch export dialog now supports manga-reader CBZ archives in addition to ZIP, with clearer archive wording and backend status messages. | #626 streaming ZIP export, #610 bulk comic/archive workflow, #591 export/interoperability requests | `ui/export_dialog.py`, `ui/mainwindow.py` |
 
+## Latest implementation pass (2026-05-07 continued: reusable presets and font workflow)
+
+| Area | Implemented | Koharu issue inspiration | Files |
+| --- | --- | --- | --- |
+| User-saved manga presets | Added persisted custom manga lettering presets built from the current textbox/style, with sanitization for font, size, stroke, colors, spacing, writing mode, fit mode, line breaks, padding, opacity, fallback chain, and font weight. Presets can now be imported/exported as JSON packs with missing-font diagnostics. | #593 text presets, #594 advanced formatting, #595 font UX | `utils/text_rendering.py`, `utils/rendering_preset_io.py`, `utils/config.py`, `ui/text_panel.py`, `ui/fontformat_commands.py`, `utils/text_style_batch.py`, `tests/test_text_rendering.py`, `tests/test_text_style_batch.py` |
+| Preset UI and batch/API parity | The text panel now has connected **Save/Import/Export preset** actions, built-in + custom presets appear in the preset picker, batch style override can apply custom presets, and automation can list/save/import/export/delete presets with `rendering_presets`. | #593 text presets, #612 automation/API workflow, #648 project-wide style changes | `ui/text_panel.py`, `ui/mainwindow.py`, `utils/text_style_batch.py`, `utils/rendering_preset_io.py` |
+| Recent font workflow | Font choices are remembered as recent lettering fonts and surfaced alongside favorites, reducing repeated font-list scrolling during manga lettering. | #595 font UX improvements, #589 workflow/font requests | `utils/config.py`, `ui/text_panel.py` |
+| Review/custom preset application | Layout review preset actions and direct formatting commands resolve the merged built-in/custom preset library, so saved presets are first-class renderer actions rather than text-panel-only UI state. | #594 advanced formatting, #593 presets, #649/#648 style repair | `ui/fontformat_commands.py`, `ui/scenetext_manager.py`, `utils/text_style_batch.py` |
+
+## Latest implementation pass (2026-05-07 continued: font UX, fit quality, export workflow)
+
+| Area | Implemented | Koharu issue inspiration | Files |
+| --- | --- | --- | --- |
+| Visual-advance lettering fit | Replaced raw character-count width estimates with script/punctuation-aware visual advance units, making CJK punctuation, emoji/symbols, combining marks, and Latin text fit diagnostics closer to actual manga lettering; added conservative tracking recommendations when text is horizontally overfull. | #594 advanced formatting/kerning, #630 fit/centering inconsistencies, #640 fixed font options | `utils/text_rendering.py`, `tests/test_text_rendering.py` |
+| Layout review tracking fix | Layout review and Typography QA now expose/apply `tighten_letter_spacing` before more destructive shrink/resize fixes, preserving lettering weight while reducing wide-line overflow. | #594 advanced formatting, #649/#648 project-wide style repair | `utils/layout_review_agent.py`, `ui/scenetext_manager.py`, `utils/rendering_qa.py` |
+| Favorite lettering fonts | Added persistent favorite font chains in Rendering settings and a one-click Favorites picker/★ capture button in the text formatting panel so common manga fonts can be reused without scrolling the full font list. | #595 font UX improvements, #593 text presets | `utils/config.py`, `ui/configpanel.py`, `ui/text_panel.py` |
+| Export handoff workflow | Added persistent “open output folder after batch export” control in Settings and the export dialog, reducing clicks after rendered/CBZ/ZIP/manifest/helper export. | #591/#587 export handoff/interoperability, #626 archive workflow | `utils/config.py`, `ui/configpanel.py`, `ui/export_dialog.py`, `ui/mainwindow.py` |
+| Automation archive export | Extended the local automation export route with `kind=archive`, `kind=zip`, and `kind=cbz`, packing batch rendered output plus optional helper images/manifests for headless workflows. | #612 API workflow, #626 ZIP export, #610 bulk CBZ workflow | `ui/mainwindow.py` |
+
 ## Latest implementation pass (2026-05-07 continued again)
 
 | Area | Implemented | Koharu issue inspiration | Files |
@@ -49,12 +68,12 @@ The repository already had substantial Koharu-inspired foundations before this p
 
 | Workstream | Status | Implemented | Partial / deferred |
 | --- | --- | --- | --- |
-| Advanced manga text rendering / formatting | **Partially implemented and advanced this pass** | Writing modes, vertical CJK plans, kinsoku/balanced wrapping, tate-chu-yoko hints, configurable latin-rotation/punctuation-hang metadata, vertical punctuation offset/rotation/bracket hints, fallback chains, manga presets, script-aware uppercase conversion, fit clamps, ink-clip risk diagnostics, effect-aware safe bounds, shadow-aware fit diagnostics, recommended resize hints, and live QA. | Full HarfBuzz/ICU shaping, OpenType vertical alternates, and true ink-bound measurement remain deferred pending optional dependency/runtime design. |
+| Advanced manga text rendering / formatting | **Partially implemented and advanced this pass** | Writing modes, vertical CJK plans, kinsoku/balanced wrapping, tate-chu-yoko hints, configurable latin-rotation/punctuation-hang metadata, vertical punctuation offset/rotation/bracket hints, fallback chains, favorite lettering fonts, manga presets, visual-advance punctuation-aware fit estimates, conservative letter-spacing review fixes, script-aware uppercase conversion, fit clamps, ink-clip risk diagnostics, effect-aware safe bounds, shadow-aware fit diagnostics, recommended resize hints, and live QA. | Full HarfBuzz/ICU shaping, OpenType vertical alternates, native kerning tables, and true ink-bound measurement remain deferred pending optional dependency/runtime design. |
 | Layout review agent | **Implemented/verified and advanced** | Selected/page review, heuristic fallback, settings, action application, recommended-box resize, vertical punctuation normalization, RTL alignment, contrast stroke, and richer QA metadata are present. | Visual before/after previews and true mask-aware squeezing still need rendered snapshots/mask geometry. |
-| PSD/export | **Partially implemented and improved** | Layered PSD handoff manifests/Photoshop JSX, editable text metadata, export manifests, current-page render API, ZIP/CBZ batch archive workflow, and optional clean/mask helper image export. | Native PSD text layer writer and streaming archive writer remain deferred. |
-| Settings/config | **Implemented and improved** | Dedicated rendering defaults include font, writing mode, fit mode, line break, reading order, effects, overflow warnings, diagnostics overlay, and script fallback chains. | Per-project profile presets and model/provider wizard remain future work. |
+| PSD/export | **Partially implemented and improved** | Layered PSD handoff manifests/Photoshop JSX, editable text metadata, export manifests, current-page render API, ZIP/CBZ batch archive workflow, API archive export, optional clean/mask helper image export, and persistent open-output-folder workflow. | Native PSD text layer writer and streaming archive writer remain deferred. |
+| Settings/config | **Implemented and improved** | Dedicated rendering defaults include font, writing mode, fit mode, line break, reading order, effects, overflow warnings, diagnostics overlay, script fallback chains, recent/favorite fonts, and user-saved manga lettering presets. | Per-project profile import/export and model/provider wizard remain future work. |
 | Keyboard/tool UX | **Partially implemented** | Existing shortcut conflict tests and text-field guard behavior remain in place; no shortcut ambiguity changes were introduced in this pass. | Broader one-owner QAction/QShortcut cleanup is deferred to a focused shortcut pass. |
-| Automation/API/headless | **Implemented and improved** | Existing local API supports project open/run/edit/export/review/render/QA/fixes; `list_pages` exposes page states and ordered textboxes, and `recent_projects` exposes reopenable project metadata for agents/onboarding flows. | Event streaming/progress subscription and MCP server parity are deferred. |
+| Automation/API/headless | **Implemented and improved** | Existing local API supports project open/run/edit/export/review/render/QA/fixes; `list_pages` exposes page states and ordered textboxes, `recent_projects` exposes reopenable project metadata for agents/onboarding flows, and archive/ZIP/CBZ export is now callable headlessly. | Event streaming/progress subscription and MCP server parity are deferred. |
 | Workflow enhancements from issues | **Improved this pass** | Reading-order-aware exports/API reduce manual agent cleanup; ZIP/CBZ archive export reduces comic delivery steps; the side text editor now has configurable comfort padding; `recent_projects` helps agents/onboarding flows reopen projects safely. | Bulk parent/child CBZ project processing and provider/model setup wizard are next candidates. |
 
 ## Issue-inspired items implemented in this pass
@@ -68,6 +87,9 @@ The repository already had substantial Koharu-inspired foundations before this p
 - **#637/#630/#624 review fixes**: layout review can now turn fit diagnostics into targeted resize actions and apply vertical punctuation, RTL alignment, contrast-stroke, ink-safe padding, and preset-suggestion fixes.
 - **#572/#567 locale uppercase**: uppercase post-processing and context actions are now script-aware instead of applying raw uppercase to every character.
 - **#612/#519 workflow polish**: automation can list recent projects and the side text editor has configurable breathing room for faster editing.
+- **#594/#595 typography workflow**: visual-advance fit diagnostics, letter-spacing review fixes, persistent favorite/recent lettering fonts, and custom saved presets improve final lettering and reduce font-selection clicks.
+- **#593/#612 preset workflow**: custom manga presets are saved from the text panel, reused in batch style override/layout review, and exposed to automation clients for headless style consistency.
+- **#626/#610/#591 export workflow**: API archive export and open-output-folder settings make rendered/CBZ/ZIP handoff faster and more discoverable.
 
 ## Deferred with reasons
 
@@ -81,11 +103,14 @@ The repository already had substantial Koharu-inspired foundations before this p
 
 ## Next batch candidates
 
-1. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
-2. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
-3. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
-4. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
-5. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
-6. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
-7. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
-8. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).
+1. Shared per-project preset packs with thumbnail previews for lettering teams (#593/#595).
+2. Weight/style-aware font browser with localized family names and deeper missing-font diagnostics (#595).
+3. True ink-bound glyph measurement / OpenType shaping for clipping-free advanced formatting (#594/#572/#624).
+4. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
+5. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
+6. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
+7. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
+8. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
+9. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
+10. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
+11. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).

--- a/docs/KOHARU_ISSUE_BACKLOG.md
+++ b/docs/KOHARU_ISSUE_BACKLOG.md
@@ -2,6 +2,25 @@
 
 _Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issues/PRs, 652 all-state items scanned. This backlog is maintained as an implementation source, not a one-time audit._
 
+## Newly implemented / advanced in this pass (continued once more 2026-05-07)
+
+| Issue | Title | Category | Relevant labels | Maps to BT-Pro? | Implemented here? | Priority | Implementation notes | Deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [#593](https://github.com/mayocream/koharu/issues/593) | Feature: Text presets (save font style/size/color configurations) | Text rendering / typography / fonts; UI/UX/editor workflow | ui, feature request, font | yes | **partial → advanced** | P0 | Added persisted custom manga lettering presets saved from the active text style/textbox, merged with built-ins in the text panel, direct formatting command path, batch style override, layout-review action application, JSON import/export packs with missing-font diagnostics, and automation `rendering_presets`. | Thumbnail previews and per-project preset pack sync remain deferred. |
+| [#595](https://github.com/mayocream/koharu/issues/595) | Feature: Font UX improvements (local names, favorites, family/weight selection) | Text rendering / typography / fonts; UI/UX/editor workflow | ui, feature request, font | yes | **advanced** | P1 | Favorite fonts now work with recent font recall, custom presets preserve font weight/family/fallback settings, preset packs warn about missing fonts, and the preset picker reduces repeated font-list navigation. | Localized family names and full weight/style browser remain deferred. |
+| [#612](https://github.com/mayocream/koharu/pull/612) / [#648](https://github.com/mayocream/koharu/issues/648) | Automation workflow / project-wide style changes | Automation/API/headless/MCP; Batch/project workflow | area: ui / workflow | yes | **advanced** | P1 | Added `rendering_presets` automation for listing/saving preset styles and custom-preset support in project/page batch style application. | Event-streamed preset operations and preset pack sync remain deferred. |
+
+## Newly implemented / advanced in this pass (continued again 2026-05-07)
+
+GitHub issue refresh: `gh` was unavailable in this container, so this pass used the GitHub REST API and topic searches across rendering/font/text, PSD/export/layer, shortcut/keybind, API/headless/automation, OCR/detector/inpaint/translator, settings/provider/model, workflow/editor/batch/export/onboarding/setup, and feature/enhancement/UX terms. The local harvest merged **249 non-PR issues** from multiple pages/searches, including current high-priority open requests #653, #652, #649, #648, #640, #610, #602, #601, #597, #595, #594, #593, #592, #591, #589, #587, and #583.
+
+| Issue | Title | Category | Relevant labels | Maps to BT-Pro? | Implemented here? | Priority | Implementation notes | Deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| [#594](https://github.com/mayocream/koharu/issues/594) | Feature: Advanced text formatting (gradients, line spacing, kerning) | Text rendering / typography / fonts; Text fitting / layout / overflow | renderer, feature request, font | yes | **advanced** | P0 | Added visual-advance based fit estimates so CJK punctuation, emoji/symbols, combining marks, and Latin spacing no longer measure as raw character counts; fit diagnostics/layout review now suggest a conservative `tighten_letter_spacing` action before shrinking/resizing wide lettering. | True kerning/OpenType shaping still needs optional shaping dependencies. |
+| [#595](https://github.com/mayocream/koharu/issues/595) | Feature: Font UX improvements (local names, favorites, family/weight selection) | Text rendering / typography / fonts; UI/UX/editor workflow | ui, feature request, font | yes | **partial → advanced** | P1 | Added persistent favorite lettering fonts in Rendering settings plus a one-click Favorites picker and ★ capture button in the text formatting panel. | Weight/style browser and localized family names remain deferred. |
+| [#626](https://github.com/mayocream/koharu/pull/626) / [#610](https://github.com/mayocream/koharu/issues/610) | Streaming ZIP export / bulk CBZ workflow | PSD/export/layers; Batch/project workflow; Automation/API/headless/MCP | area: ui / workflow | yes | **advanced** | P1 | Extended automation export with `kind=archive|zip|cbz`, creating ZIP/CBZ archives from rendered batch output plus manifests/helper images when requested. | True streaming archive progress/cancel remains deferred. |
+| [#591](https://github.com/mayocream/koharu/issues/591) / [#587](https://github.com/mayocream/koharu/issues/587) | Export interop / PSD position fidelity | PSD/export/layers; UI/UX/editor workflow | export, psd, interop | yes | **workflow advanced** | P1 | Added a persistent “open output folder after batch export” setting and export-dialog checkbox so rendered pages, CBZ/ZIP, manifests, clean/mask helpers, and handoff files are immediately discoverable after export. | Native editable PSD text writer remains deferred. |
+
 ## Newly implemented / advanced in this pass (continued 2026-05-07)
 
 | Issue | Title | Category | Relevant labels | Maps to BT-Pro? | Implemented here? | Priority | Implementation notes | Deferred reason |
@@ -30,8 +49,8 @@ _Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issue
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | [#649](https://github.com/mayocream/koharu/issues/649) | Enable global font size override from Auto across all images | ui, renderer, feature request | yes | partial → **advanced** | P0 | Batch style dialog/API can update current page or project and optionally only auto-sized blocks; fit min/max clamps and fixed font size are supported. | Visual before/after preview still deferred. |
 | [#594](https://github.com/mayocream/koharu/issues/594) | Advanced text formatting (gradients, line spacing, kerning) | renderer, feature request, font | yes | partial | P0 | Existing style panel covers spacing/effects; gradients/kerning remain. | Needs renderer/UI design. |
-| [#593](https://github.com/mayocream/koharu/issues/593) | Text presets (save font style/size/color configurations) | ui, feature request, font | yes | partial | P1 | Built-in manga presets exist. | User-saved preset library deferred. |
-| [#595](https://github.com/mayocream/koharu/issues/595) | Font UX improvements | ui, feature request, font | yes | partial | P1 | Google Fonts installer and fallback diagnostics exist. | Favorites/localized names deferred. |
+| [#593](https://github.com/mayocream/koharu/issues/593) | Text presets (save font style/size/color configurations) | ui, feature request, font | yes | partial → **advanced** | P0 | Built-in and user-saved custom manga presets now exist across UI, batch style, layout review, and automation. | Preset import/export packs and thumbnails deferred. |
+| [#595](https://github.com/mayocream/koharu/issues/595) | Font UX improvements | ui, feature request, font | yes | partial → **advanced** | P1 | Google Fonts installer, fallback diagnostics, favorite fonts, recent fonts, and font-preserving custom presets exist. | Localized names and full weight/style browser deferred. |
 | [#77](https://github.com/mayocream/koharu/issues/77) | Custom font support | renderer | yes | partial | P1 | Google/web font install flow exists. | Robust font package manager deferred. |
 
 ## Vertical CJK / RTL / punctuation
@@ -87,12 +106,14 @@ _Last refreshed: 2026-05-07 via GitHub REST API against `mayocream/koharu` issue
 
 ## Next batch candidates
 
-1. True ink-bound glyph measurement / OpenType shaping for clipping-free advanced formatting (#594/#572/#624).
-2. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
-3. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
-4. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
-5. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
-6. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
-7. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
-8. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
-9. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).
+1. Shared per-project preset packs with thumbnail previews for lettering teams (#593/#595).
+2. Weight/style-aware font browser with localized family names and deeper missing-font diagnostics (#595).
+3. True ink-bound glyph measurement / OpenType shaping for clipping-free advanced formatting (#594/#572/#624).
+4. Mask-aware collision detection/squeezing using bubble masks and text bounds (#637).
+5. Before/after thumbnails for checked-row Typography QA fixes (#649/#648/#630).
+6. Native editable PSD text writer or stronger Photoshop/GIMP handoff validation (#587/#558/#602).
+7. Canvas-side text block drag-to-reorder with undo/read-order preview (#601/#660).
+8. HarfBuzz/ICU shaping experiment for Arabic joining and vertical OpenType alternates (#602/#583/#213/#624).
+9. Streaming ZIP/CBZ export with progress/cancel and parent/child batch processing (#626/#610).
+10. Provider/model setup wizard with OCR model recommendation and failure retry diagnostics (#625/#652).
+11. Runtime GPU memory profiles and safer device fallback guidance (#638/#600).

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -147,3 +147,17 @@ The layout review agent now consumes effect-aware `recommended_box_size` diagnos
 - **Configurable vertical plans:** `vertical_layout_plan()` now records whether latin glyph rotation and punctuation hanging were enabled, and Typography QA uses the live Config values. This makes UI, API, SVG/PSD handoff, and tests agree on vertical punctuation intent.
 - **Editor comfort setting:** Config → General → Rendering / Text Formatting includes **Text editor top padding**. It updates the side text editor list immediately, fixing the cramped first-visible-row feel even after scrolling while keeping dense manga editing workflows fast.
 - **Automation workflow helper:** local automation clients can call `POST /recent_projects` to retrieve recent project paths, existence checks, and JSON/folder type before opening or running a project.
+
+## 2026-05-07 pass: favorite fonts, visual fit, archive/export workflow
+
+- **Favorite lettering fonts:** Settings → Project text rendering defaults now includes **Favorite lettering fonts**. Enter comma-separated manga/comic font families there, then use the **Favorites** combo in the text formatting panel to apply one instantly to the current style or selected text box. The **★** button captures the currently selected font into the persisted favorites list.
+- **Visual-advance fit estimates:** Renderer diagnostics and layout review no longer treat every character as the same width. CJK punctuation, brackets, emoji/symbols, combining marks, and Latin runs use script-aware visual advance units, making overflow warnings and recommended box sizes less noisy for manga punctuation-heavy text.
+- **Letter-spacing review fix:** When wide text overflows horizontally, Typography QA / layout review can suggest and apply a conservative **tighten letter spacing** action before shrinking fonts or resizing boxes. This preserves lettering weight where possible.
+- **Export workflow polish:** Batch export has a persistent **Open output folder when done** option, and the automation export route can create ZIP/CBZ archives (`kind=archive`, `kind=zip`, or `kind=cbz`) from rendered pages plus optional clean/mask helper images.
+
+## 2026-05-07 pass: reusable manga lettering presets
+
+- **Save current style as a preset:** The text formatting panel now includes **Save preset** next to the manga preset picker. It captures the current font family, weight, size, colors, stroke, shadow, spacing, writing mode, fit mode, line-break strategy, padding, opacity, and fallback chain into a persisted custom preset.
+- **Built-in + custom preset parity:** Custom presets appear beside built-in presets and can be applied from the text panel, batch style override, layout review preset actions, and automation. Presets can be imported/exported as JSON packs for team handoff, with missing-font diagnostics when the current machine lacks a preset font family.
+- **Recent font recall:** Font choices are remembered as recent lettering fonts and shown alongside favorites, reducing repeated scrolling through long font lists while lettering a chapter.
+- **Automation:** Local clients can call `rendering_presets` with `action=list`, `action=save`, `action=save_current`, `action=import`, `action=export`, or `action=delete` to inspect, create, share, or prune reusable rendering presets.

--- a/tests/test_text_rendering.py
+++ b/tests/test_text_rendering.py
@@ -215,3 +215,63 @@ def test_fit_diagnostics_expose_clip_risk_and_preset_suggestion():
     d = diag.to_dict()
     assert d["ink_clip_risk"] is True
     assert d["preset_suggestion"] in {"sfx_bold", "caption_box", "default_manga_bubble"}
+
+
+def test_glyph_advance_units_treats_cjk_punctuation_as_compact():
+    from utils.text_rendering import glyph_advance_units, estimate_text_bounds
+    assert glyph_advance_units("漢字。", "horizontal_ltr") < glyph_advance_units("漢字漢", "horizontal_ltr")
+    plain = estimate_text_bounds("漢字漢", 20, "horizontal_ltr", 200, 80)
+    punct = estimate_text_bounds("漢字。", 20, "horizontal_ltr", 200, 80)
+    assert punct[0] < plain[0]
+
+
+def test_recommended_tight_letter_spacing_is_conservative():
+    from utils.text_rendering import recommended_tight_letter_spacing
+    assert recommended_tight_letter_spacing(1.0, 1.08) < 1.0
+    assert recommended_tight_letter_spacing(1.0, 1.30) >= 0.88
+
+
+def test_custom_manga_preset_sanitization_and_merge():
+    from types import SimpleNamespace
+    from utils.text_rendering import manga_presets, preset_from_font_format, preset_id_from_label, sanitize_manga_preset
+    from utils.fontformat import FontFormat
+
+    pid = preset_id_from_label("My SFX!!", ["custom:my_sfx"])
+    assert pid == "custom:my_sfx_2"
+    preset = sanitize_manga_preset({"label": "Boom", "font_size": "48", "writing_mode": "vertical-rl", "alignment": 9, "frgb": [300, -5, 20]})
+    assert preset["font_size"] == 48.0
+    assert preset["writing_mode"] == "vertical_rl"
+    assert preset["alignment"] == 2
+    assert preset["frgb"] == [255, 0, 20]
+    fmt = FontFormat(font_size=31, stroke_width=0.12, writing_mode="rtl", letter_spacing=0.95)
+    saved = preset_from_font_format(fmt, "RTL caption")
+    cfg = SimpleNamespace(render_custom_manga_presets={"custom:rtl_caption": saved})
+    presets = manga_presets(cfg)
+    assert "default_manga_bubble" in presets
+    assert presets["custom:rtl_caption"]["writing_mode"] == "rtl"
+    assert presets["custom:rtl_caption"]["stroke_width"] == 0.12
+
+
+def test_rendering_preset_pack_roundtrip_and_font_diagnostics(tmp_path):
+    from types import SimpleNamespace
+    from utils.rendering_preset_io import import_preset_pack, preset_font_diagnostics, write_preset_pack
+
+    cfg = SimpleNamespace(render_custom_manga_presets={
+        "custom:boom": {"label": "Boom", "font_family": "Missing Manga", "font_size": 42, "writing_mode": "auto"}
+    })
+    path = tmp_path / "pack.json"
+    pack = write_preset_pack(cfg, str(path))
+    assert pack["format"].startswith("ballonstranslator")
+    assert path.exists()
+    diag = preset_font_diagnostics(pack["presets"], ["Arial"])
+    assert diag["checked"] is True
+    assert diag["missing"]["custom:boom"] == "Missing Manga"
+
+    target = SimpleNamespace(render_custom_manga_presets={})
+    result = import_preset_pack(target, str(path))
+    assert result["imported_count"] == 1
+    assert target.render_custom_manga_presets["custom:boom"]["font_size"] == 42.0
+
+    result2 = import_preset_pack(target, str(path), overwrite=False)
+    assert result2["imported_count"] == 1
+    assert any(pid.startswith("custom:boom_") for pid in target.render_custom_manga_presets)

--- a/tests/test_text_style_batch.py
+++ b/tests/test_text_style_batch.py
@@ -35,3 +35,23 @@ def test_apply_text_style_batch_can_target_only_auto_sized_blocks():
     assert project.pages["p1.png"][0].fontformat.font_family == "Noto Sans"
     assert project.pages["p1.png"][1].fontformat.font_family == "Old"
     assert project.pages["p2.png"][0].fontformat.alignment == 1
+
+
+def test_apply_text_style_batch_accepts_custom_manga_presets():
+    from types import SimpleNamespace
+    project = Project()
+    cfg = SimpleNamespace(render_custom_manga_presets={
+        "custom:quiet_caption": {
+            "label": "Quiet caption",
+            "font_size": 18,
+            "writing_mode": "horizontal_ltr",
+            "fit_mode": "balance",
+            "stroke_width": 0.02,
+            "letter_spacing": 0.93,
+        }
+    })
+    result = apply_text_style_batch(project, {"preset": "custom:quiet_caption"}, pages=["p1.png"], config_obj=cfg)
+    assert result["changed"] == 2
+    assert project.pages["p1.png"][0].fontformat.manga_preset == "custom:quiet_caption"
+    assert project.pages["p1.png"][0].fontformat.fit_mode == "balance"
+    assert project.pages["p1.png"][0].fontformat.letter_spacing == 0.93

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -943,6 +943,20 @@ class ConfigPanel(Widget):
         self.render_fallback_emoji_edit = QLineEdit(self)
         self.render_fallback_emoji_edit.textChanged.connect(lambda text: self.on_render_fallback_changed('render_fallback_fonts_emoji', text))
         generalConfigPanel.addSublock(ConfigSubBlock(self.render_fallback_emoji_edit, self.tr('Emoji/symbol fallback fonts'), discription=self.tr('Comma-separated emoji/symbol fallback font families.')))
+        self.render_favorite_fonts_edit = QLineEdit(self)
+        self.render_favorite_fonts_edit.setPlaceholderText(self.tr('e.g. Anime Ace, Bangers, Noto Sans CJK JP'))
+        self.render_favorite_fonts_edit.textChanged.connect(self.on_render_favorite_fonts_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.render_favorite_fonts_edit,
+            self.tr('Favorite lettering fonts'),
+            discription=self.tr('Comma-separated font families shown as one-click favorites in the text formatting panel.')
+        ))
+
+        self.export_open_folder_after_batch_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Open export folder after batch export'),
+            discription=self.tr('After Export all pages as..., open the output folder so exported pages/CBZ/manifest are immediately visible.')
+        )
+        self.export_open_folder_after_batch_checker.stateChanged.connect(self.on_export_open_folder_after_batch_changed)
         self.auto_region_merge_combobox = QComboBox()
         self.auto_region_merge_combobox.addItem(self.tr('Never'), 'never')
         self.auto_region_merge_combobox.addItem(self.tr('After run: on all pages'), 'all_pages')
@@ -1878,6 +1892,13 @@ class ConfigPanel(Widget):
         pcfg.render_diagnostics_overlay = self.render_diagnostics_overlay_checker.isChecked()
     def on_render_fallback_changed(self, attr: str, text: str):
         setattr(pcfg, attr, text or '')
+
+    def on_render_favorite_fonts_changed(self, text: str):
+        pcfg.render_favorite_fonts = (text or '').strip()
+
+    def on_export_open_folder_after_batch_changed(self):
+        pcfg.export_open_folder_after_batch = self.export_open_folder_after_batch_checker.isChecked()
+
     def on_text_editor_top_padding_changed(self):
         pcfg.text_editor_top_padding = int(self.text_editor_top_padding_spin.value())
         try:
@@ -2119,6 +2140,10 @@ class ConfigPanel(Widget):
             self.render_fallback_korean_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_korean', '') or ''))
             self.render_fallback_rtl_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_rtl', '') or ''))
             self.render_fallback_emoji_edit.setText(str(getattr(pcfg, 'render_fallback_fonts_emoji', '') or ''))
+            if hasattr(self, 'render_favorite_fonts_edit'):
+                self.render_favorite_fonts_edit.setText(str(getattr(pcfg, 'render_favorite_fonts', '') or ''))
+            if hasattr(self, 'export_open_folder_after_batch_checker'):
+                self.export_open_folder_after_batch_checker.setChecked(bool(getattr(pcfg, 'export_open_folder_after_batch', False)))
         self.selectext_minimenu_checker.setChecked(pcfg.textselect_mini_menu)
         self.let_uppercase_checker.setChecked(pcfg.let_uppercase_flag)
         self.let_textstyle_indep_checker.setChecked(pcfg.let_textstyle_indep_flag)

--- a/ui/export_dialog.py
+++ b/ui/export_dialog.py
@@ -84,6 +84,16 @@ class ExportFormatDialog(QDialog):
         self.include_intermediate_check.setChecked(False)
         form.addRow('', self.include_intermediate_check)
 
+        self.open_folder_after_export_check = QCheckBox(self.tr('Open output folder when done'))
+        self.open_folder_after_export_check.setToolTip(self.tr('Use the persisted Settings default for this export.'))
+        try:
+            from utils.config import pcfg
+            self.open_folder_after_export_check.setChecked(bool(getattr(pcfg, 'export_open_folder_after_batch', False)))
+        except Exception:
+            self.open_folder_after_export_check.setChecked(False)
+        self.open_folder_after_export_check.toggled.connect(self._on_open_folder_after_export_toggled)
+        form.addRow('', self.open_folder_after_export_check)
+
         self.clean_after_export_check = QCheckBox(self.tr('Clean cache after export'))
         self.clean_after_export_check.setToolTip(self.tr('Remove mask and inpainted caches for this project after export (saves disk space).'))
         self.clean_after_export_check.setChecked(False)
@@ -145,8 +155,18 @@ class ExportFormatDialog(QDialog):
             self._zip_path = base + ('.cbz' if self.get_archive_format() == 'cbz' else '.zip')
             self.zip_path_label.setText(self._zip_path)
 
+    def _on_open_folder_after_export_toggled(self, checked: bool):
+        try:
+            from utils.config import pcfg
+            pcfg.export_open_folder_after_batch = bool(checked)
+        except Exception:
+            pass
+
     def get_include_intermediate(self) -> bool:
         return self.include_intermediate_check.isChecked()
+
+    def get_open_folder_after_export(self) -> bool:
+        return self.open_folder_after_export_check.isChecked()
 
     def get_clean_after_export(self) -> bool:
         return self.clean_after_export_check.isChecked()

--- a/ui/fontformat_commands.py
+++ b/ui/fontformat_commands.py
@@ -8,6 +8,7 @@ except:
     from qtpy.QtGui import QUndoCommand
 
 from . import shared_widget as SW
+from utils.config import pcfg
 from utils.fontformat import FontFormat, px2pt
 from .textitem import TextBlkItem
 
@@ -188,10 +189,10 @@ def ffmt_change_fallback_font_chain(param_name: str, values: str, act_ffmt: Font
 
 @font_formating(push_undostack=True)
 def ffmt_change_manga_preset(param_name: str, values: str, act_ffmt: FontFormat, is_global: bool, blkitems: List[TextBlkItem], **kwargs):
-    from utils.text_rendering import MANGA_PRESETS, normalize_writing_mode, resolve_writing_mode
+    from utils.text_rendering import manga_presets, normalize_writing_mode, resolve_writing_mode
     for blkitem, value in zip(blkitems, values):
         preset_id = str(value or "")
-        preset = MANGA_PRESETS.get(preset_id)
+        preset = manga_presets(pcfg).get(preset_id)
         if not preset:
             continue
         for key, preset_value in preset.items():

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -869,6 +869,7 @@ class MainWindow(mainwindow_cls):
             'render_current_page': self._api_render_current_page,
             'list_rendering_issues': self._api_list_rendering_issues,
             'apply_rendering_preset': self._api_apply_rendering_preset,
+            'rendering_presets': self._api_rendering_presets,
             'fix_rendering_issues': self._api_fix_rendering_issues,
             'export_rendering_qa': self._api_export_rendering_qa,
             'apply_project_rendering_fixes': self._api_apply_project_rendering_fixes,
@@ -959,6 +960,24 @@ class MainWindow(mainwindow_cls):
             result = self._do_batch_export(out_dir, ext=ext, also_pdf=also_pdf, show_message=False, clean_after_export=bool((body or {}).get('clean_after_export', False)), include_intermediate=bool((body or {}).get('include_intermediate', False)))
             self.pipelineInsightsPanel.add_event('API', self.tr('Batch export via API: {0} page(s)').format(result.get('exported', 0)))
             return {'ok': True, **(result or {})}
+        if kind in {'archive', 'zip', 'cbz'}:
+            import tempfile, zipfile
+            archive_format = 'cbz' if kind == 'cbz' or str((body or {}).get('archive_format', '')).lower() == 'cbz' else 'zip'
+            archive_path = str((body or {}).get('archive_path', '') or '').strip()
+            out_dir = str((body or {}).get('out_dir', '') or '').strip()
+            if not out_dir:
+                out_dir = tempfile.mkdtemp(prefix='bt_export_')
+            result = self._do_batch_export(out_dir, ext=str((body or {}).get('ext', '') or '').strip().lower() or None, also_pdf=bool((body or {}).get('also_pdf', False)), show_message=False, clean_after_export=bool((body or {}).get('clean_after_export', False)), include_intermediate=bool((body or {}).get('include_intermediate', False)))
+            if not archive_path:
+                archive_path = osp.join(self.imgtrans_proj.directory, 'exports', ('exported.cbz' if archive_format == 'cbz' else 'exported.zip'))
+            os.makedirs(osp.dirname(archive_path), exist_ok=True)
+            with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+                for root, _dirs, files in os.walk(out_dir):
+                    for fn in sorted(files):
+                        fp = osp.join(root, fn)
+                        zf.write(fp, osp.relpath(fp, out_dir))
+            self.pipelineInsightsPanel.add_event('API', self.tr('Archive export via API: {0}').format(archive_path))
+            return {'ok': True, 'archive_path': archive_path, 'archive_format': archive_format, **(result or {})}
         if kind in {'current_page', 'render_current_page'}:
             return self._api_render_current_page_ui(body)
         if kind in {'structured_ocr', 'ocr_json'}:
@@ -1173,6 +1192,7 @@ class MainWindow(mainwindow_cls):
             indices=indices,
             only_auto_sized=bool((body or {}).get('only_auto_sized', False)),
             dry_run=bool((body or {}).get('dry_run', False)),
+            config_obj=pcfg,
         )
         if result.get('changed') and not result.get('dry_run'):
             if self.imgtrans_proj.current_img in (result.get('touched_pages') or []):
@@ -1186,18 +1206,75 @@ class MainWindow(mainwindow_cls):
     def _api_apply_rendering_preset(self, body: dict):
         return self._api_call_ui(self._api_apply_rendering_preset_ui, body)
 
+    def _api_rendering_presets(self, body: dict):
+        return self._api_call_ui(self._api_rendering_presets_ui, body)
+
+    def _api_rendering_presets_ui(self, body: dict):
+        from utils.text_rendering import manga_presets, preset_from_font_format, preset_id_from_label, sanitize_manga_preset
+        from utils.rendering_preset_io import delete_custom_preset, import_preset_pack, preset_font_diagnostics, write_preset_pack
+        action = str((body or {}).get('action', 'list') or 'list').strip().lower()
+        if action == 'list':
+            presets = manga_presets(pcfg)
+            diagnostics = preset_font_diagnostics(presets, getattr(shared, 'FONT_FAMILIES', None) or [])
+            return {'ok': True, 'presets': presets, 'count': len(presets), 'font_diagnostics': diagnostics}
+        if action == 'save_current':
+            if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+                raise ValueError('open a project and select a page first')
+            idx = int((body or {}).get('index', 0) or 0)
+            blks = self.imgtrans_proj.pages.get(self.imgtrans_proj.current_img, [])
+            if idx < 0 or idx >= len(blks):
+                raise ValueError('invalid index')
+            name = str((body or {}).get('name', '') or '').strip() or f'Preset {idx + 1}'
+            custom = dict(getattr(pcfg, 'render_custom_manga_presets', {}) or {})
+            preset_id = preset_id_from_label(name, list(custom.keys()))
+            custom[preset_id] = preset_from_font_format(blks[idx].fontformat, label=name)
+            pcfg.render_custom_manga_presets = custom
+            save_config()
+            return {'ok': True, 'preset_id': preset_id, 'preset': custom[preset_id], 'count': len(custom)}
+        if action == 'save':
+            name = str((body or {}).get('name', '') or '').strip() or 'Custom preset'
+            preset_data = dict((body or {}).get('preset', {}) or {})
+            custom = dict(getattr(pcfg, 'render_custom_manga_presets', {}) or {})
+            preset_id = str((body or {}).get('preset_id', '') or '').strip() or preset_id_from_label(name, list(custom.keys()))
+            if not preset_id.startswith('custom:'):
+                preset_id = 'custom:' + preset_id
+            custom[preset_id] = sanitize_manga_preset(preset_data, label=name)
+            pcfg.render_custom_manga_presets = custom
+            save_config()
+            return {'ok': True, 'preset_id': preset_id, 'preset': custom[preset_id], 'count': len(custom)}
+        if action == 'export':
+            path = str((body or {}).get('path', '') or '').strip()
+            if not path:
+                raise ValueError('path is required')
+            pack = write_preset_pack(pcfg, path, include_builtins=bool((body or {}).get('include_builtins', False)))
+            diagnostics = preset_font_diagnostics(pack.get('presets', {}), getattr(shared, 'FONT_FAMILIES', None) or [])
+            return {'ok': True, 'path': pack.get('path', path), 'count': len(pack.get('presets', {}) or {}), 'font_diagnostics': diagnostics}
+        if action == 'import':
+            path = str((body or {}).get('path', '') or '').strip()
+            if not path:
+                raise ValueError('path is required')
+            result = import_preset_pack(pcfg, path, overwrite=bool((body or {}).get('overwrite', False)))
+            save_config()
+            return {'ok': True, **result}
+        if action == 'delete':
+            result = delete_custom_preset(pcfg, str((body or {}).get('preset_id', '') or ''))
+            save_config()
+            return {'ok': True, **result}
+        raise ValueError(f'unknown rendering_presets action: {action}')
+
     def _api_apply_rendering_preset_ui(self, body: dict):
-        from utils.text_rendering import MANGA_PRESETS
+        from utils.text_rendering import manga_presets
         if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
             raise ValueError('open a project and select a page first')
         preset_id = str((body or {}).get('preset', '') or '').strip()
-        if preset_id not in MANGA_PRESETS:
+        presets = manga_presets(pcfg)
+        if preset_id not in presets:
             raise ValueError(f'unknown preset: {preset_id}')
         indices = (body or {}).get('indices')
         page = self.imgtrans_proj.current_img
         blks = self.imgtrans_proj.pages.get(page, [])
         target = list(range(len(blks))) if indices is None else [int(i) for i in indices]
-        preset = MANGA_PRESETS[preset_id]
+        preset = presets[preset_id]
         applied = 0
         for idx in target:
             if idx < 0 or idx >= len(blks):
@@ -1351,7 +1428,7 @@ class MainWindow(mainwindow_cls):
 
     def on_open_batch_style_override(self):
         """Apply Koharu-inspired fixed font/alignment options across a page/project."""
-        from utils.text_rendering import MANGA_PRESETS
+        from utils.text_rendering import manga_presets
         if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
             self.pipelineInsightsPanel.add_warning('BATCH_STYLE', self.tr('Open a project before applying a batch text style override.'))
             return
@@ -1409,8 +1486,11 @@ class MainWindow(mainwindow_cls):
 
         preset = QComboBox(dlg)
         preset.addItem(self.tr('Keep'), '')
-        for preset_id, preset_def in MANGA_PRESETS.items():
-            preset.addItem(self.tr(preset_def.get('label', preset_id)), preset_id)
+        for preset_id, preset_def in manga_presets(pcfg).items():
+            label = str(preset_def.get('label', preset_id) or preset_id)
+            if preset_id.startswith('custom:'):
+                label = self.tr('Custom: ') + label
+            preset.addItem(self.tr(label), preset_id)
 
         fallback_chain = QLineEdit(dlg)
         fallback_chain.setPlaceholderText(self.tr('Leave blank to keep current per-style fallback chain'))
@@ -1501,7 +1581,7 @@ class MainWindow(mainwindow_cls):
         if auto_fit.isChecked() and 'font_size' not in updates:
             updates['auto_fit_font_size'] = True
         from utils.text_style_batch import apply_text_style_batch
-        result = apply_text_style_batch(self.imgtrans_proj, updates, pages=page_names, only_auto_sized=only_auto.isChecked())
+        result = apply_text_style_batch(self.imgtrans_proj, updates, pages=page_names, only_auto_sized=only_auto.isChecked(), config_obj=pcfg)
         changed = int(result.get('changed', 0))
         if self.imgtrans_proj.current_img in page_names:
             self.st_manager.updateSceneTextitems()
@@ -3883,6 +3963,7 @@ class MainWindow(mainwindow_cls):
                     self.imgtrans_proj.clean_mask_and_inpainted_cache()
                     msg += '\n' + self.tr('Cache cleaned.')
                 QMessageBox.information(self, self.tr('Export'), msg)
+                self._open_export_folder_if_requested(zip_path)
         finally:
             if temp_export_dir and osp.isdir(temp_export_dir):
                 try:
@@ -3890,6 +3971,22 @@ class MainWindow(mainwindow_cls):
                     shutil.rmtree(temp_export_dir, ignore_errors=True)
                 except Exception:
                     pass
+
+    def _open_export_folder_if_requested(self, path: str):
+        if not getattr(pcfg, 'export_open_folder_after_batch', False):
+            return
+        try:
+            target = path if osp.isdir(path) else osp.dirname(path)
+            if not target:
+                return
+            if sys.platform.startswith('win'):
+                os.startfile(target)  # type: ignore[attr-defined]
+            elif sys.platform == 'darwin':
+                subprocess.Popen(['open', target])
+            else:
+                subprocess.Popen(['xdg-open', target])
+        except Exception as e:
+            LOGGER.warning('Could not open export folder %s: %s', path, e)
 
     def _do_batch_export(self, out_dir: str, ext: str = None, also_pdf: bool = False, show_message: bool = True, clean_after_export: bool = False, include_intermediate: bool = False):
         try:
@@ -3975,6 +4072,7 @@ class MainWindow(mainwindow_cls):
                 msg += '\n' + self.tr('Cache cleaned.')
             if show_message:
                 QMessageBox.information(self, self.tr('Export'), msg)
+                self._open_export_folder_if_requested(out_dir)
             return {'exported': exported, 'missing': missing, 'paths': exported_paths, 'helper_paths': helper_paths, 'manifest': manifest, 'marked_exported': marked_exported}
         except Exception as e:
             LOGGER.exception(e)

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1746,6 +1746,15 @@ class SceneTextManager(QObject):
                 blkitem.fontformat.line_break_strategy = strategy
                 if blkitem.blk is not None:
                     blkitem.blk.fontformat.line_break_strategy = strategy
+            for action in grouped["tighten_letter_spacing"]:
+                blkitem = selected_by_idx.get(action.block_index)
+                if blkitem is None:
+                    continue
+                spacing = max(0.80, min(float(getattr(blkitem.fontformat, 'letter_spacing', 1.0) or 1.0), float(action.args.get("letter_spacing", 0.94) or 0.94)))
+                blkitem.fontformat.letter_spacing = spacing
+                if blkitem.blk is not None:
+                    blkitem.blk.fontformat.letter_spacing = spacing
+                blkitem.set_fontformat(blkitem.fontformat)
             for action in grouped["balance_lines"]:
                 blkitem = selected_by_idx.get(action.block_index)
                 if blkitem is None:
@@ -1763,8 +1772,9 @@ class SceneTextManager(QObject):
                 if blkitem is None:
                     continue
                 preset_id = str(action.args.get("preset", "default_manga_bubble") or "default_manga_bubble")
-                from utils.text_rendering import MANGA_PRESETS
-                preset = MANGA_PRESETS.get(preset_id)
+                from utils.text_rendering import manga_presets
+                from utils.config import pcfg
+                preset = manga_presets(pcfg).get(preset_id)
                 if not preset:
                     continue
                 for key, value in preset.items():

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -2,7 +2,7 @@ import copy
 import sys
 from typing import List
 
-from qtpy.QtWidgets import QLineEdit, QSizePolicy, QHBoxLayout, QVBoxLayout, QFrame, QFontComboBox, QApplication, QPushButton, QLabel, QGroupBox, QCheckBox, QSlider, QComboBox, QDoubleSpinBox
+from qtpy.QtWidgets import QLineEdit, QSizePolicy, QHBoxLayout, QVBoxLayout, QFrame, QFontComboBox, QApplication, QPushButton, QLabel, QGroupBox, QCheckBox, QSlider, QComboBox, QDoubleSpinBox, QInputDialog, QFileDialog, QMessageBox
 from qtpy.QtCore import Signal, Qt
 from qtpy.QtGui import QFocusEvent, QMouseEvent, QTextCursor, QKeyEvent
 
@@ -10,7 +10,7 @@ from utils import shared
 from utils import config as C
 from utils.config import pcfg
 from utils.fontformat import FontFormat, px2pt, LineSpacingType
-from utils.text_rendering import MANGA_PRESETS, merge_font_fallback_chain, missing_glyphs_after_fallback, normalize_fit_mode, normalize_writing_mode, normalize_line_break_strategy
+from utils.text_rendering import MANGA_PRESETS, manga_presets, merge_font_fallback_chain, missing_glyphs_after_fallback, normalize_fit_mode, normalize_writing_mode, normalize_line_break_strategy, preset_from_font_format, preset_id_from_label
 from .custom_widget import Widget, ColorPickerLabel, ClickableLabel, CheckableLabel, TextCheckerLabel, AlignmentChecker, QFontChecker, SizeComboBox, SizeControlLabel
 from .custom_widget.flow_layout import FlowLayout
 from .textitem import TextBlkItem
@@ -73,6 +73,35 @@ def _make_format_group(title: str, widgets: list, parent=None, tooltip: str = No
         widget.setSizePolicy(QSizePolicy.Policy.Maximum, QSizePolicy.Policy.Fixed)
         layout.addWidget(widget)
     return group
+
+
+def _font_list_from_config(attr: str) -> List[str]:
+    seen = set()
+    out: List[str] = []
+    for part in str(getattr(pcfg, attr, '') or '').split(','):
+        family = part.strip()
+        if family and family.lower() not in seen:
+            seen.add(family.lower())
+            out.append(family)
+    return out
+
+
+def _favorite_font_list() -> List[str]:
+    return _font_list_from_config('render_favorite_fonts')
+
+
+def _recent_font_list() -> List[str]:
+    return _font_list_from_config('render_recent_fonts')
+
+
+def _remember_recent_font(family: str):
+    family = str(family or '').strip()
+    if not family:
+        return
+    recent = [f for f in _recent_font_list() if f.lower() != family.lower()]
+    recent.insert(0, family)
+    pcfg.render_recent_fonts = ', '.join(recent[:16])
+    C.save_config()
 
 
 class AlignmentBtnGroup(QFrame):
@@ -254,6 +283,7 @@ class FontFamilyComboBox(QFontComboBox):
     def apply_fontfamily(self):
         ffamily = self.currentFont().family()
         if ffamily in shared.FONT_FAMILIES:
+            _remember_recent_font(ffamily)
             self.param_changed.emit('font_family', ffamily)
 
     def update_font_list(self, font_list):
@@ -297,6 +327,18 @@ class FontFormatPanel(Widget):
         self.familybox.setToolTip(self.tr("Font Family"))
         self.familybox.param_changed.connect(self.on_param_changed)
         self.familybox.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+
+        self.favoriteFontCombo = QComboBox(self)
+        self.favoriteFontCombo.setObjectName("FavoriteFontCombo")
+        self.favoriteFontCombo.setMinimumWidth(170)
+        self.favoriteFontCombo.setToolTip(self.tr("Favorite lettering fonts from Settings → Favorite lettering fonts. Choosing one applies it to the current selection/style."))
+        self.favoriteFontCombo.currentIndexChanged.connect(self._on_favorite_font_selected)
+        self.addFavoriteFontBtn = QPushButton(self.tr("★"), self)
+        self.addFavoriteFontBtn.setObjectName("AddFavoriteFontButton")
+        self.addFavoriteFontBtn.setToolTip(self.tr("Add the current font family to favorite lettering fonts."))
+        self.addFavoriteFontBtn.setFixedWidth(32)
+        self.addFavoriteFontBtn.clicked.connect(self._on_add_favorite_font_clicked)
+        self._refresh_favorite_fonts()
 
         self.fontsizebox = FontSizeBox(self)
         self.fontsizebox.setToolTip(self.tr("Font Size"))
@@ -370,13 +412,20 @@ class FontFormatPanel(Widget):
 
         self.mangaPresetCombo = QComboBox(self)
         self.mangaPresetCombo.setObjectName("MangaPresetCombo")
-        self.mangaPresetCombo.addItem(self.tr("Preset: none"), "")
-        for preset_id, preset in MANGA_PRESETS.items():
-            self.mangaPresetCombo.addItem(self.tr(preset.get("label", preset_id)), preset_id)
         self.mangaPresetCombo.setMinimumWidth(150)
         self.mangaPresetCombo.setToolTip(self.tr("Apply manga lettering presets to the current selection/style: stroke, spacing, writing mode, fit mode, alignment, and padding."))
         self.mangaPresetCombo.currentIndexChanged.connect(self._on_manga_preset_changed)
         self.mangaPresetCombo.currentTextChanged.connect(lambda _t: _set_combo_tooltip_to_current(self.mangaPresetCombo, self.tr("Manga lettering preset for current selection/style.")))
+        self.saveMangaPresetBtn = QPushButton(self.tr("Save preset"), self)
+        self.saveMangaPresetBtn.setToolTip(self.tr("Save the current style/textbox formatting as a reusable manga lettering preset."))
+        self.saveMangaPresetBtn.clicked.connect(self._on_save_manga_preset_clicked)
+        self.importMangaPresetsBtn = QPushButton(self.tr("Import presets"), self)
+        self.importMangaPresetsBtn.setToolTip(self.tr("Import a shared manga lettering preset JSON pack."))
+        self.importMangaPresetsBtn.clicked.connect(self._on_import_manga_presets_clicked)
+        self.exportMangaPresetsBtn = QPushButton(self.tr("Export presets"), self)
+        self.exportMangaPresetsBtn.setToolTip(self.tr("Export your custom manga lettering presets as a reusable JSON pack."))
+        self.exportMangaPresetsBtn.clicked.connect(self._on_export_manga_presets_clicked)
+        self._refresh_manga_presets()
 
         self.fallbackChainEdit = LineEdit(parent=self)
         self.fallbackChainEdit.setObjectName("FallbackFontChainEdit")
@@ -605,6 +654,8 @@ class FontFormatPanel(Widget):
         vl0.setContentsMargins(0, 0, 0, 0)
         hl1 = QHBoxLayout()
         hl1.addWidget(self.familybox)
+        hl1.addWidget(self.favoriteFontCombo)
+        hl1.addWidget(self.addFavoriteFontBtn)
         hl1.addWidget(self.fontsizebox)
         hl1.addWidget(self.lineSpacingLabel)
         hl1.addWidget(self.lineSpacingBox)
@@ -621,7 +672,7 @@ class FontFormatPanel(Widget):
         hl2.setContentsMargins(4, 0, 4, 0)
         layout_group = _make_format_group(
             self.tr("Selection layout overrides"),
-            [self.writingModeCombo, self.fitModeCombo, self.lineBreakCombo, self.mangaPresetCombo, self.textPaddingSpinBox, self.fitMinFontSizeSpinBox, self.fitMaxFontSizeSpinBox],
+            [self.writingModeCombo, self.fitModeCombo, self.lineBreakCombo, self.mangaPresetCombo, self.saveMangaPresetBtn, self.importMangaPresetsBtn, self.exportMangaPresetsBtn, self.textPaddingSpinBox, self.fitMinFontSizeSpinBox, self.fitMaxFontSizeSpinBox],
             self,
             self.tr("Current style/textbox controls. Project defaults are in Settings → Project text rendering defaults.")
         )
@@ -720,6 +771,111 @@ class FontFormatPanel(Widget):
             return af.fontfmt
         else:
             return None
+
+    def _refresh_manga_presets(self):
+        if not hasattr(self, 'mangaPresetCombo'):
+            return
+        current = self.mangaPresetCombo.currentData()
+        self.mangaPresetCombo.blockSignals(True)
+        self.mangaPresetCombo.clear()
+        self.mangaPresetCombo.addItem(self.tr("Preset: none"), "")
+        presets = manga_presets(pcfg)
+        for preset_id, preset in presets.items():
+            label = str(preset.get("label", preset_id) or preset_id)
+            if preset_id.startswith('custom:'):
+                label = self.tr('Custom: ') + label
+            self.mangaPresetCombo.addItem(self.tr(label), preset_id)
+        idx = self.mangaPresetCombo.findData(current) if current else 0
+        self.mangaPresetCombo.setCurrentIndex(idx if idx >= 0 else 0)
+        self.mangaPresetCombo.blockSignals(False)
+
+    def _on_save_manga_preset_clicked(self):
+        fmt = self._current_format_for_reset()
+        if fmt is None:
+            return
+        default_name = getattr(fmt, '_style_name', '') or self.tr('Custom manga preset')
+        name, ok = QInputDialog.getText(self, self.tr('Save manga lettering preset'), self.tr('Preset name:'), text=default_name)
+        if not ok:
+            return
+        name = str(name or '').strip()
+        if not name:
+            return
+        custom = dict(getattr(pcfg, 'render_custom_manga_presets', {}) or {})
+        preset_id = preset_id_from_label(name, list(MANGA_PRESETS.keys()) + list(custom.keys()))
+        custom[preset_id] = preset_from_font_format(fmt, label=name)
+        pcfg.render_custom_manga_presets = custom
+        C.save_config()
+        self._refresh_manga_presets()
+        self._set_combo_by_data(self.mangaPresetCombo, preset_id)
+        self.on_param_changed('manga_preset', preset_id)
+
+    def _on_export_manga_presets_clicked(self):
+        from utils.rendering_preset_io import preset_font_diagnostics, write_preset_pack
+        default_path = 'manga_lettering_presets.json'
+        path, _ = QFileDialog.getSaveFileName(self, self.tr('Export manga lettering presets'), default_path, self.tr('Preset packs (*.json)'))
+        if not path:
+            return
+        pack = write_preset_pack(pcfg, path)
+        diagnostics = preset_font_diagnostics(pack.get('presets', {}), getattr(shared, 'FONT_FAMILIES', None) or [])
+        msg = self.tr('Exported {0} custom preset(s) to:\n{1}').format(len(pack.get('presets', {}) or {}), pack.get('path', path))
+        missing = diagnostics.get('missing', {}) if diagnostics.get('checked') else {}
+        if missing:
+            msg += '\n\n' + self.tr('Missing font families on this machine: ') + ', '.join(sorted(set(missing.values())))
+        QMessageBox.information(self, self.tr('Export presets'), msg)
+
+    def _on_import_manga_presets_clicked(self):
+        from utils.rendering_preset_io import import_preset_pack
+        path, _ = QFileDialog.getOpenFileName(self, self.tr('Import manga lettering presets'), '', self.tr('Preset packs (*.json)'))
+        if not path:
+            return
+        result = import_preset_pack(pcfg, path, overwrite=False)
+        C.save_config()
+        self._refresh_manga_presets()
+        QMessageBox.information(
+            self,
+            self.tr('Import presets'),
+            self.tr('Imported {0} preset(s). Total custom presets: {1}.').format(result.get('imported_count', 0), result.get('total_custom_presets', 0))
+        )
+
+    def _refresh_favorite_fonts(self):
+        if not hasattr(self, 'favoriteFontCombo'):
+            return
+        current = self.favoriteFontCombo.currentData()
+        self.favoriteFontCombo.blockSignals(True)
+        self.favoriteFontCombo.clear()
+        self.favoriteFontCombo.addItem(self.tr('Favorites / recent'), '')
+        favorites = _favorite_font_list()
+        for family in favorites:
+            self.favoriteFontCombo.addItem(self.tr('★ {0}').format(family), family)
+        fav_lower = {f.lower() for f in favorites}
+        for family in _recent_font_list():
+            if family.lower() not in fav_lower:
+                self.favoriteFontCombo.addItem(self.tr('Recent: {0}').format(family), family)
+        idx = self.favoriteFontCombo.findData(current) if current else 0
+        self.favoriteFontCombo.setCurrentIndex(idx if idx >= 0 else 0)
+        self.favoriteFontCombo.blockSignals(False)
+
+    def _on_favorite_font_selected(self, index: int):
+        family = str(self.favoriteFontCombo.itemData(index) or '').strip()
+        if not family:
+            return
+        self.familybox.setCurrentText(family)
+        self.on_param_changed('font_family', family)
+        self.favoriteFontCombo.blockSignals(True)
+        self.favoriteFontCombo.setCurrentIndex(0)
+        self.favoriteFontCombo.blockSignals(False)
+
+    def _on_add_favorite_font_clicked(self):
+        family = self.familybox.currentFont().family() or self.familybox.currentText()
+        family = str(family or '').strip()
+        if not family:
+            return
+        favorites = _favorite_font_list()
+        if family.lower() not in {f.lower() for f in favorites}:
+            favorites.insert(0, family)
+            pcfg.render_favorite_fonts = ', '.join(favorites[:24])
+            C.save_config()
+        self._refresh_favorite_fonts()
 
     def on_param_changed(self, param_name: str, value):
         func = FM.handle_ffmt_change.get(param_name)
@@ -925,6 +1081,7 @@ class FontFormatPanel(Widget):
             font_size += "+"
         self.fontsizebox.fcombobox.setCurrentText(font_size)
         self.familybox.setCurrentText(font_format.font_family)
+        self._refresh_favorite_fonts()
         self.colorPicker.setPickerColor(font_format.foreground_color())
         self.strokeColorPicker.setPickerColor(font_format.stroke_color())
         self.strokeWidthBox.setValue(font_format.stroke_width)
@@ -940,6 +1097,7 @@ class FontFormatPanel(Widget):
         self.lineBreakCombo.blockSignals(True)
         self._set_combo_by_data(self.lineBreakCombo, normalize_line_break_strategy(getattr(font_format, 'line_break_strategy', 'auto')))
         self.lineBreakCombo.blockSignals(False)
+        self._refresh_manga_presets()
         self.mangaPresetCombo.blockSignals(True)
         self._set_combo_by_data(self.mangaPresetCombo, getattr(font_format, 'manga_preset', '') or '')
         self.mangaPresetCombo.blockSignals(False)

--- a/utils/config.py
+++ b/utils/config.py
@@ -586,6 +586,10 @@ class ProgramConfig(Config):
     render_fallback_fonts_korean: str = "Noto Sans CJK KR, Malgun Gothic"
     render_fallback_fonts_rtl: str = "Noto Naskh Arabic, Arial, Segoe UI"
     render_fallback_fonts_emoji: str = "Noto Color Emoji, Segoe UI Emoji, Apple Color Emoji"
+    render_favorite_fonts: str = ""  # Comma-separated favorites shown first in text formatting font picker.
+    render_recent_fonts: str = ""  # Recently applied text-panel font families for quick reuse.
+    render_custom_manga_presets: Dict = field(default_factory=dict)
+    export_open_folder_after_batch: bool = False
     text_editor_top_padding: int = 14
     # Smooth scroll: animate scroll position on wheel (ms). 0 = off. 80–200 = subtle enhanced feel.
     smooth_scroll_duration_ms: int = 0
@@ -706,7 +710,7 @@ CONFIG_KEY_ORDER = (
     "model_packages_enabled", "model_package_preset_ids",
     "dev_mode",
     "diagnostic_mode",
-    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_default_line_break_strategy", "render_default_reading_order", "render_overflow_warnings", "render_diagnostics_overlay", "render_default_font_family", "render_default_stroke_width", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji", "text_editor_top_padding",
+    "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_default_line_break_strategy", "render_default_reading_order", "render_overflow_warnings", "render_diagnostics_overlay", "render_default_font_family", "render_default_stroke_width", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji", "render_favorite_fonts", "render_recent_fonts", "render_custom_manga_presets", "export_open_folder_after_batch", "text_editor_top_padding",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
     "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_run_macros",
     "huggingface_token", "translator_last_model_by_provider",

--- a/utils/layout_review_agent.py
+++ b/utils/layout_review_agent.py
@@ -15,6 +15,7 @@ ActionType = Literal[
     "switch_writing_mode",
     "recenter",
     "increase_padding",
+    "tighten_letter_spacing",
     "balance_lines",
     "apply_manga_preset",
     "set_line_break_strategy",
@@ -185,6 +186,17 @@ class LayoutReviewPlanner:
                     reason="Compatibility action: reduce font size to fit current box before resizing.",
                 )
             )
+            letter_spacing = float((blk.text_style or {}).get("letter_spacing", 1.0) or 1.0)
+            if overflow_x and letter_spacing > 0.92:
+                from .text_rendering import recommended_tight_letter_spacing
+                actions.append(
+                    ReviewAction(
+                        action="tighten_letter_spacing",
+                        block_index=blk.block_index,
+                        args={"letter_spacing": recommended_tight_letter_spacing(letter_spacing, max(est_w / max(1.0, bw), 1.0))},
+                        reason="Tighten tracking slightly before shrinking/resizing wide manga lettering.",
+                    )
+                )
             if (blk.text_style or {}).get("fit_mode") == "balance" or (blk.text_style or {}).get("line_break_strategy") != "balanced":
                 actions.append(
                     ReviewAction(
@@ -480,6 +492,7 @@ def collect_actions_by_type(page_result: PageReviewResult) -> Dict[ActionType, L
         "switch_writing_mode": [],
         "recenter": [],
         "increase_padding": [],
+        "tighten_letter_spacing": [],
         "balance_lines": [],
         "apply_manga_preset": [],
         "set_line_break_strategy": [],
@@ -509,6 +522,7 @@ def collect_actions_from_list(actions: Sequence[ReviewAction]) -> Dict[ActionTyp
         "switch_writing_mode": [],
         "recenter": [],
         "increase_padding": [],
+        "tighten_letter_spacing": [],
         "balance_lines": [],
         "apply_manga_preset": [],
         "set_line_break_strategy": [],

--- a/utils/rendering_preset_io.py
+++ b/utils/rendering_preset_io.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Dict, Iterable, Mapping, Optional, Tuple
+
+from .text_rendering import custom_manga_presets, manga_presets, preset_id_from_label, sanitize_manga_preset
+
+PRESET_PACK_FORMAT = "ballonstranslator.rendering_presets.v1"
+
+
+def build_preset_pack(config_obj, include_builtins: bool = False, source: str = "BallonsTranslator-Pro") -> Dict[str, object]:
+    """Build a portable JSON pack for custom manga lettering presets."""
+    presets = manga_presets(config_obj) if include_builtins else custom_manga_presets(config_obj)
+    return {
+        "format": PRESET_PACK_FORMAT,
+        "exported_at": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "include_builtins": bool(include_builtins),
+        "presets": {pid: sanitize_manga_preset(preset) for pid, preset in presets.items()},
+    }
+
+
+def write_preset_pack(config_obj, path: str, include_builtins: bool = False) -> Dict[str, object]:
+    path = os.path.normpath(str(path or ""))
+    if not path:
+        raise ValueError("path is required")
+    if not path.lower().endswith(".json"):
+        path += ".json"
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    pack = build_preset_pack(config_obj, include_builtins=include_builtins)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(pack, f, ensure_ascii=False, indent=2)
+    pack["path"] = path
+    return pack
+
+
+def _preset_entries_from_pack(data: Mapping[str, object]) -> Dict[str, Dict[str, object]]:
+    if not isinstance(data, Mapping):
+        raise ValueError("preset pack must be a JSON object")
+    presets = data.get("presets", data)
+    if not isinstance(presets, Mapping):
+        raise ValueError("preset pack does not contain a presets object")
+    out: Dict[str, Dict[str, object]] = {}
+    for preset_id, preset in presets.items():
+        if not isinstance(preset, Mapping):
+            continue
+        label = str(preset.get("label") or preset_id or "Imported preset")
+        pid = str(preset_id or "").strip()
+        if not pid or pid == "label":
+            pid = preset_id_from_label(label, out.keys())
+        if not pid.startswith("custom:"):
+            pid = "custom:" + pid
+        out[pid] = sanitize_manga_preset(dict(preset), label=label)
+    return out
+
+
+def read_preset_pack(path: str) -> Dict[str, object]:
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    return {"path": path, "presets": _preset_entries_from_pack(data), "format": data.get("format", "unknown") if isinstance(data, Mapping) else "unknown"}
+
+
+def import_preset_pack(config_obj, path: str, overwrite: bool = False) -> Dict[str, object]:
+    loaded = read_preset_pack(path)
+    incoming: Dict[str, Dict[str, object]] = dict(loaded.get("presets", {}) or {})
+    current: Dict[str, Dict[str, object]] = dict(getattr(config_obj, "render_custom_manga_presets", {}) or {})
+    imported: Dict[str, str] = {}
+    skipped: Dict[str, str] = {}
+    for preset_id, preset in incoming.items():
+        target_id = preset_id
+        if target_id in current and not overwrite:
+            label = str(preset.get("label") or target_id.split(":", 1)[-1])
+            target_id = preset_id_from_label(label, list(current.keys()) + list(imported.values()))
+        if target_id in current and overwrite:
+            current[target_id] = preset
+            imported[preset_id] = target_id
+        elif target_id not in current:
+            current[target_id] = preset
+            imported[preset_id] = target_id
+        else:
+            skipped[preset_id] = "duplicate"
+    config_obj.render_custom_manga_presets = current
+    return {"path": path, "imported": imported, "skipped": skipped, "imported_count": len(imported), "total_custom_presets": len(current)}
+
+
+def delete_custom_preset(config_obj, preset_id: str) -> Dict[str, object]:
+    preset_id = str(preset_id or "").strip()
+    current = dict(getattr(config_obj, "render_custom_manga_presets", {}) or {})
+    existed = preset_id in current
+    if existed:
+        current.pop(preset_id, None)
+        config_obj.render_custom_manga_presets = current
+    return {"preset_id": preset_id, "deleted": bool(existed), "total_custom_presets": len(current)}
+
+
+def preset_font_diagnostics(presets: Mapping[str, Mapping[str, object]], available_fonts: Optional[Iterable[str]] = None) -> Dict[str, object]:
+    """Return missing-font diagnostics for preset libraries without requiring Qt imports."""
+    available = {str(f).lower() for f in (available_fonts or []) if str(f or "").strip()}
+    if not available:
+        return {"checked": False, "missing": {}, "used_fonts": []}
+    used = []
+    missing = {}
+    for preset_id, preset in (presets or {}).items():
+        family = str((preset or {}).get("font_family", "") or "").strip()
+        if not family:
+            continue
+        used.append(family)
+        if family.lower() not in available:
+            missing[str(preset_id)] = family
+    return {"checked": True, "missing": missing, "used_fonts": sorted(set(used), key=str.lower)}

--- a/utils/rendering_qa.py
+++ b/utils/rendering_qa.py
@@ -22,6 +22,7 @@ from .text_rendering import (
     merge_font_fallback_chain,
     missing_glyphs_after_fallback,
     resolve_writing_mode,
+    recommended_tight_letter_spacing,
 )
 
 
@@ -106,6 +107,12 @@ def analyze_text_block(blk, page: str, index: int, config_obj=None) -> Dict:
     if overflow:
         warnings.append("overflow")
         suggestions.append({"action": "shrink_to_fit", "reason": "Measured text bounds exceed textbox bounds."})
+        if measured[0] > box_w and float(getattr(fmt, "letter_spacing", 1.0) or 1.0) > 0.92:
+            suggestions.append({
+                "action": "tighten_letter_spacing",
+                "letter_spacing": recommended_tight_letter_spacing(float(getattr(fmt, "letter_spacing", 1.0) or 1.0), measured[0] / max(1.0, box_w)),
+                "reason": "Wide lettering can often fit by tightening tracking before shrinking the font.",
+            })
     if missing:
         warnings.append("missing_glyphs")
         chain = fallback_chain_for_text(text, config_obj)
@@ -397,6 +404,14 @@ def apply_project_rendering_fixes(project, pages: Optional[Sequence[str]] = None
                             new_h = max(box_h, rec_h)
                             blk.xyxy = [cx - new_w / 2.0, cy - new_h / 2.0, cx + new_w / 2.0, cy + new_h / 2.0]
                             changed.append("textbox_size")
+            if "overflow" in diag["warnings"] and wants("tighten_letter_spacing"):
+                for suggestion in diag.get("suggestions", []) or []:
+                    if suggestion.get("action") == "tighten_letter_spacing":
+                        new_spacing = max(0.80, min(float(getattr(fmt, "letter_spacing", 1.0) or 1.0), float(suggestion.get("letter_spacing", 0.94) or 0.94)))
+                        if new_spacing < float(getattr(fmt, "letter_spacing", 1.0) or 1.0):
+                            fmt.letter_spacing = new_spacing
+                            changed.append("letter_spacing")
+                        break
             if "overflow" in diag["warnings"] and (wants("shrink_to_fit") or wants("balance_lines")):
                 fit_mode = getattr(fmt, "fit_mode", FIT_MODE_SHRINK)
                 if fit_mode in (FIT_MODE_SHRINK, FIT_MODE_EXPAND, FIT_MODE_PRESERVE, FIT_MODE_BALANCE):

--- a/utils/text_rendering.py
+++ b/utils/text_rendering.py
@@ -120,6 +120,32 @@ MANGA_PRESETS = {
     },
 }
 
+STYLE_PRESET_FIELDS = (
+    "font_family",
+    "font_size",
+    "font_weight",
+    "bold",
+    "italic",
+    "frgb",
+    "srgb",
+    "stroke_width",
+    "shadow_radius",
+    "shadow_strength",
+    "shadow_color",
+    "shadow_offset",
+    "line_spacing",
+    "letter_spacing",
+    "alignment",
+    "writing_mode",
+    "fit_mode",
+    "line_break_strategy",
+    "text_padding",
+    "fit_font_size_min",
+    "fit_font_size_max",
+    "opacity",
+    "fallback_font_chain",
+)
+
 
 @dataclass
 class TextRenderDiagnostics:
@@ -189,6 +215,106 @@ def normalize_reading_order(order: Optional[str]) -> str:
     aliases = {"right_to_left": READING_ORDER_RTL, "left_to_right": READING_ORDER_LTR, "top_to_bottom": READING_ORDER_TTB}
     order = aliases.get(order, order)
     return order if order in READING_ORDERS else READING_ORDER_AUTO
+
+
+def preset_id_from_label(label: str, existing: Optional[Sequence[str]] = None) -> str:
+    """Return a stable custom preset id from a user-facing label."""
+    base = re.sub(r"[^a-z0-9]+", "_", (label or "").strip().lower()).strip("_") or "custom_preset"
+    existing_set = {str(x) for x in (existing or [])}
+    candidate = f"custom:{base}"
+    n = 2
+    while candidate in existing_set or candidate in MANGA_PRESETS:
+        candidate = f"custom:{base}_{n}"
+        n += 1
+    return candidate
+
+
+def sanitize_manga_preset(preset: Dict[str, object], label: str = "") -> Dict[str, object]:
+    """Clamp a user-saved manga lettering preset to supported, serializable fields."""
+    src = dict(preset or {})
+    out: Dict[str, object] = {"label": str(src.get("label") or label or "Custom preset").strip() or "Custom preset"}
+    for key in STYLE_PRESET_FIELDS:
+        if key not in src:
+            continue
+        value = src.get(key)
+        if key in {"writing_mode", "fit_mode", "line_break_strategy"}:
+            if key == "writing_mode":
+                value = normalize_writing_mode(value)
+            elif key == "fit_mode":
+                value = normalize_fit_mode(value)
+            else:
+                value = normalize_line_break_strategy(value)
+        elif key in {"font_size", "stroke_width", "shadow_radius", "shadow_strength", "line_spacing", "letter_spacing", "text_padding", "fit_font_size_min", "fit_font_size_max", "opacity"}:
+            try:
+                value = float(value)
+            except Exception:
+                continue
+            if key == "opacity":
+                value = max(0.0, min(1.0, value))
+            elif key == "font_size":
+                value = max(1.0, min(512.0, value))
+            else:
+                value = max(0.0, value)
+        elif key in {"bold", "italic"}:
+            value = bool(value)
+        elif key in {"alignment"}:
+            try:
+                value = max(0, min(2, int(value)))
+            except Exception:
+                continue
+        elif key in {"frgb", "srgb", "shadow_color", "shadow_offset"}:
+            try:
+                seq = list(value or [])
+                limit = 2 if key == "shadow_offset" else 3
+                value = [float(v) if key == "shadow_offset" else int(max(0, min(255, int(v)))) for v in seq[:limit]]
+                while len(value) < limit:
+                    value.append(0.0 if key == "shadow_offset" else 0)
+            except Exception:
+                continue
+        elif key == "font_weight":
+            if value is None:
+                continue
+            try:
+                value = int(value)
+            except Exception:
+                continue
+        else:
+            value = str(value or "").strip()
+        out[key] = value
+    return out
+
+
+def custom_manga_presets(config_obj=None) -> Dict[str, Dict[str, object]]:
+    raw = getattr(config_obj, "render_custom_manga_presets", {}) if config_obj is not None else {}
+    if not isinstance(raw, dict):
+        return {}
+    out: Dict[str, Dict[str, object]] = {}
+    for preset_id, preset in raw.items():
+        pid = str(preset_id or "").strip()
+        if not pid:
+            continue
+        if not pid.startswith("custom:"):
+            pid = "custom:" + pid
+        out[pid] = sanitize_manga_preset(preset, label=pid.split(":", 1)[-1].replace("_", " "))
+    return out
+
+
+def manga_presets(config_obj=None) -> Dict[str, Dict[str, object]]:
+    """Built-in presets plus persisted user presets for UI/API/batch code."""
+    presets = {k: dict(v) for k, v in MANGA_PRESETS.items()}
+    presets.update(custom_manga_presets(config_obj))
+    return presets
+
+
+def preset_from_font_format(font_format, label: str = "Custom preset") -> Dict[str, object]:
+    values: Dict[str, object] = {"label": label}
+    for key in STYLE_PRESET_FIELDS:
+        if hasattr(font_format, key):
+            value = getattr(font_format, key)
+            if isinstance(value, (list, tuple)):
+                value = list(value)
+            values[key] = value
+    return sanitize_manga_preset(values, label=label)
 
 
 def contains_cjk(text: str) -> bool:
@@ -341,6 +467,47 @@ def normalize_vertical_punctuation(text: str) -> str:
     for src, dst in VERTICAL_PUNCT_MAP.items():
         out = out.replace(src, dst)
     return out
+
+
+def glyph_advance_units(text: str, mode: str = WRITING_MODE_HORIZONTAL_LTR) -> float:
+    """Estimate visual advance units more accurately than raw len().
+
+    CJK lettering has full-width ideographs but many punctuation marks occupy
+    half/centered cells, while emoji/symbols often need a wider cell. This
+    dependency-free estimate improves fit diagnostics and layout review without
+    requiring platform font metrics.
+    """
+    mode = normalize_writing_mode(mode)
+    total = 0.0
+    for ch in text or "":
+        if ch == "\n":
+            continue
+        if ch.isspace():
+            total += 0.35
+        elif ch in VERTICAL_CENTER_PUNCT or unicodedata.category(ch).startswith("P"):
+            total += 0.55 if mode != WRITING_MODE_VERTICAL_RL else 0.80
+        elif _is_cjk_char(ch) or KOREAN_RE.match(ch):
+            total += 1.0
+        elif ord(ch) >= 0x1F000:
+            total += 1.2
+        elif unicodedata.combining(ch):
+            total += 0.0
+        else:
+            total += 0.56
+    return total
+
+
+def max_visual_line_units(lines: Sequence[str], mode: str = WRITING_MODE_HORIZONTAL_LTR) -> float:
+    return max((glyph_advance_units(line, mode) for line in lines or []), default=0.0)
+
+
+def recommended_tight_letter_spacing(current: float, overflow_ratio: float, floor: float = 0.88) -> float:
+    """Return a conservative manga-lettering tracking value for overflow fixes."""
+    cur = max(0.1, float(current or 1.0))
+    if overflow_ratio <= 1.0:
+        return cur
+    # Do not over-condense; leave shrinking/resizing to the next review action.
+    return round(max(float(floor), min(cur, cur / min(1.12, overflow_ratio))), 3)
 
 
 def vertical_tate_chu_yoko_groups(text: str) -> List[Dict[str, object]]:
@@ -863,7 +1030,7 @@ def estimate_text_bounds(
         max_chars = max(1, int(usable_h / max(1.0, cjk_avg)))
         cols = vertical_columns(text, max_chars, line_break_strategy)
         measured_w = max(1, len(cols)) * leading
-        measured_h = max((len(c) for c in cols), default=0) * cjk_avg
+        measured_h = max((glyph_advance_units(c, mode) for c in cols), default=0.0) * cjk_avg
         line_count = max((len(c) for c in cols), default=0)
         col_count = len(cols)
     else:
@@ -875,7 +1042,7 @@ def estimate_text_bounds(
             lines = kinsoku_wrap(text, max_chars, line_break_strategy)
         else:
             lines = wrap_latin_text(text, max_chars, split_long_words=True)
-        measured_w = max((len(ln) for ln in lines), default=0) * avg
+        measured_w = max_visual_line_units(lines, mode) * fs * max(0.1, float(letter_spacing or 1.0))
         measured_h = max(1, len(lines)) * leading
         line_count = len(lines)
         col_count = 0
@@ -935,6 +1102,8 @@ def fit_font_size_to_box(
         clip = ink_clip_risk((box_w, box_h), (bounds[0], bounds[1]), margin)
         if clip and "increase_padding" not in actions:
             actions.append("increase_padding")
+        if axes and float(letter_spacing or 1.0) > 0.9:
+            actions.append("tighten_letter_spacing")
         preset = suggest_manga_preset(text_out, (box_w, box_h), resolved)
         diag = TextRenderDiagnostics(resolved, is_over, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, current, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3), clip, preset)
         return current, text_out, diag
@@ -975,6 +1144,8 @@ def fit_font_size_to_box(
     clip = ink_clip_risk((box_w, box_h), (bounds[0], bounds[1]), margin)
     if clip and "increase_padding" not in actions:
         actions.append("increase_padding")
+    if axes and float(letter_spacing or 1.0) > 0.9:
+        actions.append("tighten_letter_spacing")
     preset = suggest_manga_preset(text_out, (box_w, box_h), resolved)
     diag = TextRenderDiagnostics(resolved, overflow, (bounds[0], bounds[1]), (box_w, box_h), [], "", fit_mode, best, bounds[2], bounds[3], line_break_strategy, axes, actions, inner, margin, quality, rec_box, round(scale_hint, 3), clip, preset)
     return best, text_out, diag

--- a/utils/text_style_batch.py
+++ b/utils/text_style_batch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List, Optional, Sequence
 
-from .text_rendering import MANGA_PRESETS, normalize_fit_mode, normalize_line_break_strategy, normalize_writing_mode
+from .text_rendering import MANGA_PRESETS, manga_presets, normalize_fit_mode, normalize_line_break_strategy, normalize_writing_mode
 
 
 def _target_pages(project, pages: Optional[Iterable[str]]) -> List[str]:
@@ -17,8 +17,9 @@ def normalize_text_style_updates(updates: Dict) -> Dict:
     """Return a safe, renderer-style update dict for project-wide style application."""
     updates = dict(updates or {})
     out: Dict = {}
-    if updates.get("preset") in MANGA_PRESETS:
-        out["preset"] = str(updates.get("preset"))
+    preset_id = str(updates.get("preset", "") or "")
+    if preset_id and (preset_id in MANGA_PRESETS or preset_id.startswith("custom:")):
+        out["preset"] = preset_id
     for key in ("font_family", "fallback_font_chain"):
         val = str(updates.get(key, "") or "").strip()
         if val:
@@ -64,6 +65,7 @@ def apply_text_style_batch(
     indices: Optional[Sequence[int]] = None,
     only_auto_sized: bool = False,
     dry_run: bool = False,
+    config_obj=None,
 ) -> Dict:
     """Apply a safe batch text-style override to project blocks.
 
@@ -92,8 +94,9 @@ def apply_text_style_batch(
                 continue
             if not dry_run:
                 preset_id = updates.get("preset")
-                if preset_id in MANGA_PRESETS:
-                    for key, value in MANGA_PRESETS[preset_id].items():
+                presets = manga_presets(config_obj if config_obj is not None else getattr(project, "config", None)) if preset_id else {}
+                if preset_id in presets:
+                    for key, value in presets[preset_id].items():
                         if key != "label" and hasattr(fmt, key):
                             setattr(fmt, key, value)
                     fmt.manga_preset = preset_id


### PR DESCRIPTION
### Motivation

- Improve manga lettering workflow by adding saved/reusable presets, faster font selection, and smarter fit diagnostics to reduce manual review and rework. 
- Surface actionable renderer QA fixes (tighten tracking, recommended box resize, ink-clip risk) and make batch/archive exports easier to consume by automation and readers. 
- Expose preset and archive operations to the local automation API so headless clients can list/import/export presets and produce ZIP/CBZ archives.

### Description

- Added user-saved manga lettering presets and IO utilities by introducing `utils/rendering_preset_io.py` and wiring persisted `render_custom_manga_presets` through `utils/text_rendering.py` (`manga_presets`, `preset_from_font_format`, `sanitize_manga_preset`, `preset_id_from_label`).
- Improved font UX with persisted `render_favorite_fonts` and `render_recent_fonts` in `utils/config.py`, UI controls in `ui/configpanel.py` and `ui/text_panel.py`, a Favorites picker and ★ capture button, and recent-font recall logic (`_remember_recent_font`).
- Made fit diagnostics more accurate by estimating visual advance units (`glyph_advance_units`, `max_visual_line_units`) and conservative tracking fixes (`recommended_tight_letter_spacing`), and propagated suggestions into QA and layout review flows (`utils/rendering_qa.py`, `utils/layout_review_agent.py`, `ui/scenetext_manager.py`, `utils/text_rendering.py`).
- Added preset management UI and batch parity in `ui/text_panel.py` (Save / Import / Export preset buttons, preset picker merged with built-ins), batch application support in `utils/text_style_batch.py`, and headless preset API in `ui/mainwindow.py` (`rendering_presets` endpoint with `list`, `save_current`, `save`, `export`, `import`, `delete`).
- Export and handoff workflow polish: persistent "Open output folder when done" setting (`export_open_folder_after_batch`), Export dialog checkbox (`ui/export_dialog.py`), API archive export support (`kind=archive|zip|cbz`) and archive creation in `ui/mainwindow.py`, and automatic opening of the output folder when enabled.
- Tests updated/added to exercise new behavior in `tests/test_text_rendering.py` and `tests/test_text_style_batch.py` (glyph advance units, recommended tracking, preset sanitization/roundtrip, and batch application with custom presets).

### Testing

- Ran unit tests in `tests/test_text_rendering.py`, which include new cases for `glyph_advance_units`, `recommended_tight_letter_spacing`, preset sanitization, and preset pack import/export, and all tests passed. 
- Ran unit tests in `tests/test_text_style_batch.py`, including the new `test_apply_text_style_batch_accepts_custom_manga_presets`, and they passed. 
- Exercised automation API preset and archive code paths via the added `rendering_presets` endpoint and `kind=archive` export in a headless smoke run, which successfully returned preset listings and created ZIP/CBZ archives.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fccdacd898832c8405f9c31d587dcc)