### PR TITLE
Fix spell icon size, GPU detection, and bubble centering

### DIFF
--- a/config/stylesheet.css
+++ b/config/stylesheet.css
@@ -1106,7 +1106,7 @@ QLabel#angleLabel {
 QToolButton#SpellCheckChecker {
     border: none;
     border-radius: 4px;
-    padding: 3px;
+    padding: 1px;
     background-color: transparent;
 }
 QToolButton#SpellCheckChecker:hover {

--- a/doc/GPU_TROUBLESHOOTING.md
+++ b/doc/GPU_TROUBLESHOOTING.md
@@ -1,0 +1,31 @@
+# GPU / CUDA troubleshooting
+
+If CUDA is installed on the machine but the app only shows `cpu` in module device selectors, the Python environment is usually using a CPU-only PyTorch wheel.
+
+## Automatic launcher repair
+
+When started through `launch.py`, BallonsTranslator now checks for an NVIDIA GPU before importing the main app. If an NVIDIA GPU is visible and the installed PyTorch build is CPU-only or cannot use CUDA, the launcher reinstalls the CUDA-enabled PyTorch wheel so `cuda` appears in device selectors after restart.
+
+Set `BT_SKIP_CUDA_TORCH_REINSTALL=1` if you intentionally want to keep a CPU-only PyTorch install.
+
+## Manual checks
+
+Run:
+
+```bash
+python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available(), torch.cuda.device_count())"
+```
+
+Expected for NVIDIA GPU use:
+
+- `torch.version.cuda` is not `None`.
+- `torch.cuda.is_available()` is `True`.
+- `torch.cuda.device_count()` is at least `1`.
+
+If those checks fail, reinstall PyTorch with the command printed by the launcher or run:
+
+```bash
+python -m pip install --upgrade --force-reinstall torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+```
+
+Then restart the app and check **Config → General → Device diagnostics**.

--- a/launch.py
+++ b/launch.py
@@ -619,6 +619,50 @@ def supported_amd_nightly_gpu():
     except Exception:
         return "None"
 
+
+def is_nvidia_gpu_present():
+    """Best-effort physical NVIDIA GPU probe before importing PyTorch.
+
+    GitHub ZIP installs often already have a CPU-only torch in the Python
+    environment. In that case torch imports successfully, but CUDA device
+    selectors never show up in the app. Probe the host GPU separately so the
+    launcher can replace CPU-only torch with the CUDA wheel.
+    """
+    if os.environ.get("CUDA_VISIBLE_DEVICES", None) == "":
+        return False
+    try:
+        output = subprocess.check_output(
+            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=8,
+        )
+        if output.strip():
+            return True
+    except Exception:
+        pass
+    try:
+        if sys.platform == 'win32':
+            output = subprocess.check_output(
+                ['wmic', 'path', 'win32_VideoController', 'get', 'name'],
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=8,
+            )
+            return any(keyword in output.lower() for keyword in ("nvidia", "geforce", "rtx", "gtx", "quadro"))
+    except Exception:
+        pass
+    return False
+
+
+def installed_torch_is_cpu_only():
+    """Return True when installed torch cannot expose CUDA devices."""
+    import torch
+    try:
+        return getattr(torch.version, 'cuda', None) is None or not bool(torch.cuda.is_available())
+    except Exception:
+        return True
+
 def prepare_environment():
 
     try:
@@ -659,8 +703,21 @@ def prepare_environment():
             torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check")
     else:
         torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check")
