### PR TITLE
Improve runtime device diagnostics and device selector tooltips

### DIFF
--- a/modules/base.py
+++ b/modules/base.py
@@ -300,55 +300,206 @@ class BaseModule:
 os.environ['PYTORCH_ENABLE_MPS_FALLBACK'] = '1'
 import torch
 
-DEFAULT_DEVICE = 'cpu'
-AVAILABLE_DEVICES = ['cpu']
 
-# Build a single source of truth for runtime device options shown in module/device selectors.
-def _append_unique_device(device_name: str):
-    if device_name and device_name not in AVAILABLE_DEVICES:
-        AVAILABLE_DEVICES.append(device_name)
+def _safe_torch_version_attr(attr: str):
+    try:
+        return getattr(torch.version, attr, None)
+    except Exception as e:
+        return f'unavailable: {e}'
 
-# CUDA / ROCm (both typically exposed through torch.cuda).
+
+def _detect_runtime_devices() -> dict:
+    """Collect torch/backend device diagnostics without advertising unusable devices."""
+    diagnostics = {
+        'torch': getattr(torch, '__version__', None),
+        'torch_cuda': _safe_torch_version_attr('cuda'),
+        'torch_xpu': _safe_torch_version_attr('xpu'),
+        'cuda_available': False,
+        'cuda_count': 0,
+        'cuda_devices': [],
+        'cuda_exception': None,
+        'directml_available': False,
+        'directml_count': 0,
+        'directml_default_device': None,
+        'directml_exception': None,
+        'mps_available': False,
+        'mps_built': None,
+        'mps_exception': None,
+        'xpu_available': False,
+        'xpu_count': 0,
+        'xpu_devices': [],
+        'xpu_exception': None,
+        'available_devices': ['cpu'],
+        'default_device': 'cpu',
+    }
+
+    def append_device(device_name: str):
+        if device_name and device_name not in diagnostics['available_devices']:
+            diagnostics['available_devices'].append(device_name)
+
+    try:
+        if hasattr(torch, 'cuda'):
+            diagnostics['cuda_available'] = bool(torch.cuda.is_available())
+            diagnostics['cuda_count'] = int(torch.cuda.device_count())
+            if diagnostics['cuda_available']:
+                diagnostics['default_device'] = 'cuda'
+                append_device('cuda')
+                for idx in range(diagnostics['cuda_count']):
+                    try:
+                        diagnostics['cuda_devices'].append(torch.cuda.get_device_name(idx))
+                    except Exception as name_exc:
+                        diagnostics['cuda_devices'].append(f'cuda:{idx} name unavailable: {name_exc}')
+                    append_device(f'cuda:{idx}')
+            elif diagnostics['cuda_count'] > 0:
+                for idx in range(diagnostics['cuda_count']):
+                    try:
+                        diagnostics['cuda_devices'].append(torch.cuda.get_device_name(idx))
+                    except Exception as name_exc:
+                        diagnostics['cuda_devices'].append(f'cuda:{idx} name unavailable: {name_exc}')
+    except Exception as e:
+        diagnostics['cuda_exception'] = str(e)
+
+    try:
+        if hasattr(torch, 'xpu'):
+            diagnostics['xpu_available'] = bool(torch.xpu.is_available())
+            if diagnostics['xpu_available']:
+                diagnostics['xpu_count'] = int(torch.xpu.device_count()) if hasattr(torch.xpu, 'device_count') else 1
+                diagnostics['default_device'] = 'xpu'
+                append_device('xpu')
+                for idx in range(diagnostics['xpu_count']):
+                    try:
+                        get_name = getattr(torch.xpu, 'get_device_name', None)
+                        diagnostics['xpu_devices'].append(get_name(idx) if get_name else f'xpu:{idx}')
+                    except Exception as name_exc:
+                        diagnostics['xpu_devices'].append(f'xpu:{idx} name unavailable: {name_exc}')
+    except Exception as e:
+        diagnostics['xpu_exception'] = str(e)
+
+    try:
+        mps_backend = getattr(getattr(torch, 'backends', None), 'mps', None)
+        if mps_backend is not None:
+            is_built = getattr(mps_backend, 'is_built', None)
+            diagnostics['mps_built'] = bool(is_built()) if callable(is_built) else None
+            diagnostics['mps_available'] = bool(mps_backend.is_available())
+            if diagnostics['mps_available']:
+                diagnostics['default_device'] = 'mps'
+                append_device('mps')
+    except Exception as e:
+        diagnostics['mps_exception'] = str(e)
+
+    try:
+        import torch_directml
+        diagnostics['directml_count'] = int(torch_directml.device_count())
+        diagnostics['directml_available'] = diagnostics['directml_count'] > 0
+        if diagnostics['directml_available'] and hasattr(torch, 'privateuseone'):
+            torch.dml = torch_directml
+            diagnostics['directml_default_device'] = str(torch.dml.default_device())
+            diagnostics['default_device'] = f'privateuseone:{torch.dml.default_device()}'
+            for d in range(diagnostics['directml_count']):
+                append_device(f'privateuseone:{d}')
+    except Exception as e:
+        diagnostics['directml_exception'] = str(e)
+
+    return diagnostics
+
+
+_DEVICE_DIAGNOSTICS = _detect_runtime_devices()
+DEFAULT_DEVICE = _DEVICE_DIAGNOSTICS['default_device']
+AVAILABLE_DEVICES = list(_DEVICE_DIAGNOSTICS['available_devices'])
+
+
+def get_device_diagnostics() -> dict:
+    """Return a copy of runtime backend diagnostics gathered at import time."""
+    return deepcopy(_DEVICE_DIAGNOSTICS)
+
+
+def get_available_devices() -> List[str]:
+    """Return devices that passed runtime initialization checks."""
+    return list(AVAILABLE_DEVICES)
+
+
+def _cuda_unavailable_reason(diagnostics: dict) -> str:
+    if diagnostics.get('cuda_exception'):
+        return f"CUDA detection raised an exception: {diagnostics['cuda_exception']}"
+    if diagnostics.get('torch_cuda') is None:
+        return (
+            'PyTorch appears to be CPU-only (torch.version.cuda is None). '
+            'Install a CUDA-enabled PyTorch wheel for your NVIDIA driver. '
+            'Suggested pip command: python -m pip install --upgrade torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128 '
+            '(or choose the CUDA version matching your system at https://pytorch.org/get-started/locally/).'
+        )
+    if not diagnostics.get('cuda_available'):
+        return (
+            f"PyTorch was built with CUDA {diagnostics.get('torch_cuda')}, but CUDA is not usable by PyTorch. "
+            'Check the NVIDIA driver, CUDA runtime visibility, and that no environment variable is hiding the GPU.'
+        )
+    return ''
+
+
+def get_device_diagnostics_text() -> str:
+    """Human-readable diagnostics for logs, tooltips, and settings UI."""
+    d = _DEVICE_DIAGNOSTICS
+    devices = ', '.join(d.get('available_devices', [])) or 'none'
+    cuda_names = ', '.join(d.get('cuda_devices', [])) or 'none'
+    xpu_names = ', '.join(d.get('xpu_devices', [])) or 'none'
+    backend = DEFAULT_DEVICE.split(':', 1)[0] if DEFAULT_DEVICE != 'cpu' else 'cpu'
+    lines = [
+        f"Detected backend: {backend}",
+        f"Available device selectors: {devices}",
+        f"PyTorch: {d.get('torch')}",
+        f"PyTorch CUDA build: {d.get('torch_cuda')}",
+        f"CUDA available/count: {d.get('cuda_available')} / {d.get('cuda_count')}",
+        f"CUDA GPU names: {cuda_names}",
+        f"DirectML available/count: {d.get('directml_available')} / {d.get('directml_count')}",
+        f"MPS available/built: {d.get('mps_available')} / {d.get('mps_built')}",
+        f"XPU available/count: {d.get('xpu_available')} / {d.get('xpu_count')}",
+        f"XPU device names: {xpu_names}",
+    ]
+    if d.get('cuda_exception'):
+        lines.append(f"CUDA exception: {d['cuda_exception']}")
+    if d.get('directml_exception'):
+        lines.append(f"DirectML probe: {d['directml_exception']}")
+    if d.get('mps_exception'):
+        lines.append(f"MPS probe: {d['mps_exception']}")
+    if d.get('xpu_exception'):
+        lines.append(f"XPU probe: {d['xpu_exception']}")
+    reason = _cuda_unavailable_reason(d)
+    if DEFAULT_DEVICE == 'cpu' and reason:
+        lines.append(f"CUDA unavailable: {reason}")
+    return '\n'.join(lines)
+
+
+def _get_device_selector_description(options: List[str]) -> str:
+    d = _DEVICE_DIAGNOSTICS
+    lines = [
+        f"Detected backend: {DEFAULT_DEVICE.split(':', 1)[0] if DEFAULT_DEVICE != 'cpu' else 'cpu'}",
+        f"Available devices: {', '.join(options) if options else 'cpu'}",
+        f"PyTorch CUDA build: {d.get('torch_cuda')}",
+    ]
+    if d.get('cuda_devices'):
+        lines.append(f"CUDA GPU names: {', '.join(d['cuda_devices'])}")
+    reason = _cuda_unavailable_reason(d)
+    if 'cuda' not in options and reason:
+        lines.append(reason)
+    return '\n'.join(lines)
+
+
+LOGGER.info(
+    'Runtime device diagnostics: torch=%s, torch_cuda=%s, cuda_available=%s, cuda_count=%s, devices=%s, cuda_exception=%s',
+    _DEVICE_DIAGNOSTICS.get('torch'),
+    _DEVICE_DIAGNOSTICS.get('torch_cuda'),
+    _DEVICE_DIAGNOSTICS.get('cuda_available'),
+    _DEVICE_DIAGNOSTICS.get('cuda_count'),
+    _DEVICE_DIAGNOSTICS.get('available_devices'),
+    _DEVICE_DIAGNOSTICS.get('cuda_exception'),
+)
+if DEFAULT_DEVICE == 'cpu':
+    LOGGER.warning('Runtime device diagnostics: %s', _cuda_unavailable_reason(_DEVICE_DIAGNOSTICS))
+
 try:
