### PR TITLE
Probe PyTorch in child process and guard CUDA reinstall on Windows

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -101,6 +101,23 @@ The app will retry using the local HuggingFace cache only. If the model was neve
 | **Fresh venv** | `python -m venv venv`, activate, then `pip install -r requirements.txt` and `python launch.py`. Reduces conflicts from other projects. |
 | **Torch version** | `launch.py` installs PyTorch (CUDA or ROCm) automatically. To force a version, set **TORCH_COMMAND** (e.g. `pip install torch==... torchvision==... --index-url ...`) before running. See README or "Portable setup" for platform notes. |
 
+
+### Windows NVIDIA: torch/torchvision entry-point errors after auto-install
+
+**Symptoms:** First launch detects an NVIDIA GPU, installs CUDA PyTorch, then Windows shows `python.exe - Entry Point Not Found` dialogs mentioning `torch_cuda.dll`, `torchvision\_C.pyd`, or `operator torchvision::nms does not exist`.
+
+**Cause:** A CPU-only or mismatched PyTorch/torchvision wheel was already installed in the active Python. Older launchers imported `torch` while checking CUDA, so Windows could keep PyTorch DLLs loaded during `pip` replacement and leave a mixed install for the rest of that run.
+
+**Fix:** Use the current launcher, which probes PyTorch in a child process before reinstalling. If the environment is already mixed from a previous run, close BallonsTranslator-Pro and run:
+
+```bat
+python -m pip uninstall -y torch torchvision torchaudio
+python -m pip install --upgrade --force-reinstall torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu118
+python launch.py
+```
+
+Delete any leftover `~orch`, `~orchvision`, or `~umpy` temporary folders under `Lib\site-packages` only after Python is closed; pip may leave these behind when files were locked.
+
 ---
 
 ## 6. First run seems stuck or very slow

--- a/launch.py
+++ b/launch.py
@@ -7,6 +7,7 @@ import importlib
 import subprocess
 import shlex
 import warnings
+import json
 from platform import platform
 
 # Suppress requests' urllib3/chardet version mismatch warning (harmless for typical use)
@@ -655,13 +656,58 @@ def is_nvidia_gpu_present():
     return False
 
 
+def _probe_installed_torch():
+    """Return installed torch diagnostics without importing torch in this launcher.
+
+    Importing torch in the parent process before replacing wheels can keep
+    torch/torchvision DLLs loaded on Windows. That may leave a half-upgraded
+    install and cause entry-point errors such as ``torch_cuda.dll`` or
+    ``torchvision/_C.pyd`` symbol failures after the CUDA wheel is installed.
+    Probe in a short-lived child process instead so pip can safely uninstall
+    the old wheel.
+    """
+    probe_code = """
+import json
+import torch
+payload = {
+    'ok': True,
+    'version': getattr(torch, '__version__', None),
+    'cuda': getattr(getattr(torch, 'version', None), 'cuda', None),
+    'cuda_available': bool(torch.cuda.is_available()),
+}
+print(json.dumps(payload))
+"""
+    try:
+        result = subprocess.run(
+            [python, "-c", probe_code],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=20,
+            env=os.environ,
+        )
+    except Exception as exc:
+        return {"ok": False, "error": f"{type(exc).__name__}: {exc}"}
+
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "error": (result.stderr or result.stdout or f"probe exited with {result.returncode}").strip(),
+        }
+    try:
+        return json.loads((result.stdout or "{}").strip().splitlines()[-1])
+    except Exception as exc:
+        return {"ok": False, "error": f"invalid probe output: {exc}; stdout={result.stdout!r}"}
+
+
 def installed_torch_is_cpu_only():
     """Return True when installed torch cannot expose CUDA devices."""
-    import torch
-    try:
-        return getattr(torch.version, 'cuda', None) is None or not bool(torch.cuda.is_available())
-    except Exception:
+    info = _probe_installed_torch()
+    if not info.get("ok"):
+        print(f"Unable to inspect installed PyTorch without importing it: {info.get('error')}")
         return True
+    return info.get("cuda") is None or not bool(info.get("cuda_available"))
+
 
 def prepare_environment():
 
@@ -705,6 +751,7 @@ def prepare_environment():
         torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check")
     cuda_torch_reinstall_needed = (
         not os.environ.get("BT_SKIP_CUDA_TORCH_REINSTALL")
+        and os.environ.get("BT_CUDA_TORCH_REINSTALL_ATTEMPTED") != "1"
         and not is_amd_gpu()
         and is_nvidia_gpu_present()
         and is_installed("torch")
@@ -712,6 +759,7 @@ def prepare_environment():
     )
     if cuda_torch_reinstall_needed:
         print("NVIDIA GPU detected but installed PyTorch is CPU-only or cannot use CUDA; installing CUDA-enabled PyTorch.")
+        os.environ["BT_CUDA_TORCH_REINSTALL_ATTEMPTED"] = "1"
 
     if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision") or cuda_torch_reinstall_needed:
         install_torch_command = torch_command


### PR DESCRIPTION
### Motivation
- Avoid Windows entry-point failures that occur when the launcher imports `torch` while `pip` is replacing CPU-only wheels with CUDA wheels.  
- Prevent repeated automatic CUDA wheel reinstall attempts in a single relaunched environment which can leave a mixed/inconsistent install.  
- Provide clear recovery steps for users who already hit a mixed `torch`/`torchvision` state.

### Description
- Add `_probe_installed_torch()` in `launch.py` that runs a short-lived child Python process to safely import `torch` and return JSON diagnostics (`version`, `cuda`, `cuda_available`) without loading DLLs into the launcher process.  
- Make `installed_torch_is_cpu_only()` use the child-process probe output instead of importing `torch` in-process.  
- Add an environment guard `BT_CUDA_TORCH_REINSTALL_ATTEMPTED` to the CUDA reinstall detection logic so the launcher only attempts the automatic CUDA wheel reinstall once per relaunched environment and set it when a reinstall is triggered.  
- Update `docs/TROUBLESHOOTING.md` with a new section explaining the Windows NVIDIA symptoms, root cause, cleanup/reinstall commands, and note about leftover `~orch`/`~orchvision`/`~umpy` temp folders.

### Testing
- Ran `python -m py_compile launch.py` to check syntax, which succeeded.  
- Executed the probe via `import launch; launch._probe_installed_torch()` and verified the returned payload contains the expected keys (`ok`, `version`, `cuda`, `cuda_available`), which succeeded.  
- Performed repository checks (whitespace/diff checks) to ensure no linter/diff issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe67ceee48832c9be3286b6cb33578)