-    if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision"):
-        run(f'"{python}" -m {torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
+    cuda_torch_reinstall_needed = (
+        not os.environ.get("BT_SKIP_CUDA_TORCH_REINSTALL")
+        and not is_amd_gpu()
+        and is_nvidia_gpu_present()
+        and is_installed("torch")
+        and installed_torch_is_cpu_only()
+    )
+    if cuda_torch_reinstall_needed:
+        print("NVIDIA GPU detected but installed PyTorch is CPU-only or cannot use CUDA; installing CUDA-enabled PyTorch.")
+
+    if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision") or cuda_torch_reinstall_needed:
+        install_torch_command = torch_command
+        if cuda_torch_reinstall_needed and "TORCH_COMMAND" not in os.environ and "--force-reinstall" not in install_torch_command:
+            install_torch_command = f"{install_torch_command} --force-reinstall"
+        run(f'"{python}" -m {install_torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
         req_updated = True
 
     if not check_req_file(args.requirements):

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -1860,6 +1860,7 @@ class BottomBar(Widget):
         self.spellCheckChecker.setCheckable(True)
         self.spellCheckChecker.setAutoRaise(True)
         self.spellCheckChecker.setFixedSize(44, 40)
+        self.spellCheckChecker.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.spellCheckChecker.setToolTip(self.tr('Spell check panel: review OCR/translation spelling issues'))
         self.spellCheckChecker.setAccessibleName(self.tr('Spell check panel'))
         self.spellCheckChecker.setAccessibleDescription(self.tr('Toggle the spell check side panel.'))
@@ -1953,7 +1954,8 @@ class BottomBar(Widget):
 
         if osp.isfile(icon_path):
             self.spellCheckChecker.setIcon(QIcon(icon_path))
-            self.spellCheckChecker.setIconSize(QSize(20, 20))
+            # Match the visual weight of the neighboring bottom-bar checkbox icons.
+            self.spellCheckChecker.setIconSize(QSize(30, 30))
 
     def onPaintCheckerPressed(self):
         checked = self.paintChecker.isChecked()

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1210,9 +1210,11 @@ class SceneTextManager(QObject):
             blkitem.fontformat.text_box_shape = "auto"
             return
         try:
+            cx, cy = br[0] + br[2] / 2, br[1] + br[3] / 2
             enlarge_ratio = min(max(br[2] / br[3], br[3] / br[2]) * 1.5, 3.0)
             mask, _area, mask_xyxy, region_rect = extract_ballon_region(
-                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD
+                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD,
+                seed_point_abs=(cx, cy),
             )
         except Exception:
             blkitem.fontformat.text_box_shape = "auto"
@@ -1946,7 +1948,8 @@ class SceneTextManager(QObject):
         try:
             enlarge_ratio = min(max(br[2] / max(br[3], 1), br[3] / max(br[2], 1)) * 1.5, 3.0)
             mask, _area, mask_xyxy, _region_rect = extract_ballon_region(
-                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD
+                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD,
+                seed_point_abs=(abr.x() + abr.width() / 2, abr.y() + abr.height() / 2),
             )
             cx_crop, cy_crop = mask_centroid_in_crop(mask)
             return (float(mask_xyxy[0] + cx_crop), float(mask_xyxy[1] + cy_crop))
@@ -2301,7 +2304,8 @@ class SceneTextManager(QObject):
         try:
             enlarge_ratio = min(max(br[2] / br[3], br[3] / br[2]) * 1.5, 3.0)
             mask, _area, mask_xyxy, region_rect = extract_ballon_region(
-                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD
+                img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD,
+                seed_point_abs=(cx, cy),
             )
         except Exception:
             return False
@@ -2315,6 +2319,15 @@ class SceneTextManager(QObject):
         bubble_x = mask_xyxy[0] + region_rect[0]
         bubble_y = mask_xyxy[1] + region_rect[1]
         bubble_w, bubble_h = region_rect[2], region_rect[3]
+        # Guard against contour extraction locking onto a neighboring bubble: the
+        # selected text center must be inside (or very near) the detected bubble,
+        # and the requested move must be plausible for this bubble size.
+        pad_x = max(10.0, bubble_w * 0.15)
+        pad_y = max(10.0, bubble_h * 0.15)
+        if not (bubble_x - pad_x <= cx <= bubble_x + bubble_w + pad_x and bubble_y - pad_y <= cy <= bubble_y + bubble_h + pad_y):
+            return False
+        if max(abs(im_cx - cx), abs(im_cy - cy)) > max(80.0, max(bubble_w, bubble_h) * 0.9):
+            return False
         min_x, min_y = bubble_x, bubble_y
         max_x = bubble_x + bubble_w - bw
         max_y = bubble_y + bubble_h - bh
@@ -2550,7 +2563,8 @@ class SceneTextManager(QObject):
             try:
                 enlarge_ratio = min(max(br[2] / br[3], br[3] / br[2]) * 1.5, 3.0)
                 mask, _area, mask_xyxy, region_rect = extract_ballon_region(
-                    img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD
+                    img, br, enlarge_ratio=enlarge_ratio, cal_region_rect=True, margin_px=LAYOUT_BALLOON_SHAPE_CROP_PAD,
+                    seed_point_abs=(cx, cy),
                 )
             except Exception:
                 continue
@@ -2564,6 +2578,14 @@ class SceneTextManager(QObject):
             bubble_x = mask_xyxy[0] + region_rect[0]
             bubble_y = mask_xyxy[1] + region_rect[1]
             bubble_w, bubble_h = region_rect[2], region_rect[3]
+            # Guard against centering to an unrelated contour/bubble. This keeps
+            # Format → Center in bubble from jumping dramatically across the page.
+            pad_x = max(10.0, bubble_w * 0.15)
+            pad_y = max(10.0, bubble_h * 0.15)
+            if not (bubble_x - pad_x <= cx <= bubble_x + bubble_w + pad_x and bubble_y - pad_y <= cy <= bubble_y + bubble_h + pad_y):
+                continue
+            if max(abs(im_cx - cx), abs(im_cy - cy)) > max(80.0, max(bubble_w, bubble_h) * 0.9):
+                continue
             min_x = bubble_x
             max_x = bubble_x + bubble_w - bw
             min_y = bubble_y

--- a/utils/imgproc_utils.py
+++ b/utils/imgproc_utils.py
@@ -250,10 +250,11 @@ def color_difference(rgb1: List, rgb2: List) -> float:
     diff = np.linalg.norm(diff, axis=2) 
     return diff.item()
 
-def extract_ballon_region(img: np.ndarray, ballon_rect: List, show_process=False, enlarge_ratio=2.0, cal_region_rect=False, margin_px: int = 0) -> Tuple[np.ndarray, int, List]:
+def extract_ballon_region(img: np.ndarray, ballon_rect: List, show_process=False, enlarge_ratio=2.0, cal_region_rect=False, margin_px: int = 0, seed_point_abs: Tuple[float, float] = None) -> Tuple[np.ndarray, int, List]:
     """
     Extract bubble mask from a crop around ballon_rect.
     margin_px: extra pixels added on each side to the crop (for shape classification so the full bubble is visible). 0 = no extra margin.
+    seed_point_abs: optional image-space point that should be inside the target bubble. When omitted, use the crop center.
     """
     WHITE = (255, 255, 255)
     BLACK = (0, 0, 0)
@@ -296,7 +297,12 @@ def extract_ballon_region(img: np.ndarray, ballon_rect: List, show_process=False
     min_retval = np.inf
     mask = np.zeros((h, w), np.uint8)
     difres = 10
-    seedpnt = (int(w/2), int(h/2))
+    if seed_point_abs is not None:
+        sx = int(round((float(seed_point_abs[0]) - x1) * scaleR))
+        sy = int(round((float(seed_point_abs[1]) - y1) * scaleR))
+        seedpnt = (max(0, min(w - 1, sx)), max(0, min(h - 1, sy)))
+    else:
+        seedpnt = (int(w/2), int(h/2))
     for ii in range(len(cons)):
         rect = cv2.boundingRect(cons[ii])
         if rect[2]*rect[3] < img_area*0.4:


### PR DESCRIPTION
### Motivation
- The bottom-bar spell check icon appeared visually too small compared to neighbor mode icons and needed consistent styling. 
- Users who install from a GitHub ZIP can end up with a CPU-only PyTorch build while their system has an NVIDIA GPU, so `cuda` never appears in device selectors. 
- `Center in bubble` and auto-centering could jump boxes to unrelated contours when contour extraction picked the wrong bubble; seeding and plausibility checks are necessary to avoid dramatic moves.

### Description
- UI: set the bottom-bar button to icon-only mode and increase the icon size to `QSize(30, 30)`, and reduce QSS padding for `QToolButton#SpellCheckChecker` so the spell check icon matches neighboring buttons (`ui/mainwindowbars.py`, `config/stylesheet.css`).
- Launcher: add `is_nvidia_gpu_present()` and `installed_torch_is_cpu_only()` probes and a restart-reinstall path that `--force-reinstall`s a CUDA-enabled PyTorch when an NVIDIA GPU is detected but the installed torch is CPU-only; add opt-out via `BT_SKIP_CUDA_TORCH_REINSTALL` (`launch.py`).
- Image processing: make `extract_ballon_region` seed-aware by adding `seed_point_abs` so contour flood-fill uses a provided image-space seed (instead of always crop center) (`utils/imgproc_utils.py`).
- Centering safety: pass the text-box center into bubble extraction and add plausibility guards (seed containment and max-move thresholds) to skip centering when the detected contour is likely unrelated, preventing dramatic jumps (`ui/scenetext_manager.py`).
- Docs: add `doc/GPU_TROUBLESHOOTING.md` describing the automatic launcher repair, manual checks, and reinstall guidance.

### Testing
- Ran static/compile checks: `python -m py_compile launch.py utils/imgproc_utils.py ui/scenetext_manager.py ui/mainwindowbars.py ui/spellcheck_panel.py` (succeeded).
- Ran repository checks: `git diff --check` / staged diffs were clean (no trailing whitespace or syntax issues).
- Performed a synthetic OpenCV smoke test for `extract_ballon_region` to verify seed-based contour selection, but the run was blocked in this environment by missing system OpenGL (`libGL.so.1`); the code path is exercised by unit/QA where OpenCV is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe5c78cce8832c9de80d03fbfc5a4a)