### PR TITLE
Add auto-layout profiles, UI controls, and Latin-aware balanced wrapping with safety polish

### DIFF
--- a/doc/AUTOMATIC_TEXT_FORMATTING.md
+++ b/doc/AUTOMATIC_TEXT_FORMATTING.md
@@ -23,3 +23,37 @@ The most useful settings are in **Config Panel → Lettering**:
 - **Balloon shape (Diamond-Text)**: leave this on **Auto** for automatic shape-specific margins and line scoring.
 
 Existing projects remain compatible. Older projects that do not have the new final safety or mask-safe-area settings behave as if they are enabled.
+
+## One-click bubble lettering polish
+
+The **Format → Smart auto fit lettering** and **Format → Atomic bubble fit** actions now run a fuller safety pipeline instead of only changing the font size:
+
+1. preserve spaces in Latin translations while balancing line lengths, so automatic rewrapping no longer glues words together;
+2. choose script-aware line-breaking and writing mode before sizing;
+3. apply the chosen font size/spacing to the selected text box;
+4. grow the box modestly from renderer diagnostics if text still cannot fit at the allowed minimum size;
+5. run a final rendered-size safety pass and, when a bubble mask is available, recenter the text box in its bubble.
+
+This keeps everyday editing focused on one or two high-level actions instead of repeatedly tuning size, line spacing, padding, and position by hand. Existing manual controls remain available for special lettering or SFX cases.
+
+## Simplified auto-layout profiles
+
+The many legacy auto-layout knobs are now grouped behind the **Auto lettering preset** selector:
+
+- **Balanced (recommended)**: model-free contour/aspect-ratio bubble detection, mask-safe inner areas, centered bubbles, optimal line breaks, binary font fitting, and final overflow safety. This is the default for most manga/manhua pages.
+- **Fit inside bubble**: stricter height/short-line penalties, a lower minimum font size, compact widths, and strong one-word-line avoidance for crowded bubbles where staying inside the balloon matters most.
+- **Larger readable text**: higher minimum/maximum font size, fewer-line optimization, and roomier widths while still keeping final overflow checks and bubble centering enabled.
+
+Changing the preset applies recommended values to the advanced controls below it. The **Reset advanced values to selected preset** button can also normalize older projects that already saved confusing manual values. Optional model fields are blank by default; geometry and mask checks are used unless you explicitly enter a model ID.
+
+## Reading the advanced numbers
+
+Advanced numeric controls now show a live **What the advanced values mean** summary in Settings. Instead of requiring you to memorize scales such as `80`, `360`, or `2000`, the panel translates them into plain-language behavior:
+
+- short-line and one-word penalties are labeled loose/balanced/strict/maximum;
+- height overflow is labeled roomy, balanced, strict fit, or very strict fit;
+- line-width controls are labeled compact, balanced, roomy, or wide;
+- font-size min/max is summarized as a readable point-size range;
+- model fields say whether layout is using geometry only, built-in CLIP, a custom model, or model-assisted shape detection.
+
+If the settings feel confusing, use **Restore balanced automatic defaults**. It resets only the advanced auto-layout values and leaves unrelated text style, font, color, and rendering defaults alone.

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -18,19 +18,21 @@ The everyday lettering controls are grouped by ownership:
 - **Selection defaults / reset**: **Use project text defaults** applies Settings → Project text rendering defaults for writing mode, fit mode, line breaks, padding, and clears fallback overrides. It does not change font family, size, colors, or stroke.
 - **Live lettering diagnostics**: the panel estimates resolved writing mode, fit size, overflow/fallback status, and a quality score for the selected textbox so likely final-lettering issues are visible before exporting.
 
-Right-click selected text boxes and use **Format → Writing mode** or **Format → Recenter text in box** for quick lettering fixes.
+Right-click selected text boxes and use **Format → Smart auto fit lettering** for the recommended one-click pass: it balances preserved-space Latin lines, resolves script/writing mode, applies fit sizing, grows the text box if diagnostics still predict clipping, runs a rendered overflow safety pass, and recenters in the detected bubble when a mask is available. **Format → Atomic bubble fit** is stricter for making a phrase behave like one visual block inside a bubble. **Format → Writing mode** and **Format → Recenter text in box** remain available for narrow manual fixes.
 
 ## Renderer diagnostics
 
 Config → General → **Rendering / Text Formatting** includes:
 
+- an **Auto lettering preset** that synchronizes constrain-to-bubble, center-in-bubble, overflow, optimal-break, font-size, binary-fit, and balloon-shape defaults so most users do not need to tune the individual numeric controls;
+- a live **What the advanced values mean** readout that translates numeric penalties, widths, font ranges, skip distances, and model fields into plain-language labels such as balanced, strict fit, roomy, geometry only, or model-assisted;
 - default writing and fit modes,
 - default render font and manga effect defaults,
 - per-script fallback font chains for Latin, CJK, Korean, Arabic/Hebrew, and emoji/symbols,
 - overflow warnings,
 - an optional diagnostics overlay.
 
-The diagnostics overlay draws the text box, estimated rendered bounds, overflow status, writing mode, and missing-glyph warnings directly on the canvas. It is intended for QA and should be disabled for normal export.
+The diagnostics overlay draws the text box, estimated rendered bounds, overflow status, writing mode, and missing-glyph warnings directly on the canvas. Optional box-size and shape model IDs are now opt-in; leaving them blank uses faster geometry/mask detection, which is the recommended default. It is intended for QA and should be disabled for normal export.
 
 ## Layout review integration
 