-    if hasattr(torch, 'cuda'):
-        cuda_count = int(torch.cuda.device_count())
-        if torch.cuda.is_available() or cuda_count > 0:
-            DEFAULT_DEVICE = 'cuda'
-            _append_unique_device('cuda')
-            for idx in range(cuda_count):
-                _append_unique_device(f'cuda:{idx}')
+    BF16_SUPPORTED = DEFAULT_DEVICE == 'cuda' and torch.cuda.is_bf16_supported() or DEFAULT_DEVICE == 'xpu' and torch.xpu.is_bf16_supported()
 except Exception:
-    pass
-
-# Intel XPU
-try:
-    if hasattr(torch, 'xpu') and torch.xpu.is_available():
-        DEFAULT_DEVICE = 'xpu'
-        _append_unique_device('xpu')
-except Exception:
-    pass
-
-# Apple Silicon MPS
-try:
-    if hasattr(torch, 'backends') and hasattr(torch.backends, 'mps') and torch.backends.mps.is_available():
-        DEFAULT_DEVICE = 'mps'
-        _append_unique_device('mps')
-except Exception:
-    pass
-
-# DirectML (privateuseone)
-try:
-    import torch_directml
-    if hasattr(torch, 'privateuseone') and torch_directml.device_count() > 0:
-        torch.dml = torch_directml
-        DEFAULT_DEVICE = f'privateuseone:{torch.dml.default_device()}'
-        for d in range(torch.dml.device_count()):
-            _append_unique_device(f'privateuseone:{d}')
-except Exception:
-    # directml is not supported
-    pass
-
-BF16_SUPPORTED = DEFAULT_DEVICE == 'cuda' and torch.cuda.is_bf16_supported() or DEFAULT_DEVICE == 'xpu' and torch.xpu.is_bf16_supported()
+    BF16_SUPPORTED = False
 
 def is_nvidia():
     if DEFAULT_DEVICE == 'cuda':
