### PR TITLE
Fix Windows PyInstaller build preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ python launch.py
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.10.2+ (Python 3.10.0/3.10.1 can crash PyInstaller builds with `IndexError: tuple index out of range`)
 - Internet for first-time setup/model downloads
 - Enough disk space for selected models
 

--- a/scripts/build_windows_exe.ps1
+++ b/scripts/build_windows_exe.ps1
@@ -15,10 +15,14 @@ if (-not $IsWindows) {
 
 Write-Host "[2/6] Verifying Python..."
 & $PythonExe --version
+$BadPython310 = & $PythonExe -c "import sys; print(int((3, 10, 0) <= sys.version_info[:3] < (3, 10, 2)))"
+if ($BadPython310 -eq "1") {
+    throw "Python 3.10.0/3.10.1 can crash PyInstaller with IndexError: tuple index out of range. Install Python 3.10.2 or newer and rerun this script."
+}
 
 Write-Host "[3/6] Installing build deps..."
 & $PythonExe -m pip install -r requirements.txt
-& $PythonExe -m pip install pyinstaller
+& $PythonExe -m pip install --upgrade "pyinstaller>=6.11,<7"
 
 if ($QuantizeOptionalOnnx) {
     Write-Host "[4/6] Quantizing optional ONNX models ($OnnxQuantMode)..."
@@ -40,6 +44,6 @@ else {
 }
 
 Write-Host "[6/6] Building exe via launch.spec..."
-& $PythonExe -m PyInstaller --noconfirm launch.spec
+& $PythonExe -m PyInstaller --clean --noconfirm launch.spec
 
 Write-Host "Done. Expected output folder: dist\\launch"

--- a/scripts/package_release.py
+++ b/scripts/package_release.py
@@ -9,13 +9,35 @@ import subprocess
 import sys
 
 
+MIN_PYINSTALLER = "6.11"
+PYINSTALLER_SPEC = f"pyinstaller>={MIN_PYINSTALLER},<7"
+
+
+def _check_supported_python() -> None:
+    """Fail early for CPython releases known to crash PyInstaller analysis."""
+    if (3, 10, 0) <= sys.version_info[:3] < (3, 10, 2):
+        version = ".".join(str(part) for part in sys.version_info[:3])
+        raise SystemExit(
+            "Python 3.10 builds require Python 3.10.2 or newer. "
+            f"You are running Python {version} from {sys.executable}.\n"
+            "Python 3.10.0/3.10.1 can crash PyInstaller while disassembling "
+            "modules with `IndexError: tuple index out of range`. Install a "
+            "current Python 3.10+ release, then rerun build_windows_installer.bat."
+        )
+
+
+def _install_build_dependencies(python: str) -> None:
+    subprocess.check_call([python, "-m", "pip", "install", "-r", "requirements.txt"])
+    subprocess.check_call([python, "-m", "pip", "install", "--upgrade", PYINSTALLER_SPEC])
+
+
 def main() -> int:
     root = osp.abspath(osp.join(osp.dirname(__file__), ".."))
     os.chdir(root)
+    _check_supported_python()
     python = sys.executable
-    subprocess.check_call([python, "-m", "pip", "install", "-r", "requirements.txt"])
-    subprocess.check_call([python, "-m", "pip", "install", "pyinstaller"])
-    subprocess.check_call([python, "-m", "PyInstaller", "--noconfirm", "launch.spec"])
+    _install_build_dependencies(python)
+    subprocess.check_call([python, "-m", "PyInstaller", "--clean", "--noconfirm", "launch.spec"])
     print("Build complete. Check dist/ for executable bundle.")
     return 0
 


### PR DESCRIPTION
### Motivation
- PyInstaller analysis can crash on CPython 3.10.0/3.10.1 with `IndexError: tuple index out of range`, so builds should fail early with a clear message and remediation.
- Ensure deterministic packaging by installing a supported PyInstaller 6.x range and cleaning PyInstaller analysis to avoid stale artifacts.
- Mirror the same safeguards in the PowerShell helper and document the minimum Python requirement so Windows packagers are not blocked by a confusing crash.

### Description
- Add `_check_supported_python()` to `scripts/package_release.py` to abort when running under Python 3.10.0 or 3.10.1 and provide an explanatory message.
- Change `scripts/package_release.py` to install/upgrade `pyinstaller>=6.11,<7` and invoke PyInstaller with `--clean --noconfirm`.
- Update `scripts/build_windows_exe.ps1` to detect bad Python 3.10.x installs, upgrade PyInstaller to `>=6.11,<7`, and pass `--clean` to PyInstaller.
- Update `README.md` to require Python 3.10.2+ and mention that Python 3.10.0/3.10.1 can crash PyInstaller.

### Testing
- Ran `python -m py_compile scripts/package_release.py scripts/build_windows_installer.py`, which succeeded.
- Exercised the Python-guard via patched `sys.version_info` to ensure `_check_supported_python()` raises `SystemExit` for 3.10.0/3.10.1 and allows other versions, which succeeded.
- Ran `git diff --check` to ensure whitespace/patch hygiene, which succeeded.
- Attempted PowerShell script parse validation but it was blocked in this environment because PowerShell (`pwsh`) is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b252986e4832cac0fe6f9c757f7e9)