--- a/tests/test_text_layout_auto_formatting.py
+++ b/tests/test_text_layout_auto_formatting.py
@@ -3,6 +3,11 @@ import numpy as np
 from utils.auto_text_layout import (
     auto_layout_effective_preset,
     auto_layout_preset_settings,
+    auto_layout_profile_defaults,
+    apply_auto_layout_profile,
+    auto_layout_profile_summary,
+    auto_layout_setting_hints,
+    auto_layout_advanced_summary,
     auto_rendered_fit_scale,
     candidate_layout_widths,
     estimate_target_line_count,
@@ -59,6 +64,85 @@ def test_text_layout_module_imports_without_image_runtime_side_effects():
     import utils.text_layout as text_layout
 
     assert hasattr(text_layout, "layout_text")
+
+
+def test_auto_layout_profile_defaults_cover_advanced_knobs():
+    balanced = auto_layout_profile_defaults("balanced")
+    fit = auto_layout_profile_defaults("fit")
+    readable = auto_layout_profile_defaults("readable")
+
+    expected = {
+        "layout_constrain_to_bubble",
+        "layout_center_in_bubble_after_autolayout",
+        "layout_center_in_bubble_min_gap_px",
+        "layout_check_overflow_after_layout",
+        "layout_use_mask_safe_area",
+        "layout_box_size_check_model_id",
+        "layout_optimal_breaks",
+        "layout_hyphenation",
+        "optimize_line_breaks",
+        "layout_short_line_penalty",
+        "layout_height_overflow_penalty",
+        "layout_font_size_min",
+        "layout_font_size_max",
+        "layout_font_fit_bubble",
+        "layout_font_binary_search",
+        "layout_auto_final_fit_pass",
+        "layout_balloon_shape",
+        "layout_balloon_shape_auto_method",
+        "layout_balloon_shape_model_id",
+        "layout_min_line_width_px",
+        "layout_max_line_width_frac_no_bubble",
+        "layout_stub_penalty_1word",
+    }
+    assert expected <= set(balanced)
+    assert balanced["layout_balloon_shape_auto_method"] == "contour_ratio"
+    assert balanced["layout_balloon_shape_model_id"] == ""
+    assert fit["layout_height_overflow_penalty"] > balanced["layout_height_overflow_penalty"]
+    assert readable["layout_font_size_min"] > balanced["layout_font_size_min"]
+    assert "Balanced" in auto_layout_profile_summary("balanced")
+
+
+def test_apply_auto_layout_profile_updates_config_like_object():
+    class Cfg:
+        layout_auto_preset = "balanced"
+        layout_font_size_min = 1.0
+        layout_balloon_shape_model_id = "old/model"
+
+    cfg = Cfg()
+    applied = apply_auto_layout_profile(cfg, "fit inside")
+    assert cfg.layout_auto_preset == "fit"
+    assert cfg.layout_font_size_min == applied["layout_font_size_min"] == 6.0
+    assert cfg.layout_balloon_shape_model_id == ""
+    assert cfg.layout_constrain_to_bubble is True
+
+
+def test_auto_layout_setting_hints_explain_numeric_values():
+    hints = auto_layout_setting_hints({
+        "layout_font_size_min": 6,
+        "layout_font_size_max": 64,
+        "layout_short_line_penalty": 130,
+        "layout_height_overflow_penalty": 950,
+        "layout_stub_penalty_1word": 2700,
+        "layout_min_line_width_px": 70,
+        "layout_max_line_width_frac_no_bubble": 0.9,
+        "layout_center_in_bubble_min_gap_px": 0,
+        "layout_box_size_check_model_id": "builtin",
+        "layout_balloon_shape_auto_method": "model_contour",
+        "layout_balloon_shape_model_id": "shape/model",
+    })
+
+    assert hints["font_range"].startswith("6–64 pt")
+    assert hints["short_line_penalty"] == "strict"
+    assert hints["height_overflow_penalty"] == "strict fit"
+    assert hints["stub_penalty"] == "maximum"
+    assert hints["center_gap"] == "never skip centering"
+    assert hints["box_model"] == "built-in CLIP"
+    assert hints["shape_detection"] == "model-assisted"
+    assert "Font 6–64 pt" in auto_layout_advanced_summary({
+        "layout_font_size_min": 6,
+        "layout_font_size_max": 64,
+    })
 
 
 def test_auto_layout_presets_normalize_and_shift_behavior():

--- a/tests/test_text_rendering.py
+++ b/tests/test_text_rendering.py
@@ -15,6 +15,9 @@ from utils.text_rendering import (
     normalize_line_break_strategy,
     normalize_vertical_punctuation,
     optimal_kinsoku_wrap,
+    optimal_latin_wrap,
+    balance_lines,
+    smart_fit_text_to_box,
     resolve_writing_mode,
     vertical_columns,
     vertical_layout_plan,
@@ -28,6 +31,34 @@ from utils.text_rendering import (
     vertical_bracket_pair_hints,
     vertical_punctuation_adjustment,
 )
+
+
+def test_balanced_latin_wrap_preserves_spaces_and_reduces_widows():
+    text = "This translated sentence should keep spaces while forming even comic lettering lines"
+    lines = optimal_latin_wrap(text, 18)
+    assert " ".join(lines).replace("‐ ", "") == text
+    assert all("  " not in line for line in lines)
+    assert len(lines) >= 3
+    assert len(lines[-1]) > 6
+
+
+def test_balance_lines_latin_does_not_concatenate_words():
+    balanced = balance_lines("Hello world from a narrow bubble", 12)
+    assert "Hello world" in balanced or "world from" in balanced
+    assert "Helloworld" not in balanced
+
+
+def test_smart_fit_applies_balanced_latin_text_without_losing_spaces():
+    result = smart_fit_text_to_box(
+        "A very long translated line should become readable inside this bubble",
+        28,
+        (140, 72),
+        fit_mode="balance",
+        line_break_strategy="balanced",
+    )
+    assert "A very" in result.text or "very long" in result.text
+    assert "Avery" not in result.text
+    assert not result.overflow
 
 
 def test_resolve_writing_mode_auto_cjk_tall_box_vertical():

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -13,7 +13,7 @@ from .context_menu_config_dialog import ContextMenuConfigDialog
 from utils.config import pcfg
 from utils.data_path_manager import resolve_data_path, free_space_gb, ensure_data_path
 from utils.text_rendering import ATOMIC_FIT_BALANCED, ATOMIC_FIT_COMFORTABLE, ATOMIC_FIT_DENSE, ATOMIC_FIT_CAPTION, ATOMIC_FIT_SFX, normalize_atomic_fit_mode
-from utils.auto_text_layout import normalize_auto_layout_preset
+from utils.auto_text_layout import apply_auto_layout_profile, auto_layout_advanced_summary, auto_layout_profile_summary, auto_layout_setting_hints, normalize_auto_layout_preset
 from utils import shared as C
 from utils.shared import CONFIG_FONTSIZE_CONTENT, CONFIG_FONTSIZE_HEADER, CONFIG_FONTSIZE_TABLE, CONFIG_COMBOBOX_SHORT, CONFIG_COMBOBOX_LONG, CONFIG_COMBOBOX_MIDEAN, DISPLAY_LANGUAGE_MAP
 from .glossary_map_dialog import GlossaryMapDialog
@@ -1263,6 +1263,20 @@ class ConfigPanel(Widget):
             discription=self.tr('One control for automatic lettering behavior. Balanced is the default; Fit inside bubble uses stricter margins and smaller text; Larger readable text allows wider lines and larger font when safe.')
         )
         self.layout_auto_preset_combo.activated.connect(self._on_layout_auto_preset_changed)
+        self.layout_profile_summary_label = QLabel(self)
+        self.layout_profile_summary_label.setWordWrap(True)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.layout_profile_summary_label,
+            self.tr('Selected preset summary'),
+            discription=self.tr('Shows what the high-level automatic lettering preset controls. Advanced values below can still be edited after applying a preset.')
+        ))
+        self.layout_apply_profile_btn = QPushButton(self.tr('✨ Reset advanced values to selected preset'))
+        self.layout_apply_profile_btn.clicked.connect(self._on_apply_auto_layout_profile_clicked)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.layout_apply_profile_btn,
+            self.tr('Apply auto-layout preset'),
+            discription=self.tr('Synchronizes constrain/center/overflow/line-break/font-size/shape settings below to the selected preset. Use this when old projects have confusing manual values.')
+        ))
 
         self.layout_constrain_to_bubble_checker, layout_sublock = generalConfigPanel.addCheckBox(
             self.tr('Constrain text box to bubble'),
@@ -1298,12 +1312,12 @@ class ConfigPanel(Widget):
         )
         self.layout_use_mask_safe_area_checker.stateChanged.connect(self._on_layout_use_mask_safe_area_changed)
         self.layout_box_size_check_model_id_edit = QLineEdit()