@@ -374,13 +525,20 @@ def soft_empty_cache():
         torch.mps.empty_cache()
 
 
-def DEVICE_SELECTOR(not_supported:list[str]=[]): return deepcopy(
-    {
-        'type': 'selector',
-        'options': [opt for opt in AVAILABLE_DEVICES if all(device not in opt for device in not_supported)],
-        'value': DEFAULT_DEVICE if not any(DEFAULT_DEVICE in device for device in not_supported) else 'cpu'
-    }
-)
+def DEVICE_SELECTOR(not_supported: list[str] = None):
+    not_supported = not_supported or []
+    options = [opt for opt in AVAILABLE_DEVICES if all(device not in opt for device in not_supported)]
+    value = DEFAULT_DEVICE if not any(DEFAULT_DEVICE in device for device in not_supported) else 'cpu'
+    if value not in options:
+        value = 'cpu'
+    return deepcopy(
+        {
+            'type': 'selector',
+            'options': options,
+            'value': value,
+            'description': _get_device_selector_description(options),
+        }
+    )
 
 TORCH_DTYPE_MAP = {
     'fp32': torch.float32,

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -459,15 +459,32 @@ class ConfigPanel(Widget):
         self.load_model_checker.stateChanged.connect(self.on_load_model_changed)
         dlConfigPanel.vlayout.addWidget(msublock)
         self.default_device_combobox = QComboBox()
+        device_diag_text = ''
         try:
-            from modules.base import AVAILABLE_DEVICES
+            from modules.base import get_available_devices, get_device_diagnostics_text
             self.default_device_combobox.addItem(self.tr('Default (use module default)'))
-            self.default_device_combobox.addItems(AVAILABLE_DEVICES)
-        except Exception:
-            self.default_device_combobox.addItems([self.tr('Default (use module default)'), 'cpu', 'cuda'])
+            self.default_device_combobox.addItems(get_available_devices())
+            device_diag_text = get_device_diagnostics_text()
+        except Exception as e:
+            self.default_device_combobox.addItems([self.tr('Default (use module default)'), 'cpu'])
+            device_diag_text = self.tr('Device diagnostics unavailable: {0}').format(e)
         self.default_device_combobox.currentIndexChanged.connect(self.on_default_device_index_changed)
-        sublock = ConfigSubBlock(self.default_device_combobox, self.tr('Default device'), discription=self.tr('Preferred device for DL modules when set to Default.'))
+        device_description = self.tr('Preferred device for DL modules when set to Default.')
+        if device_diag_text:
+            device_description = device_description + '\n' + device_diag_text
+            self.default_device_combobox.setToolTip(device_diag_text)
+        sublock = ConfigSubBlock(self.default_device_combobox, self.tr('Default device'), discription=device_description)
         dlConfigPanel.vlayout.addWidget(sublock)
+        self.device_diagnostics_label = QLabel(device_diag_text)
+        self.device_diagnostics_label.setWordWrap(True)
+        self.device_diagnostics_label.setTextInteractionFlags(Qt.TextInteractionFlag.TextSelectableByMouse)
+        self.device_diagnostics_label.setStyleSheet("color: gray;")
+        self.device_diagnostics_label.setToolTip(device_diag_text)
+        dlConfigPanel.vlayout.addWidget(ConfigSubBlock(
+            self.device_diagnostics_label,
+            self.tr('Runtime device diagnostics'),
+            discription=self.tr('Shows why CUDA/GPU backends are or are not available to PyTorch.')
+        ))
         self.empty_runcache_checker, msublock = checkbox_with_label(self.tr('Empty cache after RUN'), discription=self.tr('Empty cache after RUN to save memory.'))
         dlConfigPanel.vlayout.addWidget(msublock)
         self.empty_runcache_checker.stateChanged.connect(self.on_runcache_changed)

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3504,6 +3504,14 @@ class MainWindow(mainwindow_cls):
         except Exception as e:
             lines.append(self.tr("GPU stats unavailable: {0}").format(str(e)))
 
+        try:
+            from modules.base import get_device_diagnostics_text
+            lines.append("")
+            lines.append(self.tr("Runtime device diagnostics:"))
+            lines.append(get_device_diagnostics_text())
+        except Exception as e:
+            lines.append(self.tr("Runtime device diagnostics unavailable: {0}").format(str(e)))
+
         lines.append(self.tr("Quantization note: model quantization is module-dependent; some HF/LLM modules provide low-VRAM/4-bit/8-bit style options, but not every detector/OCR/inpainter supports quantized loading."))
         return "\n".join(lines)
 


### PR DESCRIPTION
### Motivation
- Users with NVIDIA GPUs saw only `cpu` in device selectors because device list was built from runtime calls that silently failed when PyTorch/CUDA initialization was incomplete. 
- The UI provided no actionable explanation when CUDA was unavailable, leaving users without guidance to fix drivers or install CUDA-enabled PyTorch wheels. 
- Provide reliable import-time diagnostics and user-facing messages so the settings UI and runtime summary can explain why CUDA/GPU backends are or are not available. 

### Description
- Add comprehensive runtime device diagnostics in `modules/base.py` that probe `torch.__version__`, `torch.version.cuda`, `torch.cuda.is_available()`, `torch.cuda.device_count()`, CUDA device names, any detection exception text, DirectML (`torch_directml`), MPS/XPU info, and build a safe `available_devices` list without advertising unusable devices. 
- Expose helper APIs in `modules/base.py`: `get_device_diagnostics()`, `get_device_diagnostics_text()`, and `get_available_devices()`, and log a concise `Runtime device diagnostics: ...` message at import/startup. 
- Update `DEVICE_SELECTOR()` to avoid adding fake CUDA entries, return only devices that passed initialization checks, and include a `description` text (used as tooltip) explaining detected devices and why CUDA may be unavailable. 
- Surface diagnostics in the UI by updating `ui/configpanel.py` to populate the default-device combobox from `get_available_devices()` and show a selectable diagnostics label/tooltip, and by adding the diagnostics text to the runtime resource summary in `ui/mainwindow.py`. 
- Preserve existing behavior for CPU/MPS/XPU/DirectML and keep CTD model selection logic intact (CPU continues to prefer `.onnx`, non-CPU uses `.pt`). 

### Testing
- Ran Python syntax/compile checks: `python -m py_compile modules/base.py ui/configpanel.py ui/mainwindow.py` and they succeeded. 
- Performed an import/runtime smoke test that logs diagnostics (example output showed PyTorch build, `torch.version.cuda`, `cuda_available`, `available_devices`, and a logged CUDA-unavailable reason) and the log/statements printed as expected. 
- Ran monkeypatched simulations that emulate CPU-only PyTorch, CUDA-built-but-unavailable, and CUDA-available scenarios against the detection functions (`_detect_runtime_devices()` and `_cuda_unavailable_reason()`), and all assertions passed. 
- Verified UI wiring and CTD behavior by inspecting `ui/configpanel.py`, `ui/mainwindow.py`, and `modules/textdetector/ctd/inference.py` to ensure device selectors and CTD model-path selection remain correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe584e66f0832c961c7340f1f66267)