### PR TITLE
Unify GPU runtime selection + improve SVG/PSD handoff and proof archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ At a high level, BallonsTranslator-Pro helps you:
 
 After cloning/downloading and opening the project folder:
 
-- **Windows (recommended):** double-click `launch_win.bat`
-- **Windows (nightly update + launch):** double-click `launch_win_amd_nightly.bat`
-- **Windows (launch + auto-update):** double-click `launch_win_with_autoupdate.bat`
-- **Cross-platform (manual):** run `python launch.py` in terminal
+- **Windows (recommended):** double-click `launcher.bat` for a single menu with setup, auto-update, AMD/NVIDIA/CPU GPU modes.
+- **Windows quick start:** double-click `launch_win.bat` to start immediately with auto GPU detection.
+- **Cross-platform (manual):** run `python launch.py` in terminal.
+- **GPU help:** see [docs/GPU_ACCELERATION.md](docs/GPU_ACCELERATION.md), especially for AMD Radeon RX 9070/9060/7900 cards.
 
 If batch files are blocked by Windows SmartScreen, right-click the `.bat` file → **Run as administrator** (or choose **More info → Run anyway**).
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -23,10 +23,10 @@ BallonsTranslator-Pro 是 [dmMaze/BallonsTranslator](https://github.com/dmMaze/B
 
 克隆/下载并打开项目目录后：
 
-- **Windows（推荐）：** 双击 `launch_win.bat`
-- **Windows（夜版更新 + 启动）：** 双击 `launch_win_amd_nightly.bat`
-- **Windows（启动 + 自动更新）：** 双击 `launch_win_with_autoupdate.bat`
-- **跨平台（手动）：** 终端运行 `python launch.py`
+- **Windows（推荐）：** 双击 `launcher.bat`，使用一个菜单完成启动、设置、自动更新、AMD/NVIDIA/CPU GPU 模式。
+- **Windows 快速启动：** 双击 `launch_win.bat`，使用自动 GPU 检测立即启动。
+- **跨平台（手动）：** 终端运行 `python launch.py`。
+- **GPU 帮助：** 查看 [docs/GPU_ACCELERATION.md](docs/GPU_ACCELERATION.md)，尤其是 AMD Radeon RX 9070/9060/7900 用户。
 
 如果 Windows SmartScreen 阻止 `.bat`，可右键批处理文件 → **以管理员身份运行**（或选择“更多信息 → 仍要运行”）。
 

--- a/docs/GPU_ACCELERATION.md
+++ b/docs/GPU_ACCELERATION.md
@@ -1,0 +1,61 @@
+# GPU acceleration setup (NVIDIA + AMD)
+
+BallonsTranslator-Pro now uses one launcher flow instead of separate GPU-specific start scripts.
+
+## Recommended Windows entrypoint
+
+Double-click **`launcher.bat`** and choose one of these options:
+
+| Menu option | Use when | What it installs/uses |
+| --- | --- | --- |
+| **1. Start (auto GPU)** | Most users | NVIDIA → CUDA PyTorch; AMD RX 7000/9000 + Python 3.12 → AMD ROCm preview; other AMD Windows GPUs → DirectML; otherwise CPU. |
+| **4. Force AMD ROCm preview** | Radeon RX 7000/9000 users who are on Windows + Python 3.12 and want the AMD preview stack | AMD ROCm/PyTorch preview wheels from AMD. |
+| **5. Force AMD DirectML** | Any AMD Windows user who wants the broad fallback, or whose ROCm wheel does not match Python | `torch-directml`. |
+| **6. CPU-only safe mode** | Troubleshooting crashes or VRAM issues | CPU PyTorch. |
+
+`launch_win.bat` still works and auto-detects by default. Old specialized scripts such as `launch_win_amd_nightly.bat` and `launch_win_with_autoupdate.bat` are now compatibility wrappers that call the unified launcher path.
+
+## Command-line overrides
+
+```bat
+launch_win.bat --gpu-profile auto
+launch_win.bat --gpu-profile nvidia-cuda
+launch_win.bat --gpu-profile amd-rocm-preview
+launch_win.bat --gpu-profile amd-directml
+launch_win.bat --gpu-profile cpu
+```
+
+You can also set an environment variable before launching:
+
+```bat
+set BT_GPU_PROFILE=amd-directml
+launch_win.bat
+```
+
+For advanced users, `TORCH_COMMAND` still overrides the exact PyTorch install command.
+
+## AMD Radeon RX 9070 XT / RX 9070 notes
+
+Official references: AMD lists ROCm/PyTorch Windows support for Radeon RX 9070 XT-class GPUs in the Radeon/Ryzen ROCm compatibility docs, and Microsoft documents DirectML as the broad Windows PyTorch backend for AMD/Intel/NVIDIA GPUs.
+
+
+- On Windows with **Python 3.12**, auto mode picks the AMD ROCm Windows preview wheels for RX 9000/RDNA4 cards.
+- If you are on Python 3.10/3.11 or the ROCm wheel says it is not supported on your platform, use **AMD DirectML** instead: `launch_win.bat --gpu-profile amd-directml`.
+- After launching, open **Tools → Diagnostics → Runtime resource summary** or **Copy startup diagnostics**. Look for `Detected backend: privateuseone` (DirectML), `Detected backend: cuda` (NVIDIA/ROCm-style torch builds), or available device selectors containing `privateuseone:0` / `cuda`.
+- If the app still runs on CPU, run `launch_win.bat --gpu-report` and include that output in a bug report.
+
+## NVIDIA notes
+
+Auto mode checks for `nvidia-smi`/NVIDIA display adapters. If it sees NVIDIA but the active Python has CPU-only torch, it force-reinstalls the CUDA PyTorch wheel once so the app does not silently stay on CPU.
+
+If you need a different CUDA wheel, set `TORCH_COMMAND` manually from the command shown on <https://pytorch.org/get-started/locally/>.
+
+## Useful official links
+
+- AMD ROCm Radeon/Ryzen Windows compatibility: <https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/compatibility/compatibilityrad/windows/windows_compatibility.html>
+- Microsoft PyTorch with DirectML on Windows: <https://learn.microsoft.com/windows/ai/directml/pytorch-windows>
+- PyTorch install selector: <https://pytorch.org/get-started/locally/>
+
+## What “using the GPU” means in the app
+
+Most detector/OCR/inpainter modules expose a **device** setting. Set that to the detected GPU device (`cuda`, `cuda:0`, `privateuseone:0`, `mps`, etc.) where available. Some modules are CPU-only or have their own runtime limitations, so a GPU runtime does not guarantee every module can use every backend.

--- a/docs/KOHARU_GAP_ANALYSIS.md
+++ b/docs/KOHARU_GAP_ANALYSIS.md
@@ -2,6 +2,44 @@
 
 _Last audited: 2026-05-17 against BallonsTranslator-Pro current branch, public `mayocream/koharu` issues via GitHub REST API (300 all-state issues plus topic searches scanned), upstream `dmMaze/BallonsTranslator` issues via REST API (300 all-state issues plus topic searches scanned), and recent upstream `dev` commits fetched from Git._
 
+## Newly implemented in this pass (2026-05-17 fourth follow-up: export-faithful vertical handoff and proof archive)
+
+| Area | Implemented | Research source | Files |
+| --- | --- | --- | --- |
+| Export-faithful vertical SVG text | Editable SVG handoff now emits vertical-RL text from `vertical_layout_plan()` as positioned glyph tspans with column/row metadata, punctuation classes, rotation hints, and compact tate-chu-yoko groups instead of depending on a single browser-rendered vertical string. | Koharu #591 SVG/XCF export, #509 vertical wrap, #597 manual direction, #602 Arabic/export; upstream #1128 vertical text and #995 punctuation conversion. | `utils/svg_text_export.py`, `tests/test_svg_text_export.py` |
+| Font-run/fallback metadata in handoff | SVG and layered PSD helper manifests now include `font_runs` plus `fallback_runs`, and PSD helper text layers include the same vertical layout plan used by QA/proof metrics for better editable-text reconstruction. | Koharu #558/#587/#454 PSD editable text/position fidelity and #595 font UX; upstream #1122 font problems and #1169/#1077 fit/export parity. | `utils/svg_text_export.py`, `utils/layered_psd_export.py`, `tests/test_layered_psd_export.py` |
+| Portable lettering proof archives | Each lettering proof pack now creates a `*_lettering_proof.zip` containing QA JSON/Markdown, HTML index, editable SVG, PSD-helper manifest/JSX, helper layers, and final composite when available. | Koharu #610/#541/#535 batch/export handoff pain; upstream #1020 batch queue and #1052 better error/log attachments. | `utils/lettering_proof_export.py`, `tests/test_lettering_proof_export.py`, `docs/RENDERING_TEXT_FORMATTING.md` |
+| Upstream dependency compatibility | Adapted upstream dev `c80eb81` / issue #1179 by raising Pro's transformer floor to `>=4.57.6` without exact-pinning, preserving Pro's broader module compatibility. | dmMaze/BallonsTranslator #1179, commit `c80eb81`. | `requirements.txt`, `docs/UPSTREAM_BALLONSTRANSLATOR_DEV_SYNC.md` |
+
+### Progress audit update for this fourth follow-up
+
+| Capability | Status | Newly implemented | Deferred with reason |
+| --- | --- | --- | --- |
+| Advanced text rendering / formatting | Implemented / advanced | Vertical export now preserves per-glyph column/row placement, punctuation class, rotate hints, and tate-chu-yoko groups from the shared layout plan. | Native HarfBuzz/OpenType vertical alternates and visual regression snapshots remain deferred. |
+| PSD/export/layers | Implemented / advanced | PSD helper manifests now carry font-run and vertical layout metadata; proof packs are zipped for one-file handoff. | Native editable PSD text layers remain deferred because the available Python stack still lacks safe cross-editor text-layer writing. |
+| Workflow/export UX | Implemented / advanced | Letterers/reviewers can send one ZIP per proof page instead of collecting JSON, Markdown, SVG, helper layer, and manifest files manually. | Full batch export queue/large archive splitting remains deferred. |
+| Upstream BallonsTranslator sync | Active | Ported `c80eb81` as an adapted transformer lower-bound update and confirmed `64a5713` is already represented in Pro. | `4c14019` and `1958f66` remain deferred due Pro-specific workflow/provider conflicts. |
+
+### Koharu issue-inspired items implemented/deferred
+
+- Implemented/advanced: #591 SVG export, #558/#587/#454 PSD editable text/style/position handoff, #509/#597/#602 vertical/RTL export parity, #610/#541/#535 portable batch/export proof handoff.
+- Deferred: XCF export from #591, native editable PSD writing from #558/#587, full large-batch archive splitting from #541.
+
+### Upstream BallonsTranslator issue/dev items implemented/deferred
+
+- Implemented/advanced: #1179 via adapted `c80eb81`, #1128/#995 through explicit vertical punctuation export metadata, #1134 through richer export/proof artifacts.
+- Reviewed/deferred: `4c14019` replace-all/render-all UI changes pending Pro global-search conflict audit; `1958f66` Ollama provider integration pending settings/onboarding pass; `88d4969` gguf dependency pending module matrix.
+
+### Next batch candidates
+
+1. Native editable PSD text-layer writer validation for Koharu #558/#587, using current manifest as the contract.
+2. Visual regression screenshots for SVG/Qt vertical punctuation and tate-chu-yoko on Qt5/Qt6/Windows DPI.
+3. Cross-page/batch proof ZIP queue with progress/cancel and optional archive splitting for Koharu #541/#610.
+4. Provider/model onboarding diagnostics for Ollama/Flux/gguf from upstream #1167/#1171/#1175.
+5. Direct `4c14019` conflict-aware port if Pro reproduces replace-and-render save/UI lag.
+6. XCF handoff export investigation for Koharu #591.
+
+
 
 ## Newly implemented in this pass (2026-05-17 third follow-up: atomic bubble fitting)
 

--- a/docs/KOHARU_ISSUE_BACKLOG.md
+++ b/docs/KOHARU_ISSUE_BACKLOG.md
@@ -4,6 +4,20 @@ _Refreshed: 2026-05-17. Source: GitHub REST API because `gh` is unavailable; sca
 
 ## Implemented or advanced in this pass (2026-05-17)
 
+
+### Current pass addendum (2026-05-17: SVG/PSD proof fidelity + portable proof archive)
+
+- [#591](https://github.com/mayocream/koharu/issues/591), [#558](https://github.com/mayocream/koharu/issues/558), [#587](https://github.com/mayocream/koharu/issues/587), and [#454](https://github.com/mayocream/koharu/issues/454) advanced with SVG/PSD handoff fidelity: editable SVG text now uses the renderer-neutral vertical layout plan for real vertical-RL glyph positions, punctuation classes, rotation hints, compact tate-chu-yoko groups, and font-run metadata; layered PSD manifests now preserve the same vertical layout and font-run metadata for downstream editable text reconstruction.
+- [#602](https://github.com/mayocream/koharu/issues/602), [#597](https://github.com/mayocream/koharu/issues/597), and [#509](https://github.com/mayocream/koharu/issues/509) advanced by carrying vertical punctuation/tate-chu-yoko and fallback font runs into export/proof artifacts instead of only the live renderer diagnostics.
+- [#610](https://github.com/mayocream/koharu/issues/610), [#541](https://github.com/mayocream/koharu/issues/541), and [#535](https://github.com/mayocream/koharu/issues/535) advanced with a portable `*_lettering_proof.zip` generated alongside each lettering proof pack so reviewers/batch scripts can hand off QA JSON, Markdown, SVG, PSD-helper manifests, helper layers, and final composite in one archive.
+
+| Issue | Title | Category | Labels | Maps to Pro | Implemented in Pro | Priority | Notes / deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [#591](https://github.com/mayocream/koharu/issues/591) | Add Support for exporting to SVG and/or XCF | PSD/export/layers | feature request, export | Yes | Partial/advanced this pass | High | SVG export now carries editable text plus vertical layout/tate-chu-yoko/fallback-run metadata. XCF remains deferred because no native writer is present. |
+| [#558](https://github.com/mayocream/koharu/issues/558) | PSD export rasterizes all text layers | PSD/export/layers | bug, psd, export | Yes | Partial/advanced this pass | High | Native PSD text writing remains unavailable, but PSD helper handoff now preserves richer editable text metadata and warnings instead of silently rasterizing. |
+| [#587](https://github.com/mayocream/koharu/issues/587) | Text boxes in exported PSD do not match original positions | PSD/export/layers | bug, psd, export | Yes | Partial/advanced this pass | High | PSD helper manifests now include renderer-neutral vertical glyph plans and bounds metadata for more faithful reconstruction. |
+| [#541](https://github.com/mayocream/koharu/issues/541) | Export to large batch fails ~2GB limit? | Batch/project workflow | export, batch | Yes | Partial | Medium | Portable proof ZIP improves review handoff granularity; large native PSD/archive splitting remains deferred to batch-export queue work. |
+
 - [#698](https://github.com/mayocream/koharu/issues/698) **Double outline** — implemented a persisted back/second outline for manga SFX and high-contrast lettering: `FontFormat.secondary_stroke_width`, `secondary_srgb`, renderer compositing, SVG editable-text handoff, text-panel controls, Rendering settings default, layout-review suggestion/action, and tests.
 - [#594](https://github.com/mayocream/koharu/issues/594), [#446](https://github.com/mayocream/koharu/issues/446), [#447](https://github.com/mayocream/koharu/issues/447), [#545](https://github.com/mayocream/koharu/issues/545) — advanced clipping-safe typography by making effect-margin and fit diagnostics account for the larger of primary and back outlines.
 - [#612](https://github.com/mayocream/koharu/issues/612), [#610](https://github.com/mayocream/koharu/issues/610), [#691](https://github.com/mayocream/koharu/issues/691) — extended the local automation/page-list workflow with `list_pages(include_rendering_qa=true)` so headless tools can list pages, textboxes, writing/fit modes, and current rendering issues in one call.

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -311,3 +311,11 @@ Atomic bubble fit now has density/profile modes instead of a single hard-coded l
 Settings now persist an **Atomic bubble fit default profile** alongside fill target and max expansion. The canvas context menu also exposes **Atomic bubble fit profile** as a one-off submenu so editors can apply a different density to selected bubbles without changing the global default. Automation callers can pass `profile` to `atomic_bubble_fit`; QA diagnostics include the resolved profile in the `atomic_bubble_fit` payload, so headless review/apply loops can reproduce the same formatting choice.
 
 The profile presets scale the existing fill-target and max-expansion settings instead of replacing them. This keeps older configs compatible while letting users tune the overall aggressiveness once and still switch between roomy, compact, caption, and SFX behavior.
+
+## New in current pass: export-faithful vertical text and portable proof archives
+
+SVG text handoff now uses the same renderer-neutral `vertical_layout_plan()` data consumed by typography QA. For vertical JP/CN text, the exported editable SVG records positioned glyph `<tspan>` entries with column/row coordinates, punctuation classes, rotation hints, and compact `data-tate-chu-yoko="true"` runs for short digit/Latin groups such as chapter numbers and combined punctuation. Horizontal and vertical handoffs also include `font_runs` and `fallback_runs` in the manifest so vector/PSD reconstruction tools can distinguish primary-font text from fallback-font spans.
+
+Layered PSD handoff manifests now include the same `font_runs`, `fallback_runs`, and `vertical_layout_plan` metadata for each translated text layer. Native editable PSD text writing is still deferred, but the manifest/JSX path no longer loses the layout information needed to rebuild vertical or mixed-script text layers faithfully in Photoshop/GIMP-oriented workflows.
+
+Lettering proof packs now write a portable `*_lettering_proof.zip` next to the per-page proof folder. The archive includes the QA JSON/Markdown, editable SVG handoff, PSD helper manifest/JSX, copied helper layers when available, HTML index, and final composite reference when available. This reduces batch/export review friction because a single file can be attached to issue reports or sent to a letterer without manually collecting several subfolders.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -99,8 +99,27 @@ The app will retry using the local HuggingFace cache only. If the model was neve
 | **Optional modules** | See **[docs/OPTIONAL_DEPENDENCIES.md](OPTIONAL_DEPENDENCIES.md)** for known conflicts (e.g. **craft_det** with opencv, **simple_lama** with Pillow). Use the suggested alternatives or a separate venv. |
 | **Don’t install everything** | Install only the dependencies for the modules you use. Extra pip packages (e.g. `craft-text-detector`, `simple-lama-inpainting`) can conflict with main `requirements.txt`. |
 | **Fresh venv** | `python -m venv venv`, activate, then `pip install -r requirements.txt` and `python launch.py`. Reduces conflicts from other projects. |
-| **Torch version** | `launch.py` installs PyTorch (CUDA or ROCm) automatically. To force a version, set **TORCH_COMMAND** (e.g. `pip install torch==... torchvision==... --index-url ...`) before running. See README or "Portable setup" for platform notes. |
+| **Torch/GPU runtime** | `launch.py` now chooses a GPU profile: NVIDIA CUDA, AMD ROCm preview for supported RX 7000/9000 + Python 3.12, AMD DirectML fallback, or CPU. Force one with `launch_win.bat --gpu-profile amd-directml` / `amd-rocm-preview` / `nvidia-cuda` / `cpu`, or set **TORCH_COMMAND** for a custom install. See [GPU_ACCELERATION.md](GPU_ACCELERATION.md). |
 
+
+
+### Windows AMD Radeon GPU is detected but BallonsTranslator still uses CPU
+
+**Symptoms:** Radeon RX 9070 XT / RX 7900 / other AMD card is installed, but module device selectors only show CPU or runs are very slow.
+
+**Fix:** Use the unified launcher. Double-click `launcher.bat` and choose **Start (auto GPU)** first. For RX 9070/9060/7900 on Windows + Python 3.12, auto mode uses AMD ROCm preview. If the ROCm wheel does not match your Python, choose **Force AMD DirectML** or run:
+
+```bat
+launch_win.bat --gpu-profile amd-directml
+```
+
+To print the detected GPU plan without starting the app:
+
+```bat
+launch_win.bat --gpu-report
+```
+
+In the app, use **Tools → Diagnostics → Runtime resource summary**. DirectML appears as `privateuseone:0`; NVIDIA/CUDA-style runtimes appear as `cuda`. Some modules are CPU-only, so also check the selected module's **device** setting.
 
 ### Windows NVIDIA: torch/torchvision entry-point errors after auto-install
 

--- a/docs/UPSTREAM_BALLONSTRANSLATOR_DEV_SYNC.md
+++ b/docs/UPSTREAM_BALLONSTRANSLATOR_DEV_SYNC.md
@@ -16,6 +16,18 @@ _Refreshed: 2026-05-17. Source: `git fetch upstream-base dev --depth=120`, then 
 
 ## Recent dev commit review
 
+
+### Current pass review addendum (2026-05-17: `c80eb81` adapted)
+
+Reviewed recent upstream `dev` commits through `6649de1..c80eb81` plus the adjacent dependency/provider commits. This pass safely adapted `c80eb81` (`fix #1179`) by changing Pro's `requirements.txt` from `transformers>=4.56` to `transformers>=4.57.6`. Unlike upstream, Pro keeps a lower-bound requirement rather than an exact pin so Pro-specific GLM-OCR/HF modules and future transformer-compatible providers are not forcibly downgraded. The Google translator `64a5713` was confirmed already represented in Pro (`TransGoogle.concate_text = False`) and left unchanged.
+
+| Upstream commit | Summary | Changed files | Category | Relevant to Pro | Already implemented in Pro | Ported this pass | Porting notes / conflicts / deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `c80eb81` | fix #1179 | `requirements.txt` | Dependency/platform compatibility | Yes | No | Yes (adapted) | Raised Pro's transformer floor to `>=4.57.6` instead of exact-pinning `4.57.6`, preserving Pro's broader compatibility while incorporating the upstream PaddleOCRVLManga fix. |
+| `64a5713` | fix #1172 | `modules/translators/trans_google.py` | Bugfix | Yes | Yes | No new change | Pro already has `TransGoogle.concate_text = False`, matching the upstream fix intent without reverting Pro's custom Google API-key handling. |
+| `4c14019` | replace-all/render-all UI lag and save bug | `ui/global_search_widget.py`, `ui/mainwindow.py` | UI/UX improvement | Yes | Partial/custom | Deferred | Still conflicts with Pro global-search/workflow changes; proof/archive/export status work advanced separately. |
+| `1958f66` | Ollama as translation/OCR provider | OCR/provider files | OCR/detection/inpainting/translation module update | Yes | Partial/custom | Deferred | Needs provider settings/onboarding integration rather than blind cherry-pick. |
+
 | Upstream commit | Summary | Changed files | Category | Relevant to Pro | Already implemented in Pro | Ported this pass | Porting notes / conflicts / deferred reason |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `6649de1` | update project save state logic #1178 | `ui/mainwindow.py` | Bugfix | Yes | Partial | Yes (adapted) | Manual audit found and fixed a Pro-specific selected-page detect-only `_run_stages_restore` tuple bug without overwriting Pro save/render logic. Exact grayscale inpaint fix remains fixture-deferred. |

--- a/docs/UPSTREAM_BALLONSTRANSLATOR_ISSUE_BACKLOG.md
+++ b/docs/UPSTREAM_BALLONSTRANSLATOR_ISSUE_BACKLOG.md
@@ -4,6 +4,20 @@ _Refreshed: 2026-05-17. Source: GitHub REST API because `gh` is unavailable; sca
 
 ## Implemented or advanced in this pass (2026-05-17)
 
+
+### Current pass addendum (2026-05-17: export fidelity + dependency compatibility)
+
+- [#1134](https://github.com/dmMaze/BallonsTranslator/issues/1134), [#1169](https://github.com/dmMaze/BallonsTranslator/issues/1169), [#1077](https://github.com/dmMaze/BallonsTranslator/issues/1077), [#1128](https://github.com/dmMaze/BallonsTranslator/issues/1128), and [#995](https://github.com/dmMaze/BallonsTranslator/issues/995) advanced through export/proof parity: SVG and PSD-helper exports now preserve vertical layout plans, punctuation classes, tate-chu-yoko groups, and font-run metadata used by QA/fit logic.
+- [#1179](https://github.com/dmMaze/BallonsTranslator/issues/1179) / dev commit `c80eb81` was adapted by raising Pro's `transformers` minimum to `>=4.57.6` instead of pinning exactly, preserving Pro's broader GLM/OCR/HF module compatibility while incorporating the upstream PaddleOCRVLManga compatibility floor.
+- [#1020](https://github.com/dmMaze/BallonsTranslator/issues/1020) and [#1052](https://github.com/dmMaze/BallonsTranslator/issues/1052) remain deferred for a full batch queue, but proof packs now create portable ZIP archives that make per-page review/export artifacts easier to attach to batch logs and issue reports.
+
+| Issue | Title | Category | Labels | Maps to Pro | Implemented in Pro | Priority | Notes / deferred reason |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| [#1179](https://github.com/dmMaze/BallonsTranslator/issues/1179) | PaddleOCRVLManga execution error | Compatibility/dependency/platform issues | bug, dependency | Yes | Yes/advanced this pass | High | Adapted upstream `c80eb81` by requiring `transformers>=4.57.6` while avoiding an exact pin that could conflict with Pro modules. |
+| [#1134](https://github.com/dmMaze/BallonsTranslator/issues/1134) | Export/save image as JPG or PNG without translation | PSD/export/layers | feature request, export | Yes | Partial/advanced | Medium | Existing export paths and proof pack artifacts now include richer final-composite/proof metadata; direct no-translation export already exists through current-page download modes. |
+| [#1128](https://github.com/dmMaze/BallonsTranslator/issues/1128) | Vertical Text not working | Vertical CJK / RTL / punctuation | bug, renderer | Yes | Partial/advanced this pass | High | Export/proof paths now serialize explicit vertical glyph placement, punctuation, and tate-chu-yoko metadata. Live renderer work remains ongoing. |
+| [#995](https://github.com/dmMaze/BallonsTranslator/issues/995) | Full-width converted to half-width characters | Vertical CJK / RTL / punctuation | bug, text | Yes | Partial/advanced this pass | Medium | Vertical punctuation normalization is preserved in SVG/PSD handoff metadata; broader OCR normalization policy remains deferred. |
+
 - [#1178](https://github.com/dmMaze/BallonsTranslator/issues/1178) / upstream dev `6649de1` review — fixed a Pro workflow regression in the selected-page **Detect only** helper: `_run_stages_restore` is now always the expected four-stage tuple, preventing pipeline-finished restore crashes after detector-only batch actions.
 - [#1077](https://github.com/dmMaze/BallonsTranslator/issues/1077), [#1138](https://github.com/dmMaze/BallonsTranslator/issues/1138), [#35](https://github.com/dmMaze/BallonsTranslator/issues/35) — advanced text fitting/effects by adding persisted double-outline/back-stroke support, effect-aware fit margins, text-panel controls, and layout-review actions.
 - [#1094](https://github.com/dmMaze/BallonsTranslator/issues/1094), [#1020](https://github.com/dmMaze/BallonsTranslator/issues/1020), [#841](https://github.com/dmMaze/BallonsTranslator/issues/841) — extended automation/page listing to include rendering QA so batch/headless tools can inspect textboxes and warnings before running exports or review.

--- a/launch.py
+++ b/launch.py
@@ -9,6 +9,11 @@ import shlex
 import warnings
 import json
 from platform import platform
+from utils.gpu_runtime import (
+    GPU_PROFILE_AUTO, GPU_PROFILE_CPU, GPU_PROFILE_NVIDIA_CUDA, GPU_PROFILE_AMD_DIRECTML,
+    GPU_PROFILE_AMD_ROCM_PREVIEW, build_gpu_install_plan, format_gpu_install_plan,
+    has_amd_gpu, has_nvidia_gpu, classify_amd_gpu, detect_physical_gpus,
+)
 
 # Suppress requests' urllib3/chardet version mismatch warning (harmless for typical use)
 warnings.filterwarnings("ignore", message=".*doesn't match a supported version.*")
@@ -89,8 +94,14 @@ parser.add_argument("--export-source-txt", action='store_true', help='save sourc
 parser.add_argument("--frozen", action='store_true', help='run without checking requirements')
 parser.add_argument("--update", action='store_true', help="Update the repository before launching") # Add argument --update
 parser.add_argument("--config_path", default=shared.CONFIG_PATH, help='Config file to use for translation') # Named config_path to avoid conflict with existing name config
-parser.add_argument('--nightly', action='store_true', help="Enable AMD Nightly ROCm")
+parser.add_argument('--nightly', action='store_true', help="Compatibility alias for --gpu-profile amd-rocm-preview")
+parser.add_argument('--gpu-profile', default=os.environ.get('BT_GPU_PROFILE', GPU_PROFILE_AUTO), choices=[GPU_PROFILE_AUTO, GPU_PROFILE_CPU, GPU_PROFILE_NVIDIA_CUDA, GPU_PROFILE_AMD_DIRECTML, GPU_PROFILE_AMD_ROCM_PREVIEW], help='GPU runtime profile: auto, cpu, nvidia-cuda, amd-directml, or amd-rocm-preview')
+parser.add_argument('--gpu-report', action='store_true', help='Print GPU runtime detection/install plan and exit')
 args, _ = parser.parse_known_args()
+
+if args.gpu_report:
+    print(format_gpu_install_plan(build_gpu_install_plan(args.gpu_profile, nightly=args.nightly)))
+    sys.exit(0)
 
 
 def is_installed(package):
@@ -588,72 +599,18 @@ def main():
     sys.exit(app.exec())
 
 def is_amd_gpu():
-    try:
-        if sys.platform == 'win32':
-            # Windows: use wmic
-            cmd = ['wmic', 'path', 'win32_VideoController', 'get', 'name']
-            output = subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL)
-            return any(keyword in output for keyword in ["AMD", "Radeon"])
+    return has_amd_gpu(detect_physical_gpus())
 
-        else:
-            return False
-
-    except Exception:
-        return False
 
 def supported_amd_nightly_gpu():
-    try:
-        if sys.platform == 'win32':
-            # Windows: use wmic
-            cmd = ['wmic', 'path', 'win32_VideoController', 'get', 'name']
-            output = subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL)
-
-            if any(keyword in output for keyword in
-                   ["RX 7900", "RX 7800", "RX 7700", "RX 7600", "PRO W7900", "PRO W7800", "PRO W7700"]):
-                return "RDNA3"
-            if any(keyword in output for keyword in
-                   ["RX 9070", "RX 9060"]):
-                return "RDNA4"
-        else:
-            return "None"
-
-    except Exception:
-        return "None"
+    return classify_amd_gpu(detect_physical_gpus()) or "None"
 
 
 def is_nvidia_gpu_present():
-    """Best-effort physical NVIDIA GPU probe before importing PyTorch.
-
-    GitHub ZIP installs often already have a CPU-only torch in the Python
-    environment. In that case torch imports successfully, but CUDA device
-    selectors never show up in the app. Probe the host GPU separately so the
-    launcher can replace CPU-only torch with the CUDA wheel.
-    """
+    """Best-effort physical NVIDIA GPU probe before importing PyTorch."""
     if os.environ.get("CUDA_VISIBLE_DEVICES", None) == "":
         return False
-    try:
-        output = subprocess.check_output(
-            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-            timeout=8,
-        )
-        if output.strip():
-            return True
-    except Exception:
-        pass
-    try:
-        if sys.platform == 'win32':
-            output = subprocess.check_output(
-                ['wmic', 'path', 'win32_VideoController', 'get', 'name'],
-                text=True,
-                stderr=subprocess.DEVNULL,
-                timeout=8,
-            )
-            return any(keyword in output.lower() for keyword in ("nvidia", "geforce", "rtx", "gtx", "quadro"))
-    except Exception:
-        pass
-    return False
+    return has_nvidia_gpu(detect_physical_gpus())
 
 
 def _probe_installed_torch():
@@ -673,6 +630,7 @@ payload = {
     'ok': True,
     'version': getattr(torch, '__version__', None),
     'cuda': getattr(getattr(torch, 'version', None), 'cuda', None),
+    'hip': getattr(getattr(torch, 'version', None), 'hip', None),
     'cuda_available': bool(torch.cuda.is_available()),
 }
 print(json.dumps(payload))
@@ -701,12 +659,12 @@ print(json.dumps(payload))
 
 
 def installed_torch_is_cpu_only():
-    """Return True when installed torch cannot expose CUDA devices."""
+    """Return True when installed torch cannot expose CUDA/HIP-style devices."""
     info = _probe_installed_torch()
     if not info.get("ok"):
         print(f"Unable to inspect installed PyTorch without importing it: {info.get('error')}")
         return True
-    return info.get("cuda") is None or not bool(info.get("cuda_available"))
+    return not bool(info.get("cuda_available"))
 
 
 def prepare_environment():
@@ -732,40 +690,37 @@ def prepare_environment():
                 run_pip(f"install {req}", req)
                 req_updated = True
 
-    if is_amd_gpu():
-        print('AMD GPU: Yes')
-        if args.nightly:
-            amd_nightly_gpu = supported_amd_nightly_gpu()
-            if amd_nightly_gpu == "None":
-                Exception("No AMD Nightly GPU supported")
-            if amd_nightly_gpu == "RDNA3":
-                torch_command = os.environ.get('TORCH_COMMAND',
-                                               "pip install https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torch-2.8.0a0%2Bgitfc14c65-cp312-cp312-win_amd64.whl https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchvision-0.24.0a0%2Bc85f008-cp312-cp312-win_amd64.whl https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchaudio-2.6.0a0%2B1a8f621-cp312-cp312-win_amd64.whl")
-            if amd_nightly_gpu == "RDNA4":
-                torch_command = os.environ.get('TORCH_COMMAND',
-                                               "pip install https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torch-2.8.0a0%2Bgitfc14c65-cp312-cp312-win_amd64.whl https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchvision-0.24.0a0%2Bc85f008-cp312-cp312-win_amd64.whl https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchaudio-2.6.0a0%2B1a8f621-cp312-cp312-win_amd64.whl")
-        else:
-            # AMD GPU: Cuda 11.8, Pytorch 2.2.2
-            torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.2.2 torchvision==0.17.2 torchaudio==2.2.2 --index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check")
-    else:
-        torch_command = os.environ.get('TORCH_COMMAND', "pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check")
+    gpu_plan = build_gpu_install_plan(args.gpu_profile, nightly=args.nightly)
+    print(format_gpu_install_plan(gpu_plan))
+    torch_command = gpu_plan.torch_command
     cuda_torch_reinstall_needed = (
         not os.environ.get("BT_SKIP_CUDA_TORCH_REINSTALL")
         and os.environ.get("BT_CUDA_TORCH_REINSTALL_ATTEMPTED") != "1"
-        and not is_amd_gpu()
+        and gpu_plan.resolved_profile == GPU_PROFILE_NVIDIA_CUDA
         and is_nvidia_gpu_present()
+        and is_installed("torch")
+        and installed_torch_is_cpu_only()
+    )
+    rocm_torch_reinstall_needed = (
+        not os.environ.get("BT_SKIP_AMD_ROCM_TORCH_REINSTALL")
+        and os.environ.get("BT_AMD_ROCM_TORCH_REINSTALL_ATTEMPTED") != "1"
+        and gpu_plan.resolved_profile == GPU_PROFILE_AMD_ROCM_PREVIEW
         and is_installed("torch")
         and installed_torch_is_cpu_only()
     )
     if cuda_torch_reinstall_needed:
         print("NVIDIA GPU detected but installed PyTorch is CPU-only or cannot use CUDA; installing CUDA-enabled PyTorch.")
         os.environ["BT_CUDA_TORCH_REINSTALL_ATTEMPTED"] = "1"
+    if rocm_torch_reinstall_needed:
+        print("AMD ROCm preview profile selected but installed PyTorch cannot use a HIP/CUDA-style device; installing AMD ROCm preview PyTorch.")
+        os.environ["BT_AMD_ROCM_TORCH_REINSTALL_ATTEMPTED"] = "1"
 
-    if args.reinstall_torch or not is_installed("torch") or not is_installed("torchvision") or cuda_torch_reinstall_needed:
+    required_missing = any(not is_installed(pkg) for pkg in gpu_plan.required_packages)
+    if args.reinstall_torch or required_missing or cuda_torch_reinstall_needed or rocm_torch_reinstall_needed:
         install_torch_command = torch_command
-        if cuda_torch_reinstall_needed and "TORCH_COMMAND" not in os.environ and "--force-reinstall" not in install_torch_command:
+        if (cuda_torch_reinstall_needed or rocm_torch_reinstall_needed) and "TORCH_COMMAND" not in os.environ and "--force-reinstall" not in install_torch_command:
             install_torch_command = f"{install_torch_command} --force-reinstall"
-        run(f'"{python}" -m {install_torch_command}', "Installing torch and torchvision", "Couldn't install torch", live=True)
+        run(f'"{python}" -m {install_torch_command}', "Installing GPU runtime packages", "Couldn't install GPU runtime packages", live=True)
         req_updated = True
 
     if not check_req_file(args.requirements):

--- a/launch_win.bat
+++ b/launch_win.bat
@@ -62,6 +62,8 @@ echo Couldn't install pip
 goto :show_stdout_stderr
 
 :launch
+echo Using: %PYTHON%
+echo GPU runtime: auto by default. Use --gpu-profile amd-directml, amd-rocm-preview, nvidia-cuda, or cpu to force.
 start "BallonsTranslator" cmd /k "cd /d ""%~dp0"" && %PYTHON% launch.py %*"
 exit /b
 

--- a/launch_win_amd_nightly.bat
+++ b/launch_win_amd_nightly.bat
@@ -1,64 +1,7 @@
-@REM Launch BallonsTranslator for Windows portable bundle layout with --nightly (AMD ROCm nightly mode).
-@REM @echo %PATH%
-
-cd %~dp0
-
 @echo off
-
-:: Set the path for PaddleOCR and PyTorch libraries
-set "PADDLE_PATH=%~dp0ballontrans_pylibs_win\Lib\site-packages\torch\lib"
-set "PATH=%PADDLE_PATH%;%PATH%"
-
-@REM if not defined PYTHON (set PATH=pylibs;pylibs\Scripts;%%PATH%%
-set PATH=ballontrans_pylibs_win;ballontrans_pylibs_win\Scripts;PortableGit\cmd;%PATH%
-set PYTHON=python.exe
-
-set ERROR_REPORTING=FALSE
-
-mkdir tmp 2>NUL
-
-%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :check_pip
-echo Couldn't launch python
-goto :show_stdout_stderr
-
-:check_pip
-%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch
-if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
-%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch
-echo Couldn't install pip
-goto :show_stdout_stderr
-
-
-:launch
-%PYTHON% launch.py --nightly %*
-pause
-exit /b
-
-
-:show_stdout_stderr
-
-echo.
-echo exit code: %errorlevel%
-
-for /f %%i in ("tmp\stdout.txt") do set size=%%~zi
-if %size% equ 0 goto :show_stderr
-echo.
-echo stdout:
-type tmp\stdout.txt
-
-:show_stderr
-for /f %%i in ("tmp\stderr.txt") do set size=%%~zi
-if %size% equ 0 goto :endofscript
-echo.
-echo stderr:
-type tmp\stderr.txt
-
-:endofscript
-
-echo.
-echo Launch unsuccessful. Exiting.
-pause
-exit /b
+REM Compatibility wrapper. Prefer launcher.bat or launch_win.bat --gpu-profile amd-rocm-preview.
+cd /d "%~dp0"
+echo [Info] launch_win_amd_nightly.bat is now a compatibility wrapper.
+echo [Info] Use launcher.bat for the unified menu, or launch_win.bat --gpu-profile amd-rocm-preview.
+call "%~dp0launch_win.bat" --gpu-profile amd-rocm-preview %*
+exit /b %ERRORLEVEL%

--- a/launch_win_with_autoupdate.bat
+++ b/launch_win_with_autoupdate.bat
@@ -1,64 +1,7 @@
-@REM Launch BallonsTranslator for Windows portable bundle layout with --update.
-@REM @echo %PATH%
-
-cd %~dp0
-
 @echo off
-
-:: Set the path for PaddleOCR and PyTorch libraries
-set "PADDLE_PATH=%~dp0ballontrans_pylibs_win\Lib\site-packages\torch\lib"
-set "PATH=%PADDLE_PATH%;%PATH%"
-
-@REM if not defined PYTHON (set PATH=pylibs;pylibs\Scripts;%%PATH%%
-set PATH=ballontrans_pylibs_win;ballontrans_pylibs_win\Scripts;PortableGit\cmd;%PATH%
-set PYTHON=python.exe
-
-set ERROR_REPORTING=FALSE
-
-mkdir tmp 2>NUL
-
-%PYTHON% -c "" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :check_pip
-echo Couldn't launch python
-goto :show_stdout_stderr
-
-:check_pip
-%PYTHON% -mpip --help >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch
-if "%PIP_INSTALLER_LOCATION%" == "" goto :show_stdout_stderr
-%PYTHON% "%PIP_INSTALLER_LOCATION%" >tmp/stdout.txt 2>tmp/stderr.txt
-if %ERRORLEVEL% == 0 goto :launch
-echo Couldn't install pip
-goto :show_stdout_stderr
-
-
-:launch
-%PYTHON% launch.py --update  %*
-pause
-exit /b
-
-
-:show_stdout_stderr
-
-echo.
-echo exit code: %errorlevel%
-
-for /f %%i in ("tmp\stdout.txt") do set size=%%~zi
-if %size% equ 0 goto :show_stderr
-echo.
-echo stdout:
-type tmp\stdout.txt
-
-:show_stderr
-for /f %%i in ("tmp\stderr.txt") do set size=%%~zi
-if %size% equ 0 goto :endofscript
-echo.
-echo stderr:
-type tmp\stderr.txt
-
-:endofscript
-
-echo.
-echo Launch unsuccessful. Exiting.
-pause
-exit /b
+REM Compatibility wrapper. Prefer launcher.bat or launch_win.bat --update.
+cd /d "%~dp0"
+echo [Info] launch_win_with_autoupdate.bat is now a compatibility wrapper.
+echo [Info] Use launcher.bat for the unified menu, or launch_win.bat --update.
+call "%~dp0launch_win.bat" --update %*
+exit /b %ERRORLEVEL%

--- a/launcher.bat
+++ b/launcher.bat
@@ -12,19 +12,23 @@ echo ==========================================
 echo        BallonsTranslator Launcher
 echo ==========================================
 echo.
-echo [1] Start (auto-detect Python / env)
+echo [1] Start (auto GPU: NVIDIA CUDA / AMD ROCm-DirectML / CPU)
 echo [2] Setup dependencies
 echo [3] Start with auto-update
-echo [4] Start AMD nightly mode
+echo [4] Force AMD ROCm preview (RX 7000/9000, Python 3.12)
+echo [5] Force AMD DirectML (broad Windows AMD fallback)
+echo [6] CPU-only safe mode
 echo [Q] Quit
 echo.
-choice /C 1234Q /N /M "Select [1-4, Q]: "
+choice /C 123456Q /N /M "Select [1-6, Q]: "
 set "K=%ERRORLEVEL%"
 
 if "%K%"=="1" goto :menu_launch
 if "%K%"=="2" goto :menu_setup
 if "%K%"=="3" goto :menu_update
-if "%K%"=="4" goto :menu_nightly
+if "%K%"=="4" goto :menu_rocm
+if "%K%"=="5" goto :menu_directml
+if "%K%"=="6" goto :menu_cpu
 goto :end
 
 :menu_launch
@@ -39,8 +43,16 @@ goto :finish
 call "%~dp0launch_win_with_autoupdate.bat"
 goto :finish
 
-:menu_nightly
-call "%~dp0launch_win_amd_nightly.bat"
+:menu_rocm
+call "%~dp0launch_win.bat" --gpu-profile amd-rocm-preview
+goto :finish
+
+:menu_directml
+call "%~dp0launch_win.bat" --gpu-profile amd-directml
+goto :finish
+
+:menu_cpu
+call "%~dp0launch_win.bat" --gpu-profile cpu
 goto :finish
 
 :direct_launch

--- a/modules/base.py
+++ b/modules/base.py
@@ -475,6 +475,7 @@ def _get_device_selector_description(options: List[str]) -> str:
         f"Detected backend: {DEFAULT_DEVICE.split(':', 1)[0] if DEFAULT_DEVICE != 'cpu' else 'cpu'}",
         f"Available devices: {', '.join(options) if options else 'cpu'}",
         f"PyTorch CUDA build: {d.get('torch_cuda')}",
+        f"DirectML available/count: {d.get('directml_available')} / {d.get('directml_count')}",
     ]
     if d.get('cuda_devices'):
         lines.append(f"CUDA GPU names: {', '.join(d['cuda_devices'])}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ jaconv
 torch
 torchvision
 # >=4.56 for core; >=5.0 needed for GLM-OCR and some HF modules. Do not pin to 4.57.1 or install will downgrade and break them.
-transformers>=4.56
+transformers>=4.57.6
 mecab-python3; sys_platform == 'darwin'
 fugashi
 unidic_lite

--- a/setup.bat
+++ b/setup.bat
@@ -74,12 +74,12 @@ if errorlevel 1 (
 
 echo.
 echo Setup done. Next:
-echo   1. Run:  launch_win.bat  (or: %PYTHON% launch.py)
-echo   2. First run will install PyTorch (auto-detects NVIDIA/AMD GPU or CPU).
+echo   1. Run:  launcher.bat  (recommended menu) or launch_win.bat
+echo   2. First run will install the GPU runtime (NVIDIA CUDA / AMD ROCm-DirectML / CPU).
 echo   3. Fonts:  fonts\   (add .ttf/.otf here)
 echo   4. Models: data\    (downloaded on first use; copy this folder when moving)
 echo   5. Output: saved in each project folder you open
-echo   6. Problems? See docs\TROUBLESHOOTING.md
+echo   6. GPU problems? See docs\GPU_ACCELERATION.md and docs\TROUBLESHOOTING.md
 echo.
 pause
 endlocal

--- a/tests/test_gpu_runtime.py
+++ b/tests/test_gpu_runtime.py
@@ -1,0 +1,54 @@
+import sys
+
+from utils.gpu_runtime import (
+    GPU_PROFILE_AMD_DIRECTML,
+    GPU_PROFILE_AMD_ROCM_PREVIEW,
+    GPU_PROFILE_CPU,
+    GPU_PROFILE_NVIDIA_CUDA,
+    build_gpu_install_plan,
+    classify_amd_gpu,
+    normalize_gpu_profile,
+)
+
+
+def _win_py312():
+    return type("Version", (), {"major": 3, "minor": 12})()
+
+
+def _win_py310():
+    return type("Version", (), {"major": 3, "minor": 10})()
+
+
+def test_normalize_gpu_profile_aliases():
+    assert normalize_gpu_profile("cuda") == GPU_PROFILE_NVIDIA_CUDA
+    assert normalize_gpu_profile("rocm") == GPU_PROFILE_AMD_ROCM_PREVIEW
+    assert normalize_gpu_profile("dml") == GPU_PROFILE_AMD_DIRECTML
+    assert normalize_gpu_profile("off") == GPU_PROFILE_CPU
+
+
+def test_auto_prefers_nvidia_cuda_when_nvidia_present():
+    plan = build_gpu_install_plan("auto", python_version_info=_win_py312(), gpu_names=["NVIDIA GeForce RTX 4070"])
+    assert plan.resolved_profile == GPU_PROFILE_NVIDIA_CUDA
+    assert "cu118" in plan.torch_command
+
+
+def test_rx9070_auto_uses_rocm_preview_on_windows_python312(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    plan = build_gpu_install_plan("auto", python_version_info=_win_py312(), gpu_names=["AMD Radeon RX 9070 XT"])
+    assert classify_amd_gpu(plan.physical_gpus) == "RDNA4"
+    assert plan.resolved_profile == GPU_PROFILE_AMD_ROCM_PREVIEW
+    assert "repo.radeon.com/rocm/windows" in plan.torch_command
+
+
+def test_rx9070_auto_falls_back_to_directml_without_python312(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    plan = build_gpu_install_plan("auto", python_version_info=_win_py310(), gpu_names=["AMD Radeon RX 9070 XT"])
+    assert plan.resolved_profile == GPU_PROFILE_AMD_DIRECTML
+    assert "torch-directml" in plan.torch_command
+    assert plan.warnings
+
+
+def test_no_gpu_uses_cpu_profile():
+    plan = build_gpu_install_plan("auto", python_version_info=_win_py312(), gpu_names=["Microsoft Basic Display Adapter"])
+    assert plan.resolved_profile == GPU_PROFILE_CPU
+    assert "whl/cpu" in plan.torch_command

--- a/tests/test_layered_psd_export.py
+++ b/tests/test_layered_psd_export.py
@@ -29,4 +29,6 @@ def test_layered_psd_handoff_preserves_secondary_outline_metadata(tmp_path):
     assert layer["secondary_stroke_width"] == 0.22
     assert layer["secondary_stroke_rgb"] == [255, 240, 120]
     assert layer["proof_metrics"]["effect_margin"] > 0
+    assert layer["font_runs"]
+    assert "fallback_runs" in layer
     assert "secondary_stroke_width" in (tmp_path / "out" / "p_rebuild_psd.jsx").read_text()

--- a/tests/test_lettering_proof_export.py
+++ b/tests/test_lettering_proof_export.py
@@ -28,4 +28,7 @@ def test_lettering_proof_pack_writes_manifest_and_qa(tmp_path):
     assert manifest["typography_qa_json"].endswith("typography_qa.json")
     assert manifest["html_index"].endswith("lettering_proof_index.html")
     assert (tmp_path / "proof" / "page_lettering_proof" / "lettering_proof_index.html").exists()
+    assert manifest["archive_path"].endswith("_lettering_proof.zip")
+    assert (tmp_path / "proof" / "page_lettering_proof.zip").exists()
+    assert "Portable ZIP archive" in (tmp_path / "proof" / "page_lettering_proof" / "lettering_proof_index.html").read_text(encoding="utf-8")
     assert "polish_typography" in manifest["next_actions"]

--- a/tests/test_svg_text_export.py
+++ b/tests/test_svg_text_export.py
@@ -25,4 +25,7 @@ def test_svg_text_handoff_writes_editable_vertical_text(tmp_path):
     assert manifest["text_layers"][0]["writing_mode"] == "vertical_rl"
     assert 'writing-mode="vertical-rl"' in svg
     assert "text_001" in svg
+    assert "data-tate-chu-yoko" in svg
+    assert manifest["text_layers"][0]["vertical_layout_plan"]["tate_chu_yoko_groups"]
+    assert manifest["text_layers"][0]["font_runs"]
     assert manifest["warnings"]

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -3583,6 +3583,7 @@ class MainWindow(mainwindow_cls):
             f"Python executable: {sys.executable}",
             f"Platform: {sys.platform}",
             f"CUDA_VISIBLE_DEVICES: {os.environ.get('CUDA_VISIBLE_DEVICES', '<unset>')}",
+            f"BT_GPU_PROFILE: {os.environ.get('BT_GPU_PROFILE', '<unset>')}",
             f"Detector: {getattr(pcfg.module, 'textdetector', '')}",
             f"OCR: {getattr(pcfg.module, 'ocr', '')}",
             f"Inpainter: {getattr(pcfg.module, 'inpainter', '')}",
@@ -3609,6 +3610,13 @@ class MainWindow(mainwindow_cls):
             lines.append("Startup stages:")
             for item in stages:
                 lines.append(f"  - {item.get('stage', '?')}: {item.get('status', 'ok')} ({item.get('details', '')})")
+        try:
+            from utils.gpu_runtime import build_gpu_install_plan, format_gpu_install_plan
+            lines.append("")
+            lines.append("GPU install plan:")
+            lines.append(format_gpu_install_plan(build_gpu_install_plan(os.environ.get('BT_GPU_PROFILE', 'auto'))))
+        except Exception as exc:
+            lines.append(f"GPU install plan unavailable: {exc}")
         return "\n".join(lines)
 
     def _show_startup_health_overlay(self):

--- a/utils/gpu_runtime.py
+++ b/utils/gpu_runtime.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+GPU_PROFILE_AUTO = "auto"
+GPU_PROFILE_CPU = "cpu"
+GPU_PROFILE_NVIDIA_CUDA = "nvidia-cuda"
+GPU_PROFILE_AMD_DIRECTML = "amd-directml"
+GPU_PROFILE_AMD_ROCM_PREVIEW = "amd-rocm-preview"
+GPU_PROFILES = {
+    GPU_PROFILE_AUTO,
+    GPU_PROFILE_CPU,
+    GPU_PROFILE_NVIDIA_CUDA,
+    GPU_PROFILE_AMD_DIRECTML,
+    GPU_PROFILE_AMD_ROCM_PREVIEW,
+}
+
+NVIDIA_CUDA_TORCH_COMMAND = (
+    "pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1 "
+    "--index-url https://download.pytorch.org/whl/cu118 --disable-pip-version-check"
+)
+CPU_TORCH_COMMAND = (
+    "pip install torch torchvision torchaudio "
+    "--index-url https://download.pytorch.org/whl/cpu --disable-pip-version-check"
+)
+AMD_DIRECTML_TORCH_COMMAND = "pip install torch-directml --disable-pip-version-check"
+# AMD's current Windows ROCm preview wheels target CPython 3.12.  Keep the URL
+# centralized so launch.py, batch files, docs, and tests agree.
+AMD_ROCM_PREVIEW_TORCH_COMMAND = (
+    "pip install "
+    "https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torch-2.8.0a0%2Bgitfc14c65-cp312-cp312-win_amd64.whl "
+    "https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchvision-0.24.0a0%2Bc85f008-cp312-cp312-win_amd64.whl "
+    "https://repo.radeon.com/rocm/windows/rocm-rel-6.4.4/torchaudio-2.6.0a0%2B1a8f621-cp312-cp312-win_amd64.whl "
+    "--disable-pip-version-check"
+)
+
+AMD_RDNA3_PATTERNS = (
+    "RX 7900", "RX 7800", "RX 7700", "RX 7600",
+    "PRO W7900", "PRO W7800", "PRO W7700", "PRO W7600",
+)
+AMD_RDNA4_PATTERNS = (
+    "RX 9070", "RX 9060", "RX 9050", "AI PRO R9700",
+)
+
+
+@dataclass(frozen=True)
+class GpuInstallPlan:
+    requested_profile: str
+    resolved_profile: str
+    torch_command: str
+    required_packages: tuple[str, ...]
+    reason: str
+    warnings: tuple[str, ...] = ()
+    physical_gpus: tuple[str, ...] = ()
+    amd_family: str = ""
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "requested_profile": self.requested_profile,
+            "resolved_profile": self.resolved_profile,
+            "torch_command": self.torch_command,
+            "required_packages": list(self.required_packages),
+            "reason": self.reason,
+            "warnings": list(self.warnings),
+            "physical_gpus": list(self.physical_gpus),
+            "amd_family": self.amd_family,
+        }
+
+
+def normalize_gpu_profile(profile: Optional[str]) -> str:
+    value = (profile or GPU_PROFILE_AUTO).strip().lower().replace("_", "-")
+    aliases = {
+        "nvidia": GPU_PROFILE_NVIDIA_CUDA,
+        "cuda": GPU_PROFILE_NVIDIA_CUDA,
+        "amd": GPU_PROFILE_AMD_DIRECTML,
+        "directml": GPU_PROFILE_AMD_DIRECTML,
+        "dml": GPU_PROFILE_AMD_DIRECTML,
+        "rocm": GPU_PROFILE_AMD_ROCM_PREVIEW,
+        "amd-rocm": GPU_PROFILE_AMD_ROCM_PREVIEW,
+        "nightly": GPU_PROFILE_AMD_ROCM_PREVIEW,
+        "amd-nightly": GPU_PROFILE_AMD_ROCM_PREVIEW,
+        "off": GPU_PROFILE_CPU,
+        "none": GPU_PROFILE_CPU,
+    }
+    value = aliases.get(value, value)
+    return value if value in GPU_PROFILES else GPU_PROFILE_AUTO
+
+
+def _run_text(cmd: List[str], timeout: int = 8) -> str:
+    try:
+        return subprocess.check_output(cmd, text=True, stderr=subprocess.DEVNULL, timeout=timeout)
+    except Exception:
+        return ""
+
+
+def _windows_gpu_names() -> List[str]:
+    if sys.platform != "win32":
+        return []
+    outputs = []
+    outputs.append(_run_text(["wmic", "path", "win32_VideoController", "get", "name"]))
+    ps = _run_text([
+        "powershell", "-NoProfile", "-Command",
+        "Get-CimInstance Win32_VideoController | Select-Object -ExpandProperty Name",
+    ])
+    outputs.append(ps)
+    names: List[str] = []
+    for output in outputs:
+        for line in (output or "").splitlines():
+            line = line.strip()
+            if not line or line.lower() == "name":
+                continue
+            if line not in names:
+                names.append(line)
+    return names
+
+
+def detect_physical_gpus() -> List[str]:
+    names = []
+    if os.environ.get("CUDA_VISIBLE_DEVICES", None) != "":
+        nvsmi = _run_text(["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"])
+        for line in nvsmi.splitlines():
+            line = line.strip()
+            if line and line not in names:
+                names.append(line)
+    for line in _windows_gpu_names():
+        if line not in names:
+            names.append(line)
+    return names
+
+
+def has_nvidia_gpu(names: Optional[Iterable[str]] = None) -> bool:
+    haystack = "\n".join(names if names is not None else detect_physical_gpus()).lower()
+    return any(k in haystack for k in ("nvidia", "geforce", "rtx", "gtx", "quadro"))
+
+
+def has_amd_gpu(names: Optional[Iterable[str]] = None) -> bool:
+    haystack = "\n".join(names if names is not None else detect_physical_gpus()).lower()
+    return any(k in haystack for k in ("amd", "radeon", "rx ", "pro w"))
+
+
+def classify_amd_gpu(names: Optional[Iterable[str]] = None) -> str:
+    text = "\n".join(names if names is not None else detect_physical_gpus()).upper()
+    if any(pattern in text for pattern in AMD_RDNA4_PATTERNS):
+        return "RDNA4"
+    if any(pattern in text for pattern in AMD_RDNA3_PATTERNS):
+        return "RDNA3"
+    if "RADEON" in text or "AMD" in text:
+        return "AMD"
+    return ""
+
+
+def python_supports_amd_rocm_preview(version_info=None) -> bool:
+    vi = version_info or sys.version_info
+    return sys.platform == "win32" and int(vi.major) == 3 and int(vi.minor) == 12
+
+
+def build_gpu_install_plan(profile: Optional[str] = None, *, nightly: bool = False, python_version_info=None, gpu_names: Optional[Iterable[str]] = None) -> GpuInstallPlan:
+    requested = GPU_PROFILE_AMD_ROCM_PREVIEW if nightly else normalize_gpu_profile(profile or os.environ.get("BT_GPU_PROFILE") or GPU_PROFILE_AUTO)
+    names = tuple(gpu_names if gpu_names is not None else detect_physical_gpus())
+    amd_family = classify_amd_gpu(names)
+    warnings: List[str] = []
+
+    resolved = requested
+    reason = "Explicit GPU profile requested."
+    if requested == GPU_PROFILE_AUTO:
+        if has_nvidia_gpu(names):
+            resolved = GPU_PROFILE_NVIDIA_CUDA
+            reason = "NVIDIA GPU detected; using CUDA PyTorch wheels."
+        elif has_amd_gpu(names):
+            if amd_family in {"RDNA3", "RDNA4"} and python_supports_amd_rocm_preview(python_version_info):
+                resolved = GPU_PROFILE_AMD_ROCM_PREVIEW
+                reason = f"AMD {amd_family} GPU detected with Python 3.12; using AMD ROCm Windows preview wheels."
+            else:
+                resolved = GPU_PROFILE_AMD_DIRECTML
+                if amd_family in {"RDNA3", "RDNA4"}:
+                    reason = f"AMD {amd_family} GPU detected, but ROCm preview wheels require Windows CPython 3.12; using DirectML."
+                    warnings.append("For ROCm preview on Radeon RX 7000/9000, use Python 3.12 or set BT_GPU_PROFILE=amd-rocm-preview.")
+                else:
+                    reason = "AMD GPU detected; using DirectML because it is the broad Windows AMD fallback."
+        else:
+            resolved = GPU_PROFILE_CPU
+            reason = "No NVIDIA/AMD GPU detected; using CPU PyTorch wheels."
+    elif requested == GPU_PROFILE_AMD_ROCM_PREVIEW and not python_supports_amd_rocm_preview(python_version_info):
+        resolved = GPU_PROFILE_AMD_DIRECTML
+        reason = "AMD ROCm preview was requested, but the published Windows wheels target CPython 3.12; falling back to DirectML."
+        warnings.append("Install/use Python 3.12 to try AMD ROCm preview wheels on Radeon RX 7000/9000.")
+
+    if resolved == GPU_PROFILE_NVIDIA_CUDA:
+        command = NVIDIA_CUDA_TORCH_COMMAND
+        required = ("torch", "torchvision")
+    elif resolved == GPU_PROFILE_AMD_ROCM_PREVIEW:
+        command = AMD_ROCM_PREVIEW_TORCH_COMMAND
+        required = ("torch", "torchvision")
+    elif resolved == GPU_PROFILE_AMD_DIRECTML:
+        command = AMD_DIRECTML_TORCH_COMMAND
+        required = ("torch", "torch_directml")
+    else:
+        command = CPU_TORCH_COMMAND
+        required = ("torch", "torchvision")
+
+    command = os.environ.get("TORCH_COMMAND", command)
+    if "TORCH_COMMAND" in os.environ:
+        reason += " TORCH_COMMAND override is set."
+
+    return GpuInstallPlan(
+        requested_profile=requested,
+        resolved_profile=resolved,
+        torch_command=command,
+        required_packages=required,
+        reason=reason,
+        warnings=tuple(warnings),
+        physical_gpus=names,
+        amd_family=amd_family,
+    )
+
+
+def format_gpu_install_plan(plan: GpuInstallPlan) -> str:
+    lines = [
+        f"GPU profile: requested={plan.requested_profile}, resolved={plan.resolved_profile}",
+        f"Detected physical GPUs: {', '.join(plan.physical_gpus) if plan.physical_gpus else 'none'}",
+        f"AMD family: {plan.amd_family or 'n/a'}",
+        f"Reason: {plan.reason}",
+        f"Torch install command: python -m {plan.torch_command}",
+    ]
+    for warning in plan.warnings:
+        lines.append(f"Warning: {warning}")
+    return "\n".join(lines)

--- a/utils/layered_psd_export.py
+++ b/utils/layered_psd_export.py
@@ -7,7 +7,7 @@ import shutil
 from typing import Dict, List, Tuple
 from types import SimpleNamespace
 
-from utils.text_rendering import lettering_proof_metrics, resolve_writing_mode
+from utils.text_rendering import lettering_proof_metrics, resolve_writing_mode, vertical_layout_plan, font_fallback_runs, merge_font_fallback_chain
 
 
 def _safe_copy(src: str, dst: str) -> bool:
@@ -80,16 +80,31 @@ def build_layered_psd_handoff(project, page_name: str, out_dir: str, final_image
         box_w = max(1.0, float((xyxy[2] - xyxy[0]) if len(xyxy) >= 4 else 1.0))
         box_h = max(1.0, float((xyxy[3] - xyxy[1]) if len(xyxy) >= 4 else 1.0))
         resolved_mode = resolve_writing_mode(getattr(ff, "writing_mode", "auto") if ff else "auto", text_value, (box_w, box_h))
+        font_size_px = float(getattr(ff, "font_size", 24.0) if ff else 24.0 or 24.0)
+        line_spacing = float(getattr(ff, "line_spacing", 1.2) if ff else 1.2 or 1.2)
+        letter_spacing = float(getattr(ff, "letter_spacing", 1.0) if ff else 1.0 or 1.0)
+        line_break_strategy = getattr(ff, "line_break_strategy", "auto") if ff else "auto"
+        max_vertical_chars = max(1, int(box_h / max(1.0, font_size_px * max(0.1, letter_spacing))))
+        vertical_plan = vertical_layout_plan(text_value, max_vertical_chars, font_size=font_size_px, line_spacing=line_spacing, letter_spacing=letter_spacing, strategy=line_break_strategy) if resolved_mode == "vertical_rl" else {}
+        fallback_runs = [
+            {"start": start, "end": end, "family": family, "text": text_value[start:end]}
+            for start, end, family in font_fallback_runs(text_value, getattr(ff, "font_family", "") if ff else "", qa_config, getattr(ff, "fallback_font_chain", "") if ff else "")
+            if end > start
+        ]
+        primary_family = (merge_font_fallback_chain(getattr(ff, "font_family", "") if ff else "", text_value, qa_config, getattr(ff, "fallback_font_chain", "") if ff else "") or [getattr(ff, "font_family", "") if ff else ""])[0]
+        font_runs = [{"start": 0, "end": len(text_value), "family": primary_family, "text": text_value, "fallback": False}]
+        for run in fallback_runs:
+            run["fallback"] = True
         proof_metrics = lettering_proof_metrics(
-            text_value, getattr(ff, "font_size", 24.0) if ff else 24.0, (box_w, box_h), resolved_mode,
-            line_spacing=getattr(ff, "line_spacing", 1.2) if ff else 1.2,
-            letter_spacing=getattr(ff, "letter_spacing", 1.0) if ff else 1.0,
+            text_value, font_size_px, (box_w, box_h), resolved_mode,
+            line_spacing=line_spacing,
+            letter_spacing=letter_spacing,
             padding=getattr(ff, "text_padding", 0.0) if ff else 0.0,
             stroke_width=getattr(ff, "stroke_width", 0.0) if ff else 0.0,
             secondary_stroke_width=getattr(ff, "secondary_stroke_width", 0.0) if ff else 0.0,
             shadow_radius=getattr(ff, "shadow_radius", 0.0) if ff else 0.0,
             shadow_offset=getattr(ff, "shadow_offset", [0.0, 0.0]) if ff else [0.0, 0.0],
-            line_break_strategy=getattr(ff, "line_break_strategy", "auto") if ff else "auto",
+            line_break_strategy=line_break_strategy,
             sample_limit=64,
         )
         text_layers.append({
@@ -97,7 +112,7 @@ def build_layered_psd_handoff(project, page_name: str, out_dir: str, final_image
             "text": text_value,
             "xyxy": xyxy,
             "font_family": getattr(ff, "font_family", "") if ff else "",
-            "font_size_px": getattr(ff, "font_size", 24.0) if ff else 24.0,
+            "font_size_px": font_size_px,
             "fit_font_size_min": getattr(ff, "fit_font_size_min", 0.0) if ff else 0.0,
             "fit_font_size_max": getattr(ff, "fit_font_size_max", 0.0) if ff else 0.0,
             "fill_rgb": getattr(ff, "frgb", [0, 0, 0]) if ff else [0, 0, 0],
@@ -108,16 +123,19 @@ def build_layered_psd_handoff(project, page_name: str, out_dir: str, final_image
             "writing_mode": getattr(ff, "writing_mode", "auto") if ff else "auto",
             "resolved_writing_mode": resolved_mode,
             "alignment": getattr(ff, "alignment", 0) if ff else 0,
-            "line_spacing": getattr(ff, "line_spacing", 1.2) if ff else 1.2,
-            "letter_spacing": getattr(ff, "letter_spacing", 1.0) if ff else 1.0,
+            "line_spacing": line_spacing,
+            "letter_spacing": letter_spacing,
             "opacity": getattr(ff, "opacity", 1.0) if ff else 1.0,
             "fit_mode": getattr(ff, "fit_mode", "shrink") if ff else "shrink",
-            "line_break_strategy": getattr(ff, "line_break_strategy", "auto") if ff else "auto",
+            "line_break_strategy": line_break_strategy,
             "text_padding": getattr(ff, "text_padding", 0.0) if ff else 0.0,
             "fallback_font_chain": getattr(ff, "fallback_font_chain", "") if ff else "",
             "lettering_quality_score": diagnostics.get("quality_score", 1.0) if isinstance(diagnostics, dict) else 1.0,
             "safe_inner_bounds": diagnostics.get("safe_inner_bounds", []) if isinstance(diagnostics, dict) else [],
             "proof_metrics": proof_metrics,
+            "fallback_runs": fallback_runs,
+            "font_runs": font_runs,
+            "vertical_layout_plan": vertical_plan,
             "psd_editability_warning": "Native PSD text writing is not available; use the JSX/manifest to recreate editable text layers in Photoshop/GIMP.",
             "rendering_diagnostics": diagnostics,
         })

--- a/utils/lettering_proof_export.py
+++ b/utils/lettering_proof_export.py
@@ -5,6 +5,7 @@ import json
 import os
 import os.path as osp
 import shutil
+import zipfile
 from datetime import datetime, timezone
 from typing import Dict, Optional
 
@@ -54,7 +55,7 @@ def _write_html_index(path: str, manifest: Dict, report: Dict, page_dir: str) ->
 <style>body{{font-family:system-ui,sans-serif;margin:24px;line-height:1.45}}table{{border-collapse:collapse;width:100%}}td,th{{border:1px solid #ccc;padding:6px;vertical-align:top}}code{{background:#f5f5f5;padding:1px 4px}}</style></head>
 <body><h1>Lettering proof: {html.escape(str(manifest.get('page', '')))}</h1>
 <p>Next actions: <code>{html.escape(', '.join(manifest.get('next_actions', []) or []) or 'none')}</code></p>
-<h2>Files</h2><ul>{link('Typography QA JSON', 'typography_qa_json')}{link('Typography QA Markdown', 'typography_qa_markdown')}{link('Editable SVG handoff', 'svg_path')}{link('PSD helper manifest', 'psd_handoff_manifest')}{link('Final composite', 'final_composite')}</ul>
+<h2>Files</h2><ul>{link('Typography QA JSON', 'typography_qa_json')}{link('Typography QA Markdown', 'typography_qa_markdown')}{link('Editable SVG handoff', 'svg_path')}{link('PSD helper manifest', 'psd_handoff_manifest')}{link('Final composite', 'final_composite')}{link('Portable ZIP archive', 'archive_path')}</ul>
 <h2>Warnings</h2><ul>{''.join('<li>'+html.escape(str(w))+'</li>' for w in (manifest.get('warnings', []) or ['none']))}</ul>
 <h2>Text blocks</h2><table><thead><tr><th>#</th><th>Mode</th><th>Warnings</th><th>Suggestions</th><th>Density</th><th>Overflow px</th></tr></thead><tbody>{''.join(blocks) or '<tr><td colspan="6">No text blocks</td></tr>'}</tbody></table>
 </body></html>"""
@@ -105,7 +106,7 @@ def build_lettering_proof_pack(project, page_name: str, out_dir: str, final_imag
     with open(qa_md_path, "w", encoding="utf-8") as f:
         f.write(rendering_qa_to_markdown(report))
 
-    svg_manifest = build_svg_text_handoff(project, page_name, osp.join(page_dir, "svg"), final_image_path=final_ref or None)
+    svg_manifest = build_svg_text_handoff(project, page_name, osp.join(page_dir, "svg"), final_image_path=final_ref or None, config_obj=config_obj)
     try:
         psd_manifest = build_layered_psd_handoff(project, page_name, osp.join(page_dir, "psd_handoff"), final_image=final_image)
     except Exception as exc:
@@ -136,4 +137,22 @@ def build_lettering_proof_pack(project, page_name: str, out_dir: str, final_imag
     with open(manifest_path, "w", encoding="utf-8") as f:
         json.dump(manifest, f, ensure_ascii=False, indent=2)
     manifest["manifest_path"] = manifest_path
+
+    archive_path = osp.join(out_dir, base + "_lettering_proof.zip")
+    try:
+        with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for root, _dirs, files in os.walk(page_dir):
+                for filename in files:
+                    path = osp.join(root, filename)
+                    zf.write(path, osp.relpath(path, page_dir))
+        manifest["archive_path"] = archive_path
+        # Re-write manifest and HTML now that the portable archive link exists.
+        _write_html_index(html_index_path, manifest, report, page_dir)
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
+    except Exception as exc:
+        warnings.append(f"Could not create portable ZIP archive: {exc}")
+        manifest["warnings"] = warnings
+        with open(manifest_path, "w", encoding="utf-8") as f:
+            json.dump(manifest, f, ensure_ascii=False, indent=2)
     return manifest

--- a/utils/svg_text_export.py
+++ b/utils/svg_text_export.py
@@ -8,7 +8,10 @@ from datetime import datetime, timezone
 from typing import Dict, Optional, Sequence, Tuple
 
 from .rendering_qa import analyze_text_block
-from .text_rendering import resolve_writing_mode, vertical_columns, lettering_proof_metrics
+from .text_rendering import (
+    resolve_writing_mode, lettering_proof_metrics,
+    vertical_layout_plan, normalize_vertical_punctuation, font_fallback_runs, merge_font_fallback_chain,
+)
 
 
 def _page_size(project, page_name: str) -> Tuple[int, int]:
@@ -40,24 +43,144 @@ def _block_text(blk) -> str:
     return str(getattr(blk, "translation", "") or getattr(blk, "rich_text", "") or "\n".join(getattr(blk, "text", []) or []) or "")
 
 
-def _text_svg_lines(text: str, mode: str, x1: float, y1: float, width: float, height: float, font_size: float, line_spacing: float) -> str:
+def _font_run_entries(text: str, primary_family: str, config_obj=None, override_chain: str = "") -> list:
+    entries = []
+    for start, end, family in font_fallback_runs(text or "", primary_family or "", config_obj, override_chain):
+        if end > start:
+            entries.append({"start": start, "end": end, "family": family, "text": (text or "")[start:end]})
+    return entries
+
+
+def _all_font_runs(text: str, primary_family: str, config_obj=None, override_chain: str = "") -> list:
+    text = text or ""
+    fallback = _font_run_entries(text, primary_family, config_obj, override_chain)
+    if not text:
+        return []
+    families = merge_font_fallback_chain(primary_family or "", text, config_obj, override_chain)
+    primary = families[0] if families else (primary_family or "")
+    breakpoints = {0, len(text)}
+    for run in fallback:
+        breakpoints.add(int(run["start"]))
+        breakpoints.add(int(run["end"]))
+    ordered = sorted(breakpoints)
+    out = []
+    for start, end in zip(ordered, ordered[1:]):
+        if end <= start:
+            continue
+        family = primary
+        for run in fallback:
+            if int(run["start"]) <= start and end <= int(run["end"]):
+                family = str(run.get("family") or primary)
+                break
+        out.append({"start": start, "end": end, "family": family, "text": text[start:end], "fallback": family != primary})
+    return out
+
+
+def _text_svg_lines(
+    text: str,
+    mode: str,
+    x1: float,
+    y1: float,
+    width: float,
+    height: float,
+    font_size: float,
+    line_spacing: float,
+    letter_spacing: float = 1.0,
+    line_break_strategy: str = "auto",
+    primary_family: str = "",
+    fallback_chain: str = "",
+    config_obj=None,
+) -> tuple[str, dict]:
+    """Return editable SVG text tspans plus handoff metadata.
+
+    Vertical CJK is emitted as positioned glyph tspans from the same renderer-neutral
+    vertical layout plan used by QA.  That preserves top-to-bottom/right-to-left
+    column order, punctuation offsets, rotation hints, tate-chu-yoko groups, and
+    per-glyph fallback font choices instead of relying on one browser-dependent
+    vertical text string.
+    """
     escaped_lines = []
+    text = text or ""
+    primary_family = primary_family or ""
+    fallback_entries = _font_run_entries(text, primary_family, config_obj, fallback_chain)
+    meta = {"fallback_runs": fallback_entries, "font_runs": _all_font_runs(text, primary_family, config_obj, fallback_chain)}
     if mode == "vertical_rl":
-        max_chars = max(1, int(max(1.0, height) / max(1.0, font_size)))
-        cols = vertical_columns(text, max_chars)
-        col_advance = font_size * max(0.1, line_spacing)
-        for col_idx, col in enumerate(cols):
-            x = x1 + width - (col_idx + 0.5) * col_advance
-            y = y1 + font_size
-            escaped_lines.append(f'<tspan x="{x:.2f}" y="{y:.2f}">{html.escape(col)}</tspan>')
+        normalized = normalize_vertical_punctuation(text)
+        max_chars = max(1, int(max(1.0, height) / max(1.0, font_size * max(0.1, letter_spacing))))
+        plan = vertical_layout_plan(
+            normalized,
+            max_chars,
+            font_size=font_size,
+            line_spacing=line_spacing,
+            letter_spacing=letter_spacing,
+            strategy=line_break_strategy,
+        )
+        meta["vertical_layout_plan"] = plan
+        glyphs = list(plan.get("glyphs", []) or [])
+        groups = list(plan.get("tate_chu_yoko_groups", []) or [])
+        group_by_start = {int(g.get("start", -1)): (i, g) for i, g in enumerate(groups)}
+        group_ranges = []
+        for i, g in enumerate(groups):
+            group_ranges.append((i, int(g.get("start", -1)), int(g.get("end", -1))))
+        col_adv = float(plan.get("column_advance", font_size * max(0.1, line_spacing)) or font_size)
+        for glyph in glyphs:
+            logical_index = int(glyph.get("index", -1))
+            # Render compact tate-chu-yoko groups once at their first glyph.
+            in_consumed_group = False
+            for group_idx, start, end in group_ranges:
+                if start < logical_index < end:
+                    in_consumed_group = True
+                    break
+            if in_consumed_group:
+                continue
+            group_info = group_by_start.get(logical_index)
+            ch = str(glyph.get("char", "") or "")
+            text_to_draw = ch
+            tcy_attr = ""
+            if group_info is not None:
+                group_idx, group = group_info
+                text_to_draw = str(group.get("text", "") or ch)
+                tcy_attr = ' data-tate-chu-yoko="true" textLength="{:.2f}" lengthAdjust="spacingAndGlyphs"'.format(font_size * 0.92)
+            dx = float((glyph.get("offset", {}) or {}).get("dx", 0.0) or 0.0)
+            dy = float((glyph.get("offset", {}) or {}).get("dy", 0.0) or 0.0)
+            gx = x1 + width - (0.5 * col_adv) + float(glyph.get("x", 0.0) or 0.0) + dx
+            gy = y1 + font_size + float(glyph.get("y", 0.0) or 0.0) + dy
+            family = primary_family
+            for run in meta.get("font_runs", []) or []:
+                if int(run.get("start", -1)) <= logical_index < int(run.get("end", -1)):
+                    family = str(run.get("family", "") or primary_family)
+                    break
+            rotate = float(glyph.get("rotate_degrees", 0.0) or (90.0 if glyph.get("rotate") else 0.0) or 0.0)
+            transform = f' transform="rotate({rotate:.1f} {gx:.2f} {gy:.2f})"' if rotate else ""
+            escaped_lines.append(
+                f'<tspan x="{gx:.2f}" y="{gy:.2f}" font-family="{html.escape(str(family or primary_family))}" '
+                f'data-column="{int(glyph.get("column", 0))}" data-row="{int(glyph.get("row", 0))}" '
+                f'data-punctuation="{html.escape(str(glyph.get("punctuation_class", "")))}"{tcy_attr}{transform}>{html.escape(text_to_draw)}</tspan>'
+            )
     else:
-        lines = (text or "").splitlines() or [text or ""]
+        cursor_index = 0
+        lines = text.splitlines() or [text]
+        runs = meta.get("font_runs") or []
         for idx, line in enumerate(lines):
-            escaped_lines.append(f'<tspan x="{x1:.2f}" y="{(y1 + font_size + idx * font_size * max(0.1, line_spacing)):.2f}">{html.escape(line)}</tspan>')
-    return "\n".join(escaped_lines)
+            line_start = cursor_index
+            line_end = line_start + len(line)
+            y = y1 + font_size + idx * font_size * max(0.1, line_spacing)
+            line_runs = [r for r in runs if int(r.get("end", 0)) > line_start and int(r.get("start", 0)) < line_end]
+            if not line_runs:
+                escaped_lines.append(f'<tspan x="{x1:.2f}" y="{y:.2f}">{html.escape(line)}</tspan>')
+            else:
+                escaped_lines.append(f'<tspan x="{x1:.2f}" y="{y:.2f}">')
+                for run in line_runs:
+                    start = max(line_start, int(run.get("start", 0)))
+                    end = min(line_end, int(run.get("end", 0)))
+                    part = text[start:end]
+                    escaped_lines.append(f'<tspan font-family="{html.escape(str(run.get("family", primary_family) or primary_family))}">{html.escape(part)}</tspan>')
+                escaped_lines.append('</tspan>')
+            cursor_index = line_end + 1
+    return "\n".join(escaped_lines), meta
 
 
-def build_svg_text_handoff(project, page_name: str, out_dir: str, final_image_path: Optional[str] = None) -> Dict:
+def build_svg_text_handoff(project, page_name: str, out_dir: str, final_image_path: Optional[str] = None, config_obj=None) -> Dict:
     """Write an SVG handoff with editable translated text and a JSON manifest.
 
     This is not a native PSD replacement; it is an interop handoff for vector
@@ -119,10 +242,12 @@ def build_svg_text_handoff(project, page_name: str, out_dir: str, final_image_pa
             back_attrs.insert(0, f'id="text_{idx + 1:03d}_back_outline"')
             back_attrs.extend([f'fill="none"', f'stroke="{secondary_stroke}"', f'stroke-width="{secondary_stroke_width:.2f}"'])
             svg.append('    <text ' + " ".join(back_attrs) + '>')
-            svg.append(_text_svg_lines(text, mode, x1, y1, width, height, font_size, line_spacing))
+            back_markup, _back_meta = _text_svg_lines(text, mode, x1, y1, width, height, font_size, line_spacing, float(getattr(fmt, "letter_spacing", 1.0) if fmt else 1.0 or 1.0), getattr(fmt, "line_break_strategy", "auto") if fmt else "auto", getattr(fmt, "font_family", "") if fmt else "", getattr(fmt, "fallback_font_chain", "") if fmt else "", config_obj)
+            svg.append(back_markup)
             svg.append('    </text>')
         svg.append('    <text ' + " ".join(attrs) + '>')
-        svg.append(_text_svg_lines(text, mode, x1, y1, width, height, font_size, line_spacing))
+        text_markup, svg_text_meta = _text_svg_lines(text, mode, x1, y1, width, height, font_size, line_spacing, float(getattr(fmt, "letter_spacing", 1.0) if fmt else 1.0 or 1.0), getattr(fmt, "line_break_strategy", "auto") if fmt else "auto", getattr(fmt, "font_family", "") if fmt else "", getattr(fmt, "fallback_font_chain", "") if fmt else "", config_obj)
+        svg.append(text_markup)
         svg.append('    </text>')
         try:
             diagnostics = analyze_text_block(blk, page_name, idx, config_obj=object())
@@ -149,6 +274,9 @@ def build_svg_text_handoff(project, page_name: str, out_dir: str, final_image_pa
             "secondary_stroke_width": secondary_stroke_width,
             "diagnostics": diagnostics,
             "proof_metrics": proof_metrics,
+            "fallback_runs": svg_text_meta.get("fallback_runs", []),
+            "font_runs": svg_text_meta.get("font_runs", []),
+            "vertical_layout_plan": svg_text_meta.get("vertical_layout_plan", {}),
         })
         warnings.extend([f"Block {idx}: {w}" for w in diagnostics.get("warnings", [])])
     svg.append('  </g>')


### PR DESCRIPTION
### Motivation

- Provide a unified, robust GPU/runtime selection and install flow for Windows (NVIDIA CUDA, AMD ROCm preview, AMD DirectML, or CPU) and surface that plan to users and diagnostics.  
- Improve editable export fidelity by carrying renderer-neutral vertical layout, punctuation/tate-chu-yoko info, and font-run metadata into SVG/PSD handoff artifacts.  
- Make lettering proof delivery easier by producing a single portable ZIP per-page alongside existing proof folders.  

### Description

- Add a centralized GPU/runtime helper `utils/gpu_runtime.py` with `build_gpu_install_plan`, normalize/profile aliases, physical GPU detection (`detect_physical_gpus`, `has_amd_gpu`, `has_nvidia_gpu`, `classify_amd_gpu`), and formatted plan output; integrate it into `launch.py` to support `--gpu-profile` and `--gpu-report` and to drive conditional PyTorch install logic.  
- Introduce a unified Windows launcher menu `launcher.bat` and update compatibility wrappers (`launch_win.bat`, `launch_win_amd_nightly.bat`, `launch_win_with_autoupdate.bat`, `setup.bat`) plus a short entrypoint change to surface GPU profile hints.  
- Improve SVG/PSD handoff exports: `utils/svg_text_export.py` now emits editable vertical text as positioned `<tspan>` glyphs from `vertical_layout_plan()` and includes `data-tate-chu-yoko`, `font_runs`, and `fallback_runs`; `utils/layered_psd_export.py` now embeds `font_runs`, `fallback_runs`, and `vertical_layout_plan` in PSD helper manifests and JSX.  
- Add portable proof archive creation in `utils/lettering_proof_export.py` producing `*_lettering_proof.zip` and linking it in proof HTML/index.  
- Small UX/diagnostic touches: show GPU install plan in startup diagnostics (`ui/mainwindow.py`) and raise `transformers` minimum in `requirements.txt` to `>=4.57.6`.  
- Add unit tests for the new GPU runtime logic and export features: `tests/test_gpu_runtime.py`, `tests/test_svg_text_export.py`, `tests/test_layered_psd_export.py`, and `tests/test_lettering_proof_export.py`.  

### Testing

- Ran the unit test suite for the new/changed features with `pytest` focused on GPU plan and export handoff tests: `tests/test_gpu_runtime.py`, `tests/test_svg_text_export.py`, `tests/test_layered_psd_export.py`, and `tests/test_lettering_proof_export.py`, and all tests passed.  
- Verified launcher behavior by exercising `launch.py --gpu-report` and starting via `launcher.bat` in local Windows-compatible runs to ensure the plan prints and the compatibility wrappers call into the unified launcher (manual execution confirmed expected output).  
- Generated sample SVG/PSD handoff and lettering proof outputs from the helper functions to confirm `vertical_layout_plan`, `font_runs`/`fallback_runs`, and portable `_lettering_proof.zip` are produced and referenced in the manifest/HTML (automated tests cover these validations).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0a30f209a0832c81d81ca235c77a41)