-        self.layout_box_size_check_model_id_edit.setPlaceholderText(self.tr('Use "builtin" for zero-shot CLIP, or a Hugging Face model ID. Leave empty to skip.'))
+        self.layout_box_size_check_model_id_edit.setPlaceholderText(self.tr('Leave empty for fast geometry. Optional: "builtin" for CLIP or a Hugging Face model ID.'))
         self.layout_box_size_check_model_id_edit.textChanged.connect(self._on_layout_box_size_check_model_id_changed)
         generalConfigPanel.addSublock(ConfigSubBlock(
             self.layout_box_size_check_model_id_edit,
-            self.tr('Box size check model ID (secondary)'),
-            discription=self.tr('Built-in: use "builtin" (zero-shot CLIP). Custom: image-classification model with labels too_large, too_small, ok. Empty = geometric checks only.')
+            self.tr('Optional box size model ID'),
+            discription=self.tr('Recommended: leave empty. Geometry and mask-safe checks handle most pages. Use "builtin" or a custom too_large/too_small/ok classifier only if geometric checks miss your scans.')
         ))
 
         self.layout_optimal_breaks_checker, _ = generalConfigPanel.addCheckBox(
@@ -1411,16 +1425,16 @@ class ConfigPanel(Widget):
                 self.tr('Model, then contour, then aspect ratio'),
             ],
             self.tr('Auto shape method'),
-            discription=self.tr('When balloon shape is Auto, which method(s) to use. Contour = mask-based (OpenCV). Model = HF image-classification (set model ID below).')
+            discription=self.tr('When balloon shape is Auto, choose model-free contour/aspect-ratio detection by default. Model options require the optional model ID below.')
         )
         self.layout_balloon_shape_auto_method_combo.activated.connect(self._on_layout_balloon_shape_auto_method_changed)
         self.layout_balloon_shape_model_id_edit = QLineEdit()
-        self.layout_balloon_shape_model_id_edit.setPlaceholderText(self.tr('Default: prithivMLmods/Geometric-Shapes-Classification (92.9M). Lighter: 0-ma/vit-geometric-shapes-tiny'))
+        self.layout_balloon_shape_model_id_edit.setPlaceholderText(self.tr('Optional. Leave empty for contour/aspect-ratio detection.'))
         self.layout_balloon_shape_model_id_edit.textChanged.connect(self._on_layout_balloon_shape_model_id_changed)
         generalConfigPanel.addSublock(ConfigSubBlock(
             self.layout_balloon_shape_model_id_edit,
-            self.tr('Balloon shape model ID'),
-            discription=self.tr('Default is prithivMLmods/Geometric-Shapes-Classification (SigLIP2-base, 92.9M params, 8 shapes, ~99% accuracy). Use 0-ma/vit-geometric-shapes-tiny for a lighter 5.5M model. Wide bubbles are forced to oval when the model says square.')
+            self.tr('Optional balloon shape model ID'),
+            discription=self.tr('Recommended: leave empty. If you choose a model-based auto shape method, set a Hugging Face image-classification model here. Example heavy model: prithivMLmods/Geometric-Shapes-Classification; lighter: 0-ma/vit-geometric-shapes-tiny.')
         ))
         # Minimum line width so short text (e.g. "pluck!") is not broken into 2–3 char lines
         self.layout_min_line_width_spin = QSpinBox()
@@ -1457,6 +1471,23 @@ class ConfigPanel(Widget):
             self.tr('1-word line penalty'),
             discription=self.tr('Penalty for a single word on its own line in layout scoring (higher = strongly avoid e.g. "the" alone).')
         ))
+
+        self.layout_advanced_interpretation_label = QLabel(self)
+        self.layout_advanced_interpretation_label.setWordWrap(True)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.layout_advanced_interpretation_label,
+            self.tr('What the advanced values mean'),
+            discription=self.tr('Plain-language interpretation of the numeric auto-layout controls above. Use this to understand whether the current values are strict, balanced, or roomy.')
+        ))
+        self.layout_advanced_interpretation_label.setStyleSheet('color: gray;')
+        self.layout_reset_balanced_btn = QPushButton(self.tr('↩ Restore balanced automatic defaults'))
+        self.layout_reset_balanced_btn.clicked.connect(lambda: self._apply_auto_layout_profile_to_config('balanced', save=True))
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.layout_reset_balanced_btn,
+            self.tr('Safe reset for confusing values'),
+            discription=self.tr('Returns every advanced auto-layout value to the recommended Balanced defaults without changing unrelated rendering/font settings.')
+        ))
+
         self.layout_panel_preserve_line_breaks_checker, _ = generalConfigPanel.addCheckBox(
             self.tr('Translation panel: preserve line breaks'),
             discription=self.tr('When on, the translation panel does not wrap by width so line breaks match the canvas bubble (rendering parity).')
@@ -1794,9 +1825,104 @@ class ConfigPanel(Widget):
     def on_autolayout_changed(self):
         pcfg.let_autolayout_flag = self.let_autolayout_checker.isChecked()
 
+
+    def _sync_auto_layout_controls_from_config(self):
+        """Refresh advanced auto-layout widgets after a preset rewrites their config values."""
+        pairs = [
+            ('layout_constrain_to_bubble_checker', 'layout_constrain_to_bubble', 'checked'),
+            ('layout_center_in_bubble_after_autolayout_checker', 'layout_center_in_bubble_after_autolayout', 'checked'),
+            ('layout_check_overflow_after_layout_checker', 'layout_check_overflow_after_layout', 'checked'),
+            ('layout_use_mask_safe_area_checker', 'layout_use_mask_safe_area', 'checked'),
+            ('layout_optimal_breaks_checker', 'layout_optimal_breaks', 'checked'),
+            ('layout_hyphenation_checker', 'layout_hyphenation', 'checked'),
+            ('optimize_line_breaks_checker', 'optimize_line_breaks', 'checked'),
+            ('layout_font_fit_bubble_checker', 'layout_font_fit_bubble', 'checked'),
+            ('layout_font_binary_search_checker', 'layout_font_binary_search', 'checked'),
+            ('layout_auto_final_fit_pass_checker', 'layout_auto_final_fit_pass', 'checked'),
+            ('layout_center_in_bubble_min_gap_spin', 'layout_center_in_bubble_min_gap_px', 'value'),
+            ('layout_short_line_penalty_spin', 'layout_short_line_penalty', 'value'),
+            ('layout_height_overflow_penalty_spin', 'layout_height_overflow_penalty', 'value'),
+            ('layout_font_size_min_spin', 'layout_font_size_min', 'value'),
+            ('layout_font_size_max_spin', 'layout_font_size_max', 'value'),
+            ('layout_min_line_width_spin', 'layout_min_line_width_px', 'int_value'),
+            ('layout_max_line_width_frac_no_bubble_spin', 'layout_max_line_width_frac_no_bubble', 'value'),
+            ('layout_stub_penalty_1word_spin', 'layout_stub_penalty_1word', 'value'),
+            ('layout_box_size_check_model_id_edit', 'layout_box_size_check_model_id', 'text'),
+            ('layout_balloon_shape_model_id_edit', 'layout_balloon_shape_model_id', 'text'),
+        ]
+        for widget_name, cfg_key, kind in pairs:
+            if not hasattr(self, widget_name):
+                continue
+            widget = getattr(self, widget_name)
+            widget.blockSignals(True)
+            try:
+                val = getattr(pcfg.module, cfg_key)
+                if kind == 'checked':
+                    widget.setChecked(bool(val))
+                elif kind == 'int_value':
+                    widget.setValue(int(float(val)))
+                elif kind == 'value':
+                    widget.setValue(float(val))
+                elif kind == 'text':
+                    widget.setText(str(val or ''))
+            finally:
+                widget.blockSignals(False)
+        if hasattr(self, 'layout_balloon_shape_combo'):
+            shape = (getattr(pcfg.module, 'layout_balloon_shape', 'auto') or 'auto').lower()
+            idx = {"auto": 0, "round": 1, "elongated": 2, "narrow": 3, "diamond": 4, "square": 5, "bevel": 6, "pentagon": 7, "point": 8}.get(shape, 0)
+            self.layout_balloon_shape_combo.blockSignals(True)
+            self.layout_balloon_shape_combo.setCurrentIndex(idx)
+            self.layout_balloon_shape_combo.blockSignals(False)
+        if hasattr(self, 'layout_balloon_shape_auto_method_combo'):
+            method = (getattr(pcfg.module, 'layout_balloon_shape_auto_method', 'contour_ratio') or 'contour_ratio').lower()
+            idx = {"aspect_ratio": 0, "contour": 1, "model": 2, "model_contour": 3, "model_ratio": 4, "contour_ratio": 5, "model_contour_ratio": 6}.get(method, 5)
+            self.layout_balloon_shape_auto_method_combo.blockSignals(True)
+            self.layout_balloon_shape_auto_method_combo.setCurrentIndex(idx)
+            self.layout_balloon_shape_auto_method_combo.blockSignals(False)
+        self._update_auto_layout_interpretation()
+
+    def _update_auto_layout_interpretation(self):
+        if hasattr(self, 'layout_profile_summary_label'):
+            preset = normalize_auto_layout_preset(getattr(pcfg.module, 'layout_auto_preset', 'balanced'))
+            self.layout_profile_summary_label.setText(auto_layout_profile_summary(preset))
+        if hasattr(self, 'layout_advanced_interpretation_label'):
+            self.layout_advanced_interpretation_label.setText(auto_layout_advanced_summary(pcfg.module))
+        hints = auto_layout_setting_hints(pcfg.module)
+        tooltip_map = {
+            'layout_short_line_penalty_spin': 'short_line_penalty',
+            'layout_height_overflow_penalty_spin': 'height_overflow_penalty',
+            'layout_stub_penalty_1word_spin': 'stub_penalty',
+            'layout_min_line_width_spin': 'minimum_line_width',
+            'layout_max_line_width_frac_no_bubble_spin': 'no_bubble_width',
+            'layout_font_size_min_spin': 'font_range',
+            'layout_font_size_max_spin': 'font_range',
+            'layout_center_in_bubble_min_gap_spin': 'center_gap',
+            'layout_box_size_check_model_id_edit': 'box_model',
+            'layout_balloon_shape_model_id_edit': 'shape_detection',
+        }
+        for widget_name, hint_key in tooltip_map.items():
+            if hasattr(self, widget_name):
+                widget = getattr(self, widget_name)
+                base = widget.property('base_tooltip')
+                if base is None:
+                    base = widget.toolTip() or ''
+                    widget.setProperty('base_tooltip', base)
+                meaning = hints.get(hint_key, '')
+                widget.setToolTip(f"{base}\nCurrent meaning: {meaning}".strip())
+
+    def _apply_auto_layout_profile_to_config(self, preset: str, save: bool = True):
+        apply_auto_layout_profile(pcfg.module, preset)
+        self._sync_auto_layout_controls_from_config()
+        if save:
+            self.save_config.emit()
+
+    def _on_apply_auto_layout_profile_clicked(self):
+        preset = normalize_auto_layout_preset(getattr(pcfg.module, 'layout_auto_preset', 'balanced'))
+        self._apply_auto_layout_profile_to_config(preset, save=True)
+
     def _on_layout_auto_preset_changed(self, index: int):
-        pcfg.module.layout_auto_preset = ("balanced", "fit", "readable")[max(0, min(index, 2))]
-        self.save_config.emit()
+        preset = ("balanced", "fit", "readable")[max(0, min(index, 2))]
+        self._apply_auto_layout_profile_to_config(preset, save=True)
 
     def _on_layout_constrain_to_bubble_changed(self):
         pcfg.module.layout_constrain_to_bubble = self.layout_constrain_to_bubble_checker.isChecked()
@@ -1808,6 +1934,7 @@ class ConfigPanel(Widget):
 
     def _on_layout_center_in_bubble_min_gap_px_changed(self, value: float):
         pcfg.module.layout_center_in_bubble_min_gap_px = float(value)
+        self._update_auto_layout_interpretation()
         self.save_config.emit()
 
     def _on_layout_check_overflow_after_layout_changed(self):
@@ -1820,6 +1947,8 @@ class ConfigPanel(Widget):
 
     def _on_layout_box_size_check_model_id_changed(self, text: str):
         pcfg.module.layout_box_size_check_model_id = (text or "").strip()
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_optimal_breaks_changed(self):
         pcfg.module.layout_optimal_breaks = self.layout_optimal_breaks_checker.isChecked()
@@ -1831,49 +1960,71 @@ class ConfigPanel(Widget):
 
     def _on_optimize_line_breaks_changed(self):
         pcfg.module.optimize_line_breaks = self.optimize_line_breaks_checker.isChecked()
+        self._update_auto_layout_interpretation()
         self.save_config.emit()
 
     def _on_layout_short_line_penalty_changed(self, value: float):
         pcfg.module.layout_short_line_penalty = float(value)
+        self._update_auto_layout_interpretation()
         self.save_config.emit()
 
     def _on_layout_height_overflow_penalty_changed(self, value: float):
         pcfg.module.layout_height_overflow_penalty = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_font_size_min_changed(self, value: float):
         pcfg.module.layout_font_size_min = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_font_size_max_changed(self, value: float):
         pcfg.module.layout_font_size_max = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_font_fit_bubble_changed(self):
         pcfg.module.layout_font_fit_bubble = self.layout_font_fit_bubble_checker.isChecked()
+        self.save_config.emit()
 
     def _on_layout_font_binary_search_changed(self):
         pcfg.module.layout_font_binary_search = self.layout_font_binary_search_checker.isChecked()
+        self.save_config.emit()
 
     def _on_layout_auto_final_fit_pass_changed(self):
         pcfg.module.layout_auto_final_fit_pass = self.layout_auto_final_fit_pass_checker.isChecked()
+        self.save_config.emit()
 
     def _on_layout_balloon_shape_changed(self, index: int):
         pcfg.module.layout_balloon_shape = ("auto", "round", "elongated", "narrow", "diamond", "square", "bevel", "pentagon", "point")[index]
+        self.save_config.emit()
 
     def _on_layout_balloon_shape_auto_method_changed(self, index: int):
         pcfg.module.layout_balloon_shape_auto_method = (
             "aspect_ratio", "contour", "model", "model_contour", "model_ratio", "contour_ratio", "model_contour_ratio"
         )[index]
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_balloon_shape_model_id_changed(self, text: str):
         pcfg.module.layout_balloon_shape_model_id = (text or "").strip()
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_min_line_width_changed(self, value: int):
         pcfg.module.layout_min_line_width_px = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_max_line_width_frac_no_bubble_changed(self, value: float):
         pcfg.module.layout_max_line_width_frac_no_bubble = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_stub_penalty_1word_changed(self, value: float):
         pcfg.module.layout_stub_penalty_1word = float(value)
+        self._update_auto_layout_interpretation()
+        self.save_config.emit()
 
     def _on_layout_panel_preserve_line_breaks_changed(self):
         pcfg.module.layout_panel_preserve_line_breaks = self.layout_panel_preserve_line_breaks_checker.isChecked()
@@ -2165,6 +2316,8 @@ class ConfigPanel(Widget):
             self.layout_auto_preset_combo.blockSignals(True)
             self.layout_auto_preset_combo.setCurrentIndex(idx)
             self.layout_auto_preset_combo.blockSignals(False)
+            if hasattr(self, 'layout_profile_summary_label'):
+                self.layout_profile_summary_label.setText(auto_layout_profile_summary(preset))
         if hasattr(self, 'layout_constrain_to_bubble_checker'):
             self.layout_constrain_to_bubble_checker.setChecked(getattr(pcfg.module, 'layout_constrain_to_bubble', True))
         if hasattr(self, 'layout_center_in_bubble_after_autolayout_checker'):
@@ -2216,8 +2369,8 @@ class ConfigPanel(Widget):
             self.layout_balloon_shape_combo.setCurrentIndex(idx)
             self.layout_balloon_shape_combo.blockSignals(False)
         if hasattr(self, 'layout_balloon_shape_auto_method_combo'):
-            method = (getattr(pcfg.module, 'layout_balloon_shape_auto_method', 'model_contour') or 'model_contour').lower()
-            idx = {"aspect_ratio": 0, "contour": 1, "model": 2, "model_contour": 3, "model_ratio": 4, "contour_ratio": 5, "model_contour_ratio": 6}.get(method, 3)
+            method = (getattr(pcfg.module, 'layout_balloon_shape_auto_method', 'contour_ratio') or 'contour_ratio').lower()
+            idx = {"aspect_ratio": 0, "contour": 1, "model": 2, "model_contour": 3, "model_ratio": 4, "contour_ratio": 5, "model_contour_ratio": 6}.get(method, 5)
             self.layout_balloon_shape_auto_method_combo.blockSignals(True)
             self.layout_balloon_shape_auto_method_combo.setCurrentIndex(idx)
             self.layout_balloon_shape_auto_method_combo.blockSignals(False)

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1577,6 +1577,7 @@ class SceneTextManager(QObject):
             ('letter_spacing', result.letter_spacing),
             ('writing_mode', result.writing_mode),
             ('fit_mode', result.fit_mode),
+            ('line_break_strategy', (result.diagnostics or {}).get('line_break_strategy', getattr(ff, 'line_break_strategy', 'auto'))),
         ]:
             if hasattr(ff, attr) and getattr(ff, attr) != value:
                 setattr(ff, attr, value)
@@ -1589,8 +1590,61 @@ class SceneTextManager(QObject):
             changed = True
         if changed:
             blkitem.set_fontformat(ff)
+            fit_diag = (result.diagnostics or {}).get('fit', {})
+            changed = self._postprocess_auto_lettering_item(blkitem, fit_diag=fit_diag) or changed
             if blkitem.blk is not None:
                 blkitem.blk.fontformat = ff.deepcopy()
+        return changed
+
+    def _postprocess_auto_lettering_item(self, blkitem: TextBlkItem, fit_diag: dict = None) -> bool:
+        """Final automatic safety pass after smart/atomic formatting.
+
+        Grows a too-small box from renderer diagnostics, runs the rendered-size
+        safety loop, and recenters in the detected bubble when available.  This
+        keeps one-click formatting from leaving text clipped or visibly off-center.
+        """
+        changed = False
+        rect = blkitem.absBoundingRect(qrect=True)
+        diag = fit_diag or {}
+        rec = diag.get('recommended_box_size') or []
+        overflow = bool(diag.get('overflow'))
+        if overflow and len(rec) >= 2:
+            try:
+                new_w = max(rect.width(), float(rec[0]))
+                new_h = max(rect.height(), float(rec[1]))
+                # Avoid runaway boxes from bad diagnostics; fitting should prefer
+                # font/line changes before modest centered growth.
+                new_w = min(new_w, rect.width() * 1.65)
+                new_h = min(new_h, rect.height() * 1.65)
+                img = getattr(self.imgtrans_proj, 'img_array', None)
+                if img is not None:
+                    im_h, im_w = img.shape[:2]
+                    new_w = min(new_w, float(im_w))
+                    new_h = min(new_h, float(im_h))
+                if new_w > rect.width() + 0.5 or new_h > rect.height() + 0.5:
+                    x1, y1, x2, y2 = centered_resize_xyxy([rect.x(), rect.y(), rect.x() + rect.width(), rect.y() + rect.height()], [new_w, new_h])
+                    blkitem.setRect([x1, y1, x2 - x1, y2 - y1], repaint=True)
+                    changed = True
+            except Exception:
+                pass
+        try:
+            before_size = float(getattr(blkitem.fontformat, 'font_size', 0.0) or 0.0)
+            self._auto_refine_rendered_fit(blkitem)
+            after_size = float(blkitem.minFontSize())
+            if after_size > 0 and abs(after_size - before_size) > 0.05:
+                blkitem.fontformat.font_size = after_size
+                changed = True
+        except Exception:
+            pass
+        img = getattr(self.imgtrans_proj, 'img_array', None)
+        if img is not None and getattr(getattr(pcfg, 'module', None), 'layout_center_in_bubble_after_autolayout', True):
+            try:
+                im_h, im_w = img.shape[:2]
+                changed = self._center_blkitem_in_bubble(blkitem, img, im_w, im_h) or changed
+            except Exception:
+                pass
+        if changed and blkitem.blk is not None:
+            blkitem.blk._bounding_rect = blkitem.absBoundingRect()
         return changed
 
     def _apply_atomic_bubble_fit_to_item(self, blkitem: TextBlkItem, profile: str = None) -> bool:
@@ -1653,6 +1707,8 @@ class SceneTextManager(QObject):
             blkitem.set_fontformat(ff)
             if result.alignment in (0, 1, 2):
                 blkitem.setAlignment(int(result.alignment), restore_cursor=False)
+            fit_diag = (result.diagnostics or {}).get('fit', {})
+            changed = self._postprocess_auto_lettering_item(blkitem, fit_diag=fit_diag) or changed
             if blkitem.blk is not None:
                 blkitem.blk.fontformat = ff.deepcopy()
                 blkitem.blk.vertical = vertical

--- a/utils/auto_text_layout.py
+++ b/utils/auto_text_layout.py
@@ -15,6 +15,175 @@ AUTO_LAYOUT_PRESETS = (
 )
 
 
+AUTO_LAYOUT_PROFILE_DEFAULTS = {
+    AUTO_LAYOUT_PRESET_BALANCED: {
+        "layout_constrain_to_bubble": True,
+        "layout_center_in_bubble_after_autolayout": True,
+        "layout_center_in_bubble_min_gap_px": 40.0,
+        "layout_check_overflow_after_layout": True,
+        "layout_use_mask_safe_area": True,
+        "layout_box_size_check_model_id": "",
+        "layout_optimal_breaks": True,
+        "layout_hyphenation": True,
+        "optimize_line_breaks": False,
+        "layout_short_line_penalty": 80.0,
+        "layout_height_overflow_penalty": 360.0,
+        "layout_font_size_min": 8.0,
+        "layout_font_size_max": 72.0,
+        "layout_font_fit_bubble": True,
+        "layout_font_binary_search": True,
+        "layout_auto_final_fit_pass": True,
+        "layout_balloon_shape": "auto",
+        "layout_balloon_shape_auto_method": "contour_ratio",
+        "layout_balloon_shape_model_id": "",
+        "layout_min_line_width_px": 80.0,
+        "layout_max_line_width_frac_no_bubble": 0.78,
+        "layout_stub_penalty_1word": 2000.0,
+    },
+    AUTO_LAYOUT_PRESET_FIT: {
+        "layout_constrain_to_bubble": True,
+        "layout_center_in_bubble_after_autolayout": True,
+        "layout_center_in_bubble_min_gap_px": 30.0,
+        "layout_check_overflow_after_layout": True,
+        "layout_use_mask_safe_area": True,
+        "layout_box_size_check_model_id": "",
+        "layout_optimal_breaks": True,
+        "layout_hyphenation": True,
+        "optimize_line_breaks": False,
+        "layout_short_line_penalty": 120.0,
+        "layout_height_overflow_penalty": 900.0,
+        "layout_font_size_min": 6.0,
+        "layout_font_size_max": 64.0,
+        "layout_font_fit_bubble": True,
+        "layout_font_binary_search": True,
+        "layout_auto_final_fit_pass": True,
+        "layout_balloon_shape": "auto",
+        "layout_balloon_shape_auto_method": "contour_ratio",
+        "layout_balloon_shape_model_id": "",
+        "layout_min_line_width_px": 70.0,
+        "layout_max_line_width_frac_no_bubble": 0.72,
+        "layout_stub_penalty_1word": 2600.0,
+    },
+    AUTO_LAYOUT_PRESET_READABLE: {
+        "layout_constrain_to_bubble": False,
+        "layout_center_in_bubble_after_autolayout": True,
+        "layout_center_in_bubble_min_gap_px": 50.0,
+        "layout_check_overflow_after_layout": True,
+        "layout_use_mask_safe_area": True,
+        "layout_box_size_check_model_id": "",
+        "layout_optimal_breaks": True,
+        "layout_hyphenation": True,
+        "optimize_line_breaks": True,
+        "layout_short_line_penalty": 60.0,
+        "layout_height_overflow_penalty": 240.0,
+        "layout_font_size_min": 10.0,
+        "layout_font_size_max": 84.0,
+        "layout_font_fit_bubble": True,
+        "layout_font_binary_search": True,
+        "layout_auto_final_fit_pass": True,
+        "layout_balloon_shape": "auto",
+        "layout_balloon_shape_auto_method": "contour_ratio",
+        "layout_balloon_shape_model_id": "",
+        "layout_min_line_width_px": 92.0,
+        "layout_max_line_width_frac_no_bubble": 0.86,
+        "layout_stub_penalty_1word": 1600.0,
+    },
+}
+
+
+def auto_layout_profile_defaults(value: str | None) -> dict:
+    """Return user-facing preset defaults for all advanced auto-layout knobs.
+
+    This keeps the many legacy tuning values behind one stable profile while
+    still allowing expert users to override individual fields after applying it.
+    Model-backed checks are intentionally off in these defaults so automatic
+    layout remains local, fast, and predictable unless the user opts into a
+    model ID explicitly.
+    """
+    preset = normalize_auto_layout_preset(value)
+    return dict(AUTO_LAYOUT_PROFILE_DEFAULTS[preset])
+
+
+def apply_auto_layout_profile(config_obj, value: str | None) -> dict:
+    """Apply a preset's advanced defaults to a module config-like object."""
+    preset = normalize_auto_layout_preset(value)
+    defaults = auto_layout_profile_defaults(preset)
+    if config_obj is not None:
+        setattr(config_obj, "layout_auto_preset", preset)
+        for key, val in defaults.items():
+            setattr(config_obj, key, val)
+    return defaults
+
+
+def auto_layout_profile_summary(value: str | None) -> str:
+    preset = normalize_auto_layout_preset(value)
+    if preset == AUTO_LAYOUT_PRESET_FIT:
+        return "Strict fit: smaller min font, strong overflow penalties, compact line widths, mask-safe area, no model checks by default."
+    if preset == AUTO_LAYOUT_PRESET_READABLE:
+        return "Readable: allows roomier boxes/fewer lines and larger font while keeping final overflow checks and bubble centering on."
+    return "Balanced: mask-safe geometry, centered bubbles, optimal line breaks, binary font fitting, and model-free shape detection by default."
+
+
+def _band(value: float, bands: tuple[tuple[float, str], ...], fallback: str) -> str:
+    try:
+        val = float(value)
+    except Exception:
+        return fallback
+    for limit, label in bands:
+        if val <= limit:
+            return label
+    return fallback
+
+
+def auto_layout_setting_hints(values: dict | object | None = None) -> dict:
+    """Translate advanced numeric auto-layout values into editor-friendly labels.
+
+    The raw values are still used by the layout engine, but the UI can show these
+    labels so users understand whether a number currently means strict, balanced,
+    or roomy behavior.  `values` may be a dict, dataclass/config object, or None.
+    """
+    def get(name: str, default):
+        if values is None:
+            return default
+        if isinstance(values, dict):
+            return values.get(name, default)
+        return getattr(values, name, default)
+
+    min_pt = float(get("layout_font_size_min", 8.0) or 8.0)
+    max_pt = float(get("layout_font_size_max", 72.0) or 72.0)
+    short_pen = float(get("layout_short_line_penalty", 80.0) or 0.0)
+    height_pen = float(get("layout_height_overflow_penalty", 360.0) or 0.0)
+    stub_pen = float(get("layout_stub_penalty_1word", 2000.0) or 0.0)
+    min_width = float(get("layout_min_line_width_px", 80.0) or 80.0)
+    no_bubble = float(get("layout_max_line_width_frac_no_bubble", 0.78) or 0.78)
+    center_gap = float(get("layout_center_in_bubble_min_gap_px", 40.0) or 0.0)
+    box_model = str(get("layout_box_size_check_model_id", "") or "").strip()
+    shape_model = str(get("layout_balloon_shape_model_id", "") or "").strip()
+    shape_method = str(get("layout_balloon_shape_auto_method", "contour_ratio") or "contour_ratio")
+
+    return {
+        "font_range": f"{min_pt:g}–{max_pt:g} pt (" + _band(min_pt, ((6.5, "tiny text allowed"), (9.5, "normal manga range")), "large/readable minimum") + ")",
+        "short_line_penalty": _band(short_pen, ((40, "very loose"), (90, "balanced"), (150, "strict")), "very strict"),
+        "height_overflow_penalty": _band(height_pen, ((250, "roomy / may grow taller"), (550, "balanced"), (950, "strict fit")), "very strict fit"),
+        "stub_penalty": _band(stub_pen, ((900, "loose"), (1800, "balanced"), (2600, "strong")), "maximum"),
+        "minimum_line_width": _band(min_width, ((72, "compact/narrow"), (95, "balanced"), (125, "roomy")), "very roomy"),
+        "no_bubble_width": _band(no_bubble, ((0.70, "compact"), (0.82, "balanced"), (0.92, "wide/readable")), "very wide"),
+        "center_gap": "never skip centering" if center_gap <= 0 else f"skip combined bubbles within {center_gap:g}px",
+        "box_model": "geometry only" if not box_model else ("built-in CLIP" if box_model == "builtin" else "custom model"),
+        "shape_detection": ("model-assisted" if shape_model or shape_method.startswith("model") else "model-free contour/aspect"),
+    }
+
+
+def auto_layout_advanced_summary(values: dict | object | None = None) -> str:
+    hints = auto_layout_setting_hints(values)
+    return (
+        f"Font {hints['font_range']}; lines: {hints['short_line_penalty']} short-line, "
+        f"{hints['stub_penalty']} one-word, {hints['height_overflow_penalty']} height; "
+        f"widths: {hints['minimum_line_width']} in bubbles / {hints['no_bubble_width']} outside; "
+        f"centering: {hints['center_gap']}; checks: {hints['box_model']}, {hints['shape_detection']}."
+    )
+
+
 @dataclass(frozen=True)
 class AutoLayoutPresetSettings:
     """Small set of user-facing automatic lettering behaviors.

--- a/utils/config.py
+++ b/utils/config.py
@@ -142,8 +142,8 @@ class ModuleConfig(Config):
     layout_constrain_to_bubble: bool = True
     # After layout: check if box or text lines extend outside the bubble; shrink box or scale font to fix (no model).
     layout_check_overflow_after_layout: bool = True
-    # Optional HF image-classification model to check if detection box is too large/small for bubble. "builtin" = zero-shot CLIP. Custom: labels too_large, too_small, ok. Empty = skip.
-    layout_box_size_check_model_id: str = "builtin"
+    # Optional HF image-classification model to check if detection box is too large/small for bubble. Empty = fast geometric checks only. "builtin" = zero-shot CLIP.
+    layout_box_size_check_model_id: str = ""
     # After auto layout, center each text box in its bubble (centroid). Skip boxes that are close to another (combined/overlapping bubbles).
     layout_center_in_bubble_after_autolayout: bool = True
     layout_center_in_bubble_min_gap_px: float = 40.0  # skip centering if another block is within this many pixels (edge-to-edge)
@@ -170,9 +170,9 @@ class ModuleConfig(Config):
     layout_use_mask_safe_area: bool = True
     # Balloon shape for Diamond-Text style layout: "auto" (detect from aspect ratio), "round", "elongated", "narrow", "diamond", "square", "bevel", "pentagon", "point". Affects insets and line-length scoring.
     layout_balloon_shape: str = "auto"
-    # When "auto": which method(s) to use and in what order. model_contour = try model first, then contour (recommended when using a model).
-    layout_balloon_shape_auto_method: str = "model_contour"
-    layout_balloon_shape_model_id: str = "prithivMLmods/Geometric-Shapes-Classification"  # SigLIP2-base 92.9M, 8 shapes, 99% acc. Lighter: 0-ma/vit-geometric-shapes-tiny (5.5M, 6 shapes)
+    # When "auto": which method(s) to use and in what order. Default is model-free contour/aspect-ratio detection; set a model ID to opt into model-based shape classification.
+    layout_balloon_shape_auto_method: str = "contour_ratio"
+    layout_balloon_shape_model_id: str = ""  # Optional. Heavier: prithivMLmods/Geometric-Shapes-Classification. Lighter: 0-ma/vit-geometric-shapes-tiny.
     # Minimum line width (px) so short text (e.g. "pluck!") is not forced into 2–3 char lines; layout never uses a narrower width.
     layout_min_line_width_px: float = 80.0
     # Max line width as fraction of box width for free-standing text (no bubble). Lower = more lines, shorter lines. Only used when region_rect is None.
@@ -684,7 +684,7 @@ CONTEXT_MENU_DEFAULT = {
     'overlay_import': True, 'overlay_clear': True,
     'transform_free': True, 'transform_reset_warp': True, 'transform_warp_preset': True,
     'order_bring_front': True, 'order_send_back': True,
-    'format_apply': True, 'format_layout': True, 'format_auto_fit': True, 'format_fit_to_bubble': True, 'format_auto_fit_binary': True, 'format_balloon_shape': True, 'format_resize_to_fit_content': True, 'format_fit_to_mask_safe_box': True, 'format_center_in_bubble': True, 'format_angle': True, 'format_squeeze': True,
+    'format_apply': True, 'format_layout': True, 'format_auto_fit': True, 'format_fit_to_bubble': True, 'format_smart_auto_fit': True, 'format_atomic_bubble_fit': True, 'format_polish_typography': True, 'format_auto_fit_binary': True, 'format_balloon_shape': True, 'format_resize_to_fit_content': True, 'format_fit_to_mask_safe_box': True, 'format_center_in_bubble': True, 'format_angle': True, 'format_squeeze': True,
     'format_layout_review_selected': True, 'format_layout_review_page': True, 'format_layout_review_config': True,
     'run_detect_region': True, 'run_detect_page': True, 'run_translate': True, 'run_ocr': True,
     'run_ocr_translate': True, 'run_ocr_translate_inpaint': True, 'run_inpaint': True,

--- a/utils/text_rendering.py
+++ b/utils/text_rendering.py
@@ -1068,6 +1068,66 @@ def split_long_word(word: str, max_chars: int, marker: str = "‐") -> List[str]
     return [p for p in pieces if p]
 
 
+
+def optimal_latin_wrap(text: str, max_chars: int, split_long_words: bool = True) -> List[str]:
+    """Balanced Latin/space-delimited wrapper that preserves spaces.
+
+    The CJK kinsoku wrappers intentionally discard ASCII whitespace because
+    manga CJK text is commonly set without spaces.  Latin translations need the
+    opposite: keep word spacing while avoiding one-word/widow final lines and
+    very ragged rows in narrow bubbles.
+    """
+    max_chars = max(2, int(max_chars or 2))
+    paragraphs = (text or "").splitlines() or [text or ""]
+    wrapped: List[str] = []
+    for para in paragraphs:
+        words: List[str] = []
+        for raw in para.split():
+            if split_long_words and len(raw) > max_chars:
+                words.extend(split_long_word(raw, max_chars))
+            else:
+                words.append(raw)
+        if not words:
+            continue
+        n = len(words)
+        lengths = [len(w) for w in words]
+        prefix = [0]
+        for ln in lengths:
+            prefix.append(prefix[-1] + ln)
+
+        def line_len(i: int, j: int) -> int:
+            # Spaces between words in [i, j).
+            return prefix[j] - prefix[i] + max(0, j - i - 1)
+
+        total = line_len(0, n)
+        target_lines = max(1, int(math.ceil(total / max_chars)))
+        target = max(1.0, total / target_lines)
+        dp = [float("inf")] * (n + 1)
+        nxt = [-1] * (n + 1)
+        dp[n] = 0.0
+        for i in range(n - 1, -1, -1):
+            for j in range(i + 1, n + 1):
+                ln = line_len(i, j)
+                if ln > max_chars and j > i + 1:
+                    break
+                overflow_penalty = 100.0 * max(0, ln - max_chars)
+                ragged_penalty = (target - min(target, float(ln))) ** 2
+                widow_penalty = 18.0 if (j == n and i > 0 and (j - i == 1 or ln <= max(3, target * 0.38))) else 0.0
+                single_word_penalty = 3.0 if (j - i == 1 and n > 2 and ln < target * 0.65) else 0.0
+                score = ragged_penalty + overflow_penalty + widow_penalty + single_word_penalty + dp[j]
+                if score < dp[i]:
+                    dp[i] = score
+                    nxt[i] = j
+        if nxt[0] < 0:
+            wrapped.extend(wrap_latin_text(para, max_chars, split_long_words=split_long_words))
+            continue
+        i = 0
+        while i < n and nxt[i] > i:
+            j = nxt[i]
+            wrapped.append(" ".join(words[i:j]))
+            i = j
+    return [ln for ln in wrapped if ln]
+
 def wrap_latin_text(text: str, max_chars: int, split_long_words: bool = True) -> List[str]:
     lines: List[str] = []
     for para in (text or "").splitlines() or [text or ""]:
@@ -1097,15 +1157,19 @@ def resolve_fit_font_size_bounds(style_min: float = 0.0, style_max: float = 0.0,
 
 def balance_lines(text: str, max_chars: int, strategy: str = LINE_BREAK_BALANCED) -> str:
     strategy = normalize_line_break_strategy(strategy)
+    raw = text or ""
+    if not (contains_cjk(raw) or contains_rtl(raw)):
+        lines = optimal_latin_wrap(raw.replace("\n", " "), max_chars, split_long_words=True)
+        return "\n".join(lines) if lines else raw
     if strategy == LINE_BREAK_BALANCED:
-        lines = optimal_kinsoku_wrap(text, max_chars, strategy)
+        lines = optimal_kinsoku_wrap(raw, max_chars, strategy)
     else:
-        lines = kinsoku_wrap(text, max_chars, strategy)
+        lines = kinsoku_wrap(raw, max_chars, strategy)
     if len(lines) <= 2:
-        return "\n".join(lines) if lines else (text or "")
+        return "\n".join(lines) if lines else raw
     total = sum(len(ln) for ln in lines)
     target = max(1, int(math.ceil(total / len(lines))))
-    return "\n".join(optimal_kinsoku_wrap(text, min(max_chars, max(target, max_chars // 2)), strategy))
+    return "\n".join(optimal_kinsoku_wrap(raw, min(max_chars, max(target, max_chars // 2)), strategy))
 
 
 def vertical_columns(text: str, max_chars_per_column: int, strategy: str = LINE_BREAK_CJK_STRICT) -> List[str]:
@@ -1394,7 +1458,7 @@ def fit_font_size_to_box(
     text_out = text or ""
     if fit_mode == FIT_MODE_BALANCE and resolved != WRITING_MODE_VERTICAL_RL:
         avg = max(1.0, max(1.0, font_size) * 0.56 * max(0.1, letter_spacing))
-        text_out = balance_lines(text_out.replace("\n", ""), max(2, int(max(1.0, box_w - 2 * padding) / avg)), line_break_strategy)
+        text_out = balance_lines(text_out.replace("\n", " "), max(2, int(max(1.0, box_w - 2 * padding) / avg)), line_break_strategy)
     if resolved == WRITING_MODE_VERTICAL_RL:
         text_out = normalize_vertical_punctuation(text_out)
     lo = max(1.0, float(min_font_size or 1.0))
@@ -1545,7 +1609,7 @@ def smart_fit_text_to_box(
 
     if allow_balance and resolved != WRITING_MODE_VERTICAL_RL:
         avg = max(1.0, max(1.0, float(font_size or 1.0)) * 0.56 * active_spacing)
-        balanced = balance_lines(active_text.replace("\n", ""), max(2, int(max(1.0, eff_size[0] - 2 * float(padding or 0.0)) / avg)), active_break)
+        balanced = balance_lines(active_text.replace("\n", " "), max(2, int(max(1.0, eff_size[0] - 2 * float(padding or 0.0)) / avg)), active_break)
         if balanced and balanced != active_text:
             active_text = balanced
             actions.append("balance_lines")
@@ -1622,7 +1686,7 @@ def _candidate_atomic_lines(text: str, max_chars: int, strategy: str, mode: str)
         return vertical_columns(text or "", max(1, int(max_chars or 1)), strategy)
     if contains_cjk(text or "") or mode == WRITING_MODE_RTL:
         return optimal_kinsoku_wrap((text or "").replace("\n", ""), max(1, int(max_chars or 1)), strategy)
-    return wrap_latin_text((text or "").replace("\n", " "), max(1, int(max_chars or 1)), split_long_words=True)
+    return optimal_latin_wrap((text or "").replace("\n", " "), max(2, int(max_chars or 1)), split_long_words=True)
 
 
 def plan_atomic_bubble_fit(
@@ -1854,8 +1918,11 @@ def plan_typography_cleanup(
         width = max(1.0, float((box_size or (0.0, 0.0))[0] or 1.0) - 2 * float(text_padding or 0.0))
         avg = max(1.0, max(1.0, float(font_size or 1.0)) * 0.54 * max(0.1, float(letter_spacing or 1.0)))
         max_chars = max(2, int(width / avg))
-        balanced_lines = optimal_kinsoku_wrap(active_text.replace("\n", ""), max_chars, active_break)
-        balanced_text = "\n".join(balanced_lines) if balanced_lines else active_text
+        if contains_cjk(active_text) or contains_rtl(active_text):
+            balanced_lines = optimal_kinsoku_wrap(active_text.replace("\n", ""), max_chars, active_break)
+            balanced_text = "\n".join(balanced_lines) if balanced_lines else active_text
+        else:
+            balanced_text = balance_lines(active_text.replace("\n", " "), max_chars, active_break)
         if balanced_text and balanced_text != active_text:
             active_text = balanced_text
             actions.append("balance_lines")


### PR DESCRIPTION
### Motivation
- Provide a single, user-friendly way to control many legacy auto-layout knobs through presets and clearer UI feedback while keeping advanced tuning available.
- Improve one-click lettering (smart/atomic fits) so Latin translations preserve spaces, choose script-aware line-breaking, and run final renderer-based safety and bubble-centering passes.
- Expose profile defaults and human-readable hints so users understand numeric advanced values and can safely restore recommended defaults.

### Description
- Add a full auto-layout profile system in `utils/auto_text_layout.py` including `AUTO_LAYOUT_PROFILE_DEFAULTS`, `auto_layout_profile_defaults`, `apply_auto_layout_profile`, `auto_layout_profile_summary`, `auto_layout_setting_hints`, and `auto_layout_advanced_summary`, and wire them into existing preset normalization logic.
- Update default module config values in `utils/config.py` (model IDs default to empty, balloon shape auto method default to `contour_ratio`) and add new context menu/action keys for smart/atomic fitting and polishing.
- Enhance the UI in `ui/configpanel.py` with preset summary, an "Apply preset" button, a human-readable advanced-values label, a "Restore balanced automatic defaults" button, live tooltip hints, sync/apply helpers, and connections to save config when presets/advanced values change.
- Improve smart/atomic one-click flows in `ui/scenetext_manager.py` by applying the formatter's chosen `line_break_strategy` back to the style, running a `_postprocess_auto_lettering_item` safety pass to grow modestly from renderer diagnostics, run a rendered-fit refinement, and recentre text blocks in detected bubbles when available.
- Implement Latin/space-preserving balanced wrapping in `utils/text_rendering.py` with `optimal_latin_wrap`, integrate it into `balance_lines`, `smart_fit_text_to_box`, `_candidate_atomic_lines`, and `plan_typography_cleanup` so Latin text keeps spaces and avoids concatenation while reducing widows.
- Update docs (`doc/AUTOMATIC_TEXT_FORMATTING.md`, `docs/RENDERING_TEXT_FORMATTING.md`) to document the new automatic pass, presets, one-click polish, and UI hints.
- Add and update unit tests in `tests/test_text_layout_auto_formatting.py` and `tests/test_text_rendering.py` to cover profile defaults, apply/profile behavior, setting hints, Latin wrapping, balancing, and smart fitting behavior.

### Testing
- Ran unit tests in `tests/test_text_layout_auto_formatting.py`, which include new assertions for profile defaults, `apply_auto_layout_profile`, and `auto_layout_setting_hints`; all assertions passed.
- Ran unit tests in `tests/test_text_rendering.py`, which include new tests for `optimal_latin_wrap`, `balance_lines`, and `smart_fit_text_to_box` to verify space-preserving wrapping and avoid word concatenation; tests passed.
- Ran existing layout and rendering tests (unchanged suites) to ensure integrations with `balance_lines` and config UI syncing did not regress; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b1bda06fc832cb79785443db626a3)