### PR TITLE
Add English README, sync and simplify localized READMEs, and add translation notes

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -1,0 +1,129 @@
+> [!IMPORTANT]  
+> **If you're sharing the translated result publicly and no experienced human translator participated in a thorough translation or proofread, please mark it as machine translation somewhere clear to see.**
+
+# BallonsTranslator-Pro
+[简体中文](/README.md) | English | [pt-BR](doc/README_PT-BR.md) | [Русский](doc/README_RU.md) | [日本語](doc/README_JA.md) | [Indonesia](doc/README_ID.md) | [Tiếng Việt](doc/README_VI.md) | [한국어](doc/README_KO.md) | [Español](doc/README_ES.md) | [Français](doc/README_FR.md)
+
+BallonsTranslator-Pro is an advanced fork of [dmMaze/BallonsTranslator](https://github.com/dmMaze/BallonsTranslator) focused on serious manga/comic translation workflows.
+
+<p align="center">
+  <img src="doc/src/1111.png" width="100%">
+</p>
+
+At a high level, BallonsTranslator-Pro helps you:
+
+1. Detect speech balloons/text areas
+2. Read text (OCR)
+3. Translate text
+4. Clean original text from artwork (inpaint)
+5. Edit and export pages
+
+- Full change history: [docs/CHANGELOG.md](docs/CHANGELOG.md)
+
+---
+
+## Launch the app quickly (what to click)
+
+After cloning/downloading and opening the project folder:
+
+- **Windows (recommended):** double-click `launcher.bat` for a single menu with setup, auto-update, AMD/NVIDIA/CPU GPU modes.
+- **Windows quick start:** double-click `launch_win.bat` to start immediately with auto GPU detection.
+- **Cross-platform (manual):** run `python launch.py` in terminal.
+- **GPU help:** see [docs/GPU_ACCELERATION.md](docs/GPU_ACCELERATION.md), especially for AMD Radeon RX 9070/9060/7900 cards.
+
+If batch files are blocked by Windows SmartScreen, right-click the `.bat` file → **Run as administrator** (or choose **More info → Run anyway**).
+
+---
+
+## Install Google Fonts (native in-app)
+
+You can now install Google Fonts directly from the app:
+
+1. Open **Tools → Models → Install Google Font...**
+2. Enter a family name (example: `Bangers`, `Noto Sans JP`, `Comic Neue`)
+3. The app downloads and registers the font automatically.
+
+Installed fonts are stored under `fonts/google/` and become available in font pickers.
+
+---
+
+## Clone / download instructions
+
+### Option A — Download ZIP (easiest)
+
+1. Open the repo page on GitHub.
+2. Click **Code** → **Download ZIP**.
+3. Extract to a normal folder (example: `Documents/BallonsTranslator-Pro`).
+4. Open that folder.
+5. Launch using `launch_win.bat` (Windows) or terminal (`python launch.py`).
+
+### Option B — Git clone (terminal)
+
+```bash
+git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro
+cd BallonsTranslator-Pro
+python launch.py
+```
+
+### Option C — GitHub Desktop
+
+1. Install GitHub Desktop.
+2. **File → Clone repository**.
+3. Paste repo URL and choose a local path.
+4. Open the local folder.
+5. Launch `launch_win.bat` (Windows) or `python launch.py`.
+
+---
+
+## Requirements
+
+- Python 3.10.2+ (Python 3.10.0/3.10.1 can crash PyInstaller builds with `IndexError: tuple index out of range`)
+- Internet for first-time setup/model downloads
+- Enough disk space for selected models
+
+Check Python:
+
+```bash
+python --version
+```
+
+---
+
+## Why Pro
+
+- Practical module combinations for real projects
+- Better batch and long-chapter workflow support
+- More automatic bubble lettering with shape-aware safe areas, balanced line breaks, density-aware font scaling, and final overflow safety checks (see [Automatic text formatting](doc/AUTOMATIC_TEXT_FORMATTING.md))
+- LLM-aided review chain for quality/consistency
+- Strong defaults for fast onboarding
+
+---
+
+## Basic workflow
+
+1. **Open pages**: File → Open Folder / Open Images
+2. **Select modules**: Detector / OCR / Inpaint / Translator
+3. Click **Run**
+4. Review and edit text bubbles
+5. Export from **Tools → Export all pages**
+
+---
+
+## Useful paths in this repo
+
+- App launcher: `launch.py`
+- Windows one-click launcher: `launch_win.bat`
+- Config template: `config/config.example.json`
+- Active config: `config/config.json`
+- Models: `data/models/`
+- Fonts: `fonts/`
+
+---
+
+## Docs
+
+- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
+- [docs/QUALITY_RANKINGS.md](docs/QUALITY_RANKINGS.md)
+- [docs/MODELS_REFERENCE.md](docs/MODELS_REFERENCE.md)
+- [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
+- [docs/INDESIGN_LPTXT_WORKFLOW.md](docs/INDESIGN_LPTXT_WORKFLOW.md)

--- a/doc/README_ES.md
+++ b/doc/README_ES.md
@@ -1,289 +1,49 @@
-> [!IMPORTANT]
-> **Si planeas compartir públicamente los resultados de traducción automática generados con esta herramienta, y no han sido revisados o traducidos completamente por un traductor con experiencia, por favor indícalo claramente como traducción automática en un lugar visible.**
+# BallonsTranslator Pro
 
-## BallonTranslator
+> Esta versión está alineada con `README.md` y `README_zh_CN.md` (actualizado el 18 de mayo de 2026).
 
-[Chino](/README.md) | [Inglês](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Ruso](../doc/README_RU.md) | [Japonés](../doc/README_JA.md) | [Indonesio](../doc/README_ID.md) | [Vietnamita](../doc/README_VI.md) | [Koreano](../doc/README_KO.md) | Español | [Français](../doc/README_FR.md) 
+## Resumen
 
-BallonTranslator es otra herramienta asistida por ordenador, basada en el aprendizaje profundo, para traducir cómics/manga.
+BallonsTranslator Pro es una herramienta para traducir cómics/imágenes con flujo OCR → traducción → corrección de texto → renderizado. Incluye múltiples motores OCR, traductores y opciones de inpainting/renderizado.
 
-<img src="../doc/src/ui0.jpg" div align=center>
+## Características principales
 
-<p align=center>
-  <strong>Vista previa</strong>
-</p>
-  
-## Recursos
-* **Traducción totalmente automática:** 
-  - Detecta, reconoce, elimina y traduce textos automáticamente. El rendimiento global depende de estos módulos.
-  - La maquetación se basa en el formato estimado del texto original.
-  - Funciona bien con manga y cómics.
-  - Diseño mejorado para manga->inglés, inglés->chino (basado en la extracción de regiones de globos).
-  
-* **Edición de imágenes:**
-  - Permite editar máscaras e inpainting (similar a la herramienta Pincel recuperador de imperfecciones de Photoshop).
-  - Adaptado para imágenes con una relación de aspecto extrema, como los webtoons.
-  
-* **Edición de texto:**
-  - Admite formato de texto y [preajustes de estilo de texto](https://github.com/dmMaze/BallonsTranslator/pull/311). Los textos traducidos pueden editarse interactivamente.
-  - Buscar y reemplazar.
-  - Exportación/importación a/desde documentos Word.
+- Flujo completo por lotes para manga/manhua/manhwa e imágenes generales.
+- Motores OCR locales y en la nube (PaddleOCR, MangaOCR, EasyOCR, LLM/VLM OCR, etc.).
+- Traducción automática con proveedores LLM y MT.
+- Herramientas de edición: detección de globos, limpieza de máscara, estilos y tipografía.
+- Renderizado y exportación (incluyendo SVG/subtítulos en los flujos compatibles).
+- Controles de rendimiento (GPU/VRAM/modelos opcionales).
 
-## Instalación
+## Instalación rápida
 
-### En Windows
-Si no quieres instalar Python y Git manualmente y tienes acceso a Internet:  
-Descarga `BallonsTranslator_dev_src_with_gitpython.7z` desde [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) o [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), descomprime y ejecuta `launch_win.bat`.  
-Ejecute `scripts/local_gitpull.bat` para obtener la última actualización.
+1. Clona el repositorio.
+2. Instala dependencias con `pip install -r requirements.txt`.
+3. Ejecuta `python launch.py`.
 
-### Ejecutar el código fuente
-Instale [Python](https://www.python.org/downloads/release/python-31011) **<= 3.12** (no utilice la versión de Microsoft Store) y [Git](https://git-scm.com/downloads).
+Para Windows también hay scripts: `launch_win.bat`, `build_windows_installer.bat`.
 
-```bash
-# Clonar este repositorio
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+## Documentación
 
-# Iniciar la aplicación
-$ python3 launch.py
+Consulta `docs/` para:
 
-# Actualizar la aplicación
-$ python3 launch.py --update
-```
+- Guía de traducciones: `docs/TRANSLATIONS.md`, `docs/TRANSLATIONS_zh_CN.md`
+- Rendimiento/GPU: `docs/GPU_ACCELERATION.md`
+- Inpainting/renderizado: `docs/INPAINTING_QUALITY_AND_SPEED.md`, `docs/RENDERING_TEXT_FORMATTING.md`
+- Vídeo/subtítulos: `docs/VIDEO_SUBTITLE_FLOW_EXAMPLE.md` y archivos relacionados
 
-En la primera ejecución, se instalarán las librerías necesarias y las plantillas se descargarán automáticamente. Si las descargas fallan, tendrás que descargar la carpeta **data** (o los archivos que faltan mencionados en el terminal) desde [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) o [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) y guardarla en la ruta correspondiente de la carpeta de código fuente.
+## Idiomas de UI soportados
 
-## Creación de la aplicación para macOS (compatible con chips Intel y Apple Silicon)
-[Referencia](doc/macOS_app.md)
-Pueden ocurrir algunos problemas; por ahora, se recomienda ejecutar el código fuente directamente.
+- English (`en_US`)
+- 简体中文 (`zh_CN`)
+- Español (`es_MX`)
+- Français (`fr_FR`)
+- Português (Brasil) (`pt_BR`)
+- Русский (`ru_RU`)
+- 한국어 (`ko_KR`)
+- Magyar (`hu_HU`)
 
-*Nota: macOS también puede ejecutar el código fuente si la aplicación no funciona.*
+## Contribución
 
-![录屏2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
-
-#### 1. Preparación
--  Descargue las bibliotecas y plantillas de [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) o [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing).
-
-<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  Coloca todos los recursos descargados en una carpeta llamada `data`. La estructura final del directorio debería ser la siguiente:
-  
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 directorios, 23 ficheros
-```
-
-- Instale la herramienta de línea de comandos pyenv para gestionar las versiones de Python. Se recomienda la instalación a través de Homebrew.
-
-```
-# Instalación mediante Homebrew
-brew install pyenv
-
-# Instalación mediante script oficial
-curl https://pyenv.run | bash
-
-# Configuración del entorno shell tras la instalación
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-#### 2. Creación de la aplicación
-```
-# Introduzca el directorio de trabajo `data`.
-cd data
-
-# Clonar la rama `dev` del repositorio
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# Introduzca el directorio de trabajo `BallonsTranslator`.
-cd BallonsTranslator
-
-# Ejecute el script de construcción, que le pedirá la contraseña en el paso pyinstaller, introduzca la contraseña y pulse enter
-sh scripts/build-macos-app.sh
-```
-
-> 📌 La aplicación empaquetada se encuentra en ./data/BallonsTranslator/dist/BallonsTranslator.app. Arrastre la aplicación a la carpeta de aplicaciones de macOS para instalarla. Listo para usar sin ajustes adicionales de Python.
-
-
-</details>
-
-# Utilización
-
-**Se recomienda ejecutar el programa en un terminal en caso de que se produzca un fallo y no se proporcione información, como se muestra en el siguiente gif.**
-<img src="../doc/src/run.gif">  
-
-- En la primera ejecución, selecciona el traductor y establece los idiomas de origen y destino haciendo clic en el icono de configuración.
-- Abre una carpeta que contenga las imágenes del cómic (manga/manhua/manhwa) que necesites traducir haciendo clic en el icono de la carpeta.
-- Haz clic en el botón «Ejecutar» y espera a que se complete el proceso.
-
-Los formatos de fuente, como el tamaño y el color, son determinados automáticamente por el programa en este proceso. Puede predeterminar estos formatos cambiando las opciones correspondientes de "decidir por el programa" a "utilizar configuración global" en el panel Configuración->Diagramación. (La configuración global son los formatos que se muestran en el panel de formato de fuente de la derecha cuando no está editando ningún bloque de texto en la escena).
-
-## Edición de imágenes
-
-### Herramienta para pintar
-<img src="../doc/src/imgedit_inpaint.gif">
-<p align = "center">
-  <strong>Modo de edición de imágenes, herramienta Inpainting</strong>
-</p>
-
-### Herramienta rectángulo
-<img src="../doc/src/rect_tool.gif">
-<p align = "center">
-  <strong>Herramienta rectángulo</strong>
-</p>
-
-Para 'borrar' los resultados de inpainting no deseados, utilice la herramienta inpainting o la herramienta rectángulo con el **botón derecho del ratón** pulsado. El resultado depende de la precisión con la que el algoritmo ("método 1" y "método 2" en el gif) extrae la máscara de texto. El rendimiento puede ser peor con texto y fondos complejos.
-
-## Edición de texto
-<img src="../doc/src/textedit.gif">
-<p align = "center">
-  <strong>Modo de edición de texto</strong>
-</p>
-
-<img src="../doc/src/multisel_autolayout.gif" div align=center>
-<p align=center>
-  <strong>Formato de texto por lotes y maquetación automática</strong>
-</p>
-
-<img src="../doc/src/ocrselected.gif" div align=center>
-<p align=center>
-  <strong>OCR y traducción de áreas seleccionadas</strong>
-</p>
-
-## Atajos
-* `A`/`D` o `pageUp`/`Down` para pasar de página
-* `Ctrl+Z`, `Ctrl+Shift+Z` para deshacer/rehacer la mayoría de las operaciones (la pila de deshacer se borra al pasar página).
-* `T` para el modo de edición de texto (o el botón "T" de la barra de herramientas inferior).
-* `W` para activar el modo de creación de bloques de texto, arrastra el ratón por la pantalla con el botón derecho pulsado para añadir un nuevo bloque de texto (ver gif de edición de texto).
-* `P` para el modo de edición de imágenes.
-* En el modo de edición de imágenes, utiliza el control deslizante de la esquina inferior derecha para controlar la transparencia de la imagen original.
-* Desactivar o activar cualquier módulo automático a través de la barra de título->ejecutar. Ejecutar con todos los módulos desactivados remapeará las letras y renderizará todo el texto según la configuración correspondiente.
-* Establece los parámetros de los módulos automáticos en el panel de configuración.
-* `Ctrl++`/`Ctrl+-` (También `Ctrl+Shift+=`) para redimensionar la imagen.
-* `Ctrl+G`/`Ctrl+F` para buscar globalmente/en la página actual.
-* `0-9` para ajustar la opacidad de la capa de texto.
-* Para editar texto: negrita - `Ctrl+B`, subrayado - `Ctrl+U`, cursiva - `Ctrl+I`.
-* Ajuste la sombra y la transparencia del texto en el panel de estilo de texto -> Efecto.
-* ```Alt+Arrow Keys``` o ```Alt+WASD``` (```pageDown``` o ```pageUp``` mientras estás en el modo de edición de texto) para cambiar entre bloques de texto.
-
-<img src="../doc/src/configpanel.png">
-
-## Modo Headless (ejecución sin interfaz gráfica)
-
-```python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-
-La configuración (idioma de origen, idioma de destino, modelo de inpainting, etc.) se cargará desde config/config.json. Si el tamaño de la fuente renderizada no es correcto, especifique manualmente el DPI lógico mediante `--ldpi`. Los valores típicos son 96 y 72.
-
-## Módulos de automatización
-Este proyecto depende en gran medida de [manga-image-translator](https://github.com/zyddnys/manga-image-translator). Los servicios en línea y la formación de modelos no son baratos, así que por favor considere hacer una donación al proyecto:
-- Ko-fi: [https://ko-fi.com/voilelabs](https://ko-fi.com/voilelabs)
-- Patreon: [https://www.patreon.com/voilelabs](https://www.patreon.com/voilelabs)
-- 爱发电: [https://afdian.net/@voilelabs](https://afdian.net/@voilelabs)
-
-El [traductor de Sugoi](https://sugoitranslator.com/) fue creado por [mingshiba](https://www.patreon.com/mingshiba).
-
-## Detección de texto
- * Permite detectar texto en inglés y japonés. El código de entrenamiento y más detalles en [comic-text-detector](https://github.com/dmMaze/comic-text-detector).
- * Admite el uso de la detección de texto de [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Es necesario rellenar el nombre de usuario y la contraseña, y el inicio de sesión automático se realizará cada vez que se inicie el programa.
-   * Para obtener instrucciones detalladas, consulte el [Manual de TuanziOCR](../doc/Manual_TuanziOCR_ES.md).
- * Los modelos `YSGDetector` fueron entrenados por [lhj5426](https://github.com/lhj5426). Estos modelos filtran las onomatopeyas en CGs/Manga. Descarga los checkpoints desde [YSGYoloDetector](https://huggingface.co/YSGforMTL/YSGYoloDetector) y colócalos en la carpeta `data/models`.
-
-
-## OCR
-* Todos los modelos mit* proceden de manga-image-translator y admiten el reconocimiento en inglés, japonés y coreano, así como la extracción del color del texto.
-* [manga_ocr](https://github.com/kha-white/manga-ocr) es de [kha-white](https://github.com/kha-white), reconocimiento de texto para japonés, centrado principalmente en el manga japonés.
-* Admite el uso de OCR de [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Es necesario rellenar el nombre de usuario y la contraseña, y el inicio de sesión automático se realizará cada vez que se inicie el programa.
-  * La implementación actual utiliza OCR en cada bloque de texto individualmente, lo que resulta en una velocidad más lenta y ninguna mejora significativa en la precisión. No se recomienda. Si es necesario, utilice el Detector Tuanzi.
-  * Cuando se utiliza Tuanzi Detector para la detección de texto, se recomienda configurar el OCR a none_ocr para leer el texto directamente, ahorrando tiempo y reduciendo el número de peticiones.
-  * Para obtener instrucciones detalladas, consulte el [Manual de TuanziOCR](doc/Manual_TuanziOCR_ES.md).
-* Se añadió como un módulo opcional el soporte para PaddleOCR. En el modo Debug, verás un mensaje indicando que no está instalado. Puedes instalarlo fácilmente siguiendo las instrucciones que se muestran ahí. Si no quieres instalar el paquete manualmente, simplemente descomenta (elimina el `#`) las líneas correspondientes a paddlepaddle(gpu) y paddleocr. Hazlo bajo tu propia responsabilidad y riesgo. Si no se instaló correctamente, y genera errores; de ser así, repórtalo en Issues.
-* Se añadió soporte para [OneOCR](https://github.com/b1tg/win11-oneocr). Es un modelo local de Windows, tomado de las aplicaciones Recortes (Snipping Tool) o Fotos `Win.PHOTOS`. Para usarlo, necesitas colocar el modelo y los archivos DLL en la carpeta 'data/models/one-ocr'. Es mejor colocar todos los archivos antes de ejecutar el programa. Puedes leer cómo encontrar y extraer los archivos DLL y del modelo aquí:
-https://github.com/dmMaze/BallonsTranslator/discussions/859#discussioncomment-12876757. Agradecimientos a AuroraWright por el proyecto [OneOCR](https://github.com/AuroraWright/oneocr).
-
-## Inpainting
-* AOT es de [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
-* Todas las lama* se ajustan mediante [LaMa](https://github.com/advimman/lama).
-* PatchMatch es un algoritmo de [PyPatchMatch](https://github.com/vacancy/PyPatchMatch). Este programa utiliza una [versión modificada](https://github.com/dmMaze/PyPatchMatchInpaint) por mí.
-
-## Traductores disponibles
-* **Google Translate**: El servicio de Google Translate ha sido desactivado en China. Para usarlo desde la China continental, debes configurar un proxy global y cambiar la URL en el panel de configuración a `*`.com
-* **Caiyun**: Requiere que solicites un [token de acceso](https://dashboard.caiyunapp.com/).
-* **Papago**: Compatible sin configuraciones adicionales.
-* **DeepL y Sugoi (incluyendo su conversión con CT2 Translation)**: Agradecimientos a [Snowad14](https://github.com/Snowad14).
-Si deseas usar el traductor Sugoi (solo soporta traducción del japonés al inglés), debes descargar el [modelo offline](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm) y mover la carpeta ```sugoi_translator``` dentro del directorio BallonsTranslator/ballontranslator/data/models.
-* **Sugoi** traduce del japonés al inglés completamente sin conexión.
-* Se admite [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame). Si se ejecuta localmente en una sola tarjeta gráfica con poca memoria de video, puedes activar el ```low vram mode``` o Modo de bajo consumo de VRAM en el panel de configuración (activado por defecto).
-* Para **DeepLX**, consulta [Vercel](https://github.com/bropines/Deeplx-vercel) o el [proyecto deeplx](https://github.com/OwO-Network/DeepLX).
-* Se admiten dos versiones de traductores compatibles con **OpenAI**. Son compatibles tanto con el proveedor oficial como con proveedores de LLM de terceros que sigan la API de **OpenAI**. Es necesario configurarlo en el panel de ajustes.
-   * La versión sin sufijo consume menos tokens, pero su estabilidad en la segmentación de oraciones es ligeramente peor, lo que puede causar problemas al traducir textos largos.
-   * La versión con el sufijo **exp** consume más tokens, pero es más estable y usa técnicas tipo "jailbreak" en el prompt, adecuada para traducciones de textos largos.
-* [m2m100](https://huggingface.co/facebook/m2m100_1.2B): Descarga y mueve la carpeta 'm2m100-1.2B-ctranslate2' al directorio 'data/models'.
-* **Puedes encontrar información sobre los módulos de traductores [aquí](../doc/modules/translators.md)**.
-
-Para otros modelos de traducción offline al inglés de buena calidad, consulta este [hilo de discusión](https://github.com/dmMaze/BallonsTranslator/discussions/515).
-Para añadir un nuevo traductor, consulte [Cómo_añadir_un_nuevo_traductor](../doc/Como_añadir_un_nuevo_traductor.md). Es tan sencillo como crear una subclase de una clase base e implementar dos interfaces. Luego puedes usarla en la aplicación. Las contribuciones al proyecto son bienvenidas.
-
-## FAQ & Varios
-* Los ordenadores con tarjeta gráfica Nvidia o chip Apple Silicon activan por defecto la aceleración por GPU.
-* Gracias a [bropines](https://github.com/bropines) por proporcionar la traducción al ruso.
-* Los métodos de entrada de terceros pueden causar errores visuales en el cuadro de edición de la derecha. Véase el issue [#76](https://github.com/dmMaze/BallonsTranslator/issues/76); de momento no se planea solucionar esto.
-* El menú flotante al seleccionar texto admite funciones como diccionarios agregados, traducción profesional palabra por palabra y [Saladict](https://saladict.crimx.com)(*Diccionario emergente profesional y traductor de páginas todo en uno*). Consulta las [instrucciones de instalación](../doc/saladict_es.md).
-* Acelera el rendimiento si tienes un dispositivo [NVIDIA CUDA](https://pytorch.org/docs/stable/notes/cuda.html) o [AMD ROCm](https://pytorch.org/docs/stable/notes/hip.html), ya que la mayoría de los módulos utilizan [PyTorch](https://pytorch.org/get-started/locally/).
-* Las fuentes son de tu sistema.
-* Añadido script de exportación JSX para Photoshop por [bropines](https://github.com/bropines). Para leer las instrucciones, mejorar el código y simplemente explorar cómo funciona, vaya a `scripts/export to photoshop` -> `install_manual.md`.
-
-<details>
-  <summary><i>Pasos para habilitar la aceleración por GPU con tarjetas gráficas AMD (ROCm6)</i></summary>
-
-1.  Actualiza el controlador de la tarjeta gráfica a la versión más reciente (se recomienda la versión 24.12.1 o superior). Descarga e instala [AMD HIP SDK 6.2](https://www.amd.com/en/developer/resources/rocm-hub/hip-sdk.html).
-2.  Descarga [ZLUDA](https://github.com/lshqqytiger/ZLUDA/releases) (versión ROCm6) y descomprímelo dentro de una carpeta llamada 'zluda'.
-Copia esta carpeta 'zluda' al disco del sistema, por ejemplo: 'C:\zluda'.
-3.  Configura las variables de entorno del sistema (en **Windows 10**):
-Ve a `Configuración → Propiedades del sistema → Configuración avanzada del sistema → Variables de entorno`.
-En “Variables del sistema”, busca la variable **Path**, haz clic en editar y añade al final: `C:\zluda` y `%HIP_PATH_62%\bin`.
-4.  Sustituye los archivos de enlace dinámico de la biblioteca CUDA: Copia los siguientes archivos desde 'C:\zluda' al escritorio: `cublas.dll`, `cusparse.dll` y `nvrtc.dll`. Luego, renómbralos de acuerdo con las siguientes reglas:
-
-**Nota: Si usas el controlador AMD 25.5.1, asegúrate de actualizar ZLUDA a la versión 3.9.5 o superior.**
-
-```
-  Nombre original → Nuevo nombre
-
-  cublas.dll → cublas64_11.dll
-
-  cusparse.dll → cusparse64_11.dll
-
-  nvrtc.dll → nvrtc64_112_0.dll
-```
-  Sustituye los archivos renombrados en el directorio: `BallonsTranslator\ballontrans_pylibs_win\Lib\site-packages\torch\lib\` reemplazando los archivos del mismo nombre.
-
-5.  Inicia el programa y configura el OCR y la detección de texto para que usen CUDA **(la reparación de imágenes debe seguir usando la CPU)**.
-6.  Al ejecutar OCR por primera vez, ZLUDA compilará los archivos PTX **(este proceso puede tardar entre 5 y 10 minutos dependiendo del rendimiento del CPU)**,**En las siguientes ejecuciones, no será necesario volver a compilar.**
-</details>
+- Ver `CONTRIBUTING.md`.
+- Mantén sincronizadas las traducciones cuando se actualicen `README.md` y `README_zh_CN.md`.

--- a/doc/README_FR.md
+++ b/doc/README_FR.md
@@ -1,254 +1,42 @@
-> [!IMPORTANT]  
-> **Si vous partagez publiquement le résultat traduit et qu'aucun traducteur humain expérimenté n'a participé à la traduction ou à la relecture, veuillez indiquer clairement qu'il s'agit d'une traduction automatique.**
+# BallonsTranslator Pro
 
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | Français
+> Cette version est alignée sur `README.md` et `README_zh_CN.md` (mise à jour le 18 mai 2026).
 
-BallonTranslator est un autre outil assisté par ordinateur, basé sur l'apprentissage profond (deep learning), permettant de traduire des comics/mangas.
+## Aperçu
 
-<img src="../doc/src/ui0.jpg" div align=center>
+BallonsTranslator Pro est un outil de traduction d’images/bandes dessinées avec pipeline OCR → traduction → correction du texte → rendu final.
 
-<p align=center>
-aperçu
-</p>
+## Fonctions principales
 
-Prend en charge le formatage riche du texte et les préréglages de style. Les textes traduits peuvent être édités interactivement.
+- Traitement par lots pour manga/manhua/manhwa et images générales.
+- Moteurs OCR locaux/cloud (PaddleOCR, MangaOCR, EasyOCR, OCR LLM/VLM, etc.).
+- Traduction automatique avec fournisseurs LLM et MT.
+- Outils d’édition: bulles, masques, styles de texte, polices.
+- Rendu et export (dont SVG/sous-titres pour les workflows compatibles).
+- Contrôle des performances (GPU/VRAM/modèles optionnels).
 
-Prend en charge rechercher & remplacer
+## Installation rapide
 
-Prend en charge l’export/import vers/depuis des documents Word
+1. Cloner le dépôt.
+2. Installer les dépendances: `pip install -r requirements.txt`.
+3. Lancer: `python launch.py`.
 
-# Fonctionnalités
-* Traduction entièrement automatisée
-  - Prend en charge la détection, la reconnaissance, la suppression et la traduction automatiques du texte. Les performances globales dépendent de ces modules.
-  - La composition typographique est basée sur l'estimation du formatage du texte original.
-  - Fonctionne correctement avec les mangas et comics.
-  - Amélioration du lettrage manga->Anglais, Anglais->Chinois (basé sur l'extraction des zones de bulles).
-  
-* Édition d’image  
-  - Prise en charge de l'édition et de la retouche des masques (similaire à l'outil Pinceau correcteur dans Photoshop)
-  - Adapté aux images à rapport hauteur/largeur extrême comme les webtoons
-  
-* Édition de texte
-  - Prend en charge le formatage riche du texte et les [préréglages de style](https://github.com/dmMaze/BallonsTranslator/pull/311). Les textes traduits peuvent être édités interactivement.
-  - Prend en charge rechercher & remplacer
-  - Prend en charge l’export/import vers/depuis des documents Word
+Scripts Windows disponibles: `launch_win.bat`, `build_windows_installer.bat`.
 
-# Installation
+## Documentation
 
-## Sous Windows
-Si vous ne souhaitez pas installer Python et Git vous-même et que vous avez accès à Internet :
-Téléchargez BallonsTranslator_dev_src_with_gitpython.7z depuis [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), décompressez et lancez launch_win.bat. 
-Exécutez scripts/local_gitpull.bat pour obtenir la dernière mise à jour.
-Notez que ces paquets fournis ne fonctionnent pas sous Windows 7, les utilisateurs de Win7 doivent installer [Python 3.8](https://www.python.org/downloads/release/python-3810/) et exécuter le code source.
+Voir `docs/` pour:
 
-## Exécuter le code source
+- Traductions: `docs/TRANSLATIONS.md`, `docs/TRANSLATIONS_zh_CN.md`
+- Performance/GPU: `docs/GPU_ACCELERATION.md`
+- Inpainting/rendu: `docs/INPAINTING_QUALITY_AND_SPEED.md`, `docs/RENDERING_TEXT_FORMATTING.md`
+- Vidéo/sous-titres: `docs/VIDEO_SUBTITLE_FLOW_EXAMPLE.md` et documents liés
 
-Installez [Python](https://www.python.org/downloads/release/python-31011) **<= 3.12** (ne pas utiliser celui du Microsoft Store) et [Git](https://git-scm.com/downloads).
+## Langues UI prises en charge
 
-```bash
-# Clonez ce dépôt
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+English (`en_US`), 简体中文 (`zh_CN`), Español (`es_MX`), Français (`fr_FR`), Português (Brasil) (`pt_BR`), Русский (`ru_RU`), 한국어 (`ko_KR`), Magyar (`hu_HU`).
 
-# Lancez l'application
-$ python3 launch.py
+## Contribution
 
-# Mettre à jour l'application
-$ python3 launch.py --update
-```
-
-Lors du premier lancement, le programme installera automatiquement les bibliothèques requises et téléchargera les modèles. Si les téléchargements échouent, il faudra récupérer le dossier **data** (ou les fichiers manquants indiqués dans le terminal) depuis [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) et les placer au bon endroit dans le dossier du code source.
-
-## Construire l'application macOS (compatible Intel et puces Apple Silicon)
-[Reference](../doc/macOS_app.md)  
-Quelques problèmes peuvent survenir, exécuter directement le code source est pour l’instant recommandé.
-
-<i>Remarque : macOS peut également exécuter le code source si l'application ne fonctionne pas.</i>
-
-![录屏2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
-
-#### 1. Préparation
--   Téléchargez les bibliothèques et les modèles depuis [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw "MEGA") ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)
-
-
-<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  Placez toutes les ressources téléchargées dans un dossier nommé data. L'arborescence finale des dossiers doit ressembler à ceci :
-
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 dossiers, 23 fichiers
-```
-
--  Installez l’outil en ligne de commande pyenv pour gérer les versions de Python. Il est recommandé de l’installer via Homebrew.
-```
-# Installation via Homebrew
-brew install pyenv
-
-# Installation via le script officiel
-curl https://pyenv.run | bash
-
-# Configuration de l'environnement shell après installation
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-
-#### 2、Construire l'application
-```
-# Se placer dans le répertoire de travail `data`
-cd data
-
-# Cloner la branche `dev` du dépôt
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# Entrer dans le répertoire `BallonsTranslator`
-cd BallonsTranslator
-
-# Lancer le script de construction, demandera le mot de passe lors de l'étape pyinstaller, entrez le mot de passe et validez
-sh scripts/build-macos-app.sh
-```
-> 📌L'application empaquetée se trouve dans ./data/BallonsTranslator/dist/BallonsTranslator.app. Glissez l'application dans le dossier Applications de macOS pour l’installer. Prête à l’emploi sans configuration Python supplémentaire.
-</details> 
-
-# Utilisation
-
-**Il est conseillé de lancer le programme dans un terminal pour voir les messages en cas de plantage, voir le gif suivant.**
-<img src="../doc/src/run.gif">  
-- La première fois que vous lancez l'application, veuillez sélectionner le traducteur et définir les langues source et cible en cliquant sur l'icône des paramètres.
-- Ouvrez un dossier contenant les images du manga/manhua/manhwa/comic à traduire en cliquant sur l’icône dossier.
-- Cliquez sur le bouton `Run` et attendez la fin du processus.
-
-Les formats de police, tels que la taille et la couleur, sont déterminés automatiquement par le programme au cours de ce processus. Vous pouvez prédéfinir ces formats en modifiant les options correspondantes de « Déterminer par programme » à « Utiliser les paramètres globaux » dans le panneau de configuration -> Composition typographique. (Les paramètres globaux sont les formats affichés dans le panneau de format de police de droite lorsque vous ne modifiez aucun bloc de texte dans la scène.)
-
-## Édition d’image
-
-### Outil de retouche
-<img src="../doc/src/imgedit_inpaint.gif">
-<p align = "center">
-Mode d'édition d'image, outil de retouche
-</p>
-
-### Outil Rect
-<img src="../doc/src/rect_tool.gif">
-<p align = "center">
-Outil Rect
-</p>
-
-Pour « effacer » les résultats indésirables de la retouche, utilisez l'outil de retouche ou l'outil de correction en maintenant le **clic droit** enfoncé.
-Le résultat dépend de la précision avec laquelle l'algorithme (méthode 1 et méthode 2 dans le gif) extrait le masque de texte. Il peut être moins performant sur des textes et des arrière-plans complexes.  
-
-## Édition de texte
-<img src="../doc/src/textedit.gif">
-<p align = "center">
-Mode édition de texte
-</p>
-
-<img src="../doc/src/multisel_autolayout.gif" div align=center>
-<p align=center>
-Formatage de texte en lot & auto-mise en page
-</p>
-
-<img src="../doc/src/ocrselected.gif" div align=center>
-<p align=center>
-OCR & traduction d’une zone sélectionnée
-</p>
-
-## Raccourcis
-* ```A```/```D``` ou ```pageUp```/```Down``` pour changer de page.
-* ```Ctrl+Z```, ```Ctrl+Shift+Z``` pour annuler/rétablir la plupart des opérations. (Remarque : la pile d'annulation sera effacée après avoir changé de page.)
-* ```T``` pour le mode édition de texte (ou le bouton "T" en bas).
-* ```W``` pour activer le mode de création de blocs de texte, cliquez avec le clic droit de la souris sur le canevas et faites glisser la souris pour ajouter un nouveau bloc de texte. (voir le gif sur l'édition de texte)
-* ```P``` pour le mode édition d’image.
-* En mode édition d'image, utilisez le curseur en bas à droite pour contrôler la transparence de l'image d'origine.
-* Désactivez ou activez les modules automatiques via la barre de titre->Exécuter. L'exécution avec tous les modules désactivés réécrira et réaffichera tout le texte en fonction des paramètres correspondants.
-* Définissez les paramètres des modules automatiques dans le panneau de configuration.
-* ```Ctrl++```/```Ctrl+-``` (Aussi ```Ctrl+Shift+=```) pour redimensionner l’image.
-* ```Ctrl+G```/```Ctrl+F``` pour faire une recherche globale/dans la page actuelle.
-* ```0-9``` pour ajuster l'opacité du calque de texte.
-* Pour l'édition de texte : gras - ```Ctrl+B```, souligné - ```Ctrl+U```, italique - ```Ctrl+I``` 
-* Définissez l'ombre et la transparence du texte dans le panneau Style de texte -> Effet.
-* ```Alt+Touches fléchées``` ou ```Alt+WASD``` (```pageDown``` ou ```pageUp``` en mode édition de texte) pour passer d'un bloc de texte à l'autre.
-  
-<img src="../doc/src/configpanel.png">
-
-## Mode sans interface (exécution sans interface graphique)
-``` python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-Notez que la configuration (langue source, langue cible, modèle de retouche, etc.) sera chargée à partir du fichier config/config.json.  
-Si la taille de la police rendue n'est pas correcte, spécifiez manuellement la résolution logique via ```--ldpi ```, les valeurs typiques sont 96 et 72.
-
-
-# Modules d'automatisation
-Ce projet dépend fortement de [manga-image-translator](https://github.com/zyddnys/manga-image-translator), un service en ligne et la formation des modèles n'est pas bon marché, veuillez envisager de faire un don au projet :
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>  
-
-[Sugoi translator](https://sugoitranslator.com/) est créé par [mingshiba](https://www.patreon.com/mingshiba).
-  
-## Détection de texte
- * Prise en charge de la détection de texte en anglais et en japonais. Le code source et plus de détails sont disponibles sur [comic-text-detector].
- * Prise en charge de la détection de texte à partir de [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Le nom d'utilisateur et le mot de passe doivent être renseignés, et la connexion automatique sera effectuée à chaque lancement du programme.
-
-   * Pour obtenir des instructions détaillées, consultez le [Manuel TuanziOCR](../doc/Manual_TuanziOCR_FR.md)
- 
- * Les Modèles`YSGDetector` sont entraînés par [lhj5426](https://github.com/lhj5426), filtrent les onomatopées dans CGs/mangas. Téléchargez depuis [YSGYoloDetector](https://huggingface.co/YSGforMTL/YSGYoloDetector) et placez dans `data/models`. 
-
-
-## OCR
- * Les modèles mit* viennent de manga-image-translator, prennent en charge l’anglais, japonais, coréen et l’extraction de couleur du texte.
- * [manga_ocr](https://github.com/kha-white/manga-ocr) est un logiciel de reconnaissance de texte japonais développé par [kha-white](https://github.com/kha-white), principalement destiné aux mangas japonais.
- * Prise en charge de la reconnaissance optique de caractères (OCR) via [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Le nom d'utilisateur et le mot de passe doivent être renseignés, et la connexion automatique s'effectuera à chaque lancement du programme.
-   * L’implémentation actuelle applique l’OCR sur chaque bloc, plus lente et pas plus précise, non recommandée. Préférez Tuanzi Detector.
-   * Lorsque vous utilisez le Tuanzi Detector pour la détection de texte, il est recommandé de définir OCR sur none_ocr afin de lire directement le texte, ce qui permet de gagner du temps et de réduire le nombre de requêtes.
-   * Pour obtenir des instructions détaillées, consultez le [Manuel TuanziOCR](../doc/Manual_TuanziOCR_FR.md)
-* Ajouté en option sous forme de module PaddleOCR. En mode débogage, un message vous indiquera qu'il n'est pas présent. Vous pouvez simplement l'installer en suivant les instructions qui y sont décrites. Si vous ne souhaitez pas installer le paquet vous-même, il vous suffit de décommenter (supprimer le `#`) les lignes contenant paddlepaddle(gpu) et paddleocr. Tout cela se fait à vos propres risques et périls. Pour moi (bropines) et deux testeurs, tout s'est bien installé, mais vous pourriez rencontrer une erreur. Signalez-la dans le ticket et identifiez-moi.
-* Ajouté [OneOCR](https://github.com/b1tg/win11-oneocr). Modèle WINDOWS local provenant des applications SnippingTOOL ou Win.PHOTOS. Pour l'utiliser, vous devez placer les fichiers du modèle et les fichiers DLL dans le dossier « data/models/one-ocr ». Avant de lancer le programme, il est préférable de copier tous les fichiers en une seule fois. Pour savoir comment trouver et obtenir les fichiers DLL et les fichiers de modèle, consultez : https://github.com/dmMaze/BallonsTranslator/discussions/859#discussioncomment-12876757 . Merci à AuroraWright pour le projet [OneOCR](https://github.com/AuroraWright/oneocr)
-
-## Retouche
-  * AOT provient de [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
-  * Tous les lama* sont affinés à l'aide de [LaMa](https://github.com/advimman/lama)
-  * PatchMatch est un algorithme issu de [PyPatchMatch](https://github.com/vacancy/PyPatchMatch), ce programme utilise une [version modifiée](https://github.com/dmMaze/PyPatchMatchInpaint)
-  
-## Traducteurs
-
-Traducteurs disponibles : Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu, Papago et Yandex.
-
-* Vous trouverez des informations sur les modules Traducteurs [ici](../doc/modules/translators.md). *(Anglais)*
-
-## FAQ & Divers
-* Si vous avez une carte Nvidia ou une puce Apple, l’accélération matérielle sera activée.
-* Ajout de la prise en charge de [saladict](https://saladict.crimx.com) (*Dictionnaire contextuel et traducteur de pages professionnel tout-en-un*) dans le mini-menu lors de la sélection de texte. [Guide d'installation](../doc/saladict_fr.md)
-* Accélérez les performances si vous disposez d'un périphérique [NVIDIA's CUDA](https://pytorch.org/docs/stable/notes/cuda.html) ou [AMD's ROCm](https://pytorch.org/docs/stable/notes/hip.html), car la plupart des modules utilisent [PyTorch](https://pytorch.org/get-started/locally/).
-* Les polices proviennent des polices de votre système.
-* Merci à [bropines](https://github.com/bropines) pour l'adaptation en russe.
-* Ajout du script JSX « Export vers Photoshop » par [bropines](https://github.com/bropines). </br> Pour lire les instructions, améliorer le code et simplement explorer son fonctionnement, rendez-vous dans `scripts/export vers Photoshop` -> `install_manual.md`.
+- Voir `CONTRIBUTING.md`.
+- Garder les traductions synchronisées avec `README.md` et `README_zh_CN.md`.

--- a/doc/README_HU.md
+++ b/doc/README_HU.md
@@ -1,0 +1,37 @@
+# BallonsTranslator Pro
+
+> Ez a fájl a `README.md` és `README_zh_CN.md` tartalmához lett igazítva (frissítve: 2026-05-18).
+
+## Áttekintés
+
+A BallonsTranslator Pro képregények/képek fordítására szolgál OCR → fordítás → szövegkorrekció → renderelés folyamattal.
+
+## Fő funkciók
+
+- Kötegelt feldolgozás manga/manhua/manhwa és általános képekhez.
+- Helyi és felhős OCR motorok (PaddleOCR, MangaOCR, EasyOCR, LLM/VLM OCR stb.).
+- Automatikus fordítás LLM és MT szolgáltatókkal.
+- Buborék-, maszk-, stílus- és betűszerkesztés.
+- Renderelés és export (SVG/felirat támogatással, ahol elérhető).
+- Teljesítményhangolás (GPU/VRAM/opcionális modellek).
+
+## Gyors telepítés
+
+1. Klónozd a repót.
+2. Telepítsd a függőségeket: `pip install -r requirements.txt`.
+3. Indítás: `python launch.py`.
+
+Windows szkriptek: `launch_win.bat`, `build_windows_installer.bat`.
+
+## Dokumentáció
+
+Lásd a `docs/` mappát fordítási, GPU, inpainting/renderelési, videó/felirat témákhoz.
+
+## Támogatott felületi nyelvek
+
+English (`en_US`), 简体中文 (`zh_CN`), Español (`es_MX`), Français (`fr_FR`), Português (Brasil) (`pt_BR`), Русский (`ru_RU`), 한국어 (`ko_KR`), Magyar (`hu_HU`).
+
+## Közreműködés
+
+- Lásd: `CONTRIBUTING.md`.
+- Tartsd szinkronban a fordításokat a `README.md` és `README_zh_CN.md` frissítéseivel.

--- a/doc/README_ID.md
+++ b/doc/README_ID.md
@@ -1,150 +1,52 @@
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | Indonesia | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+# BallonsTranslator-Pro
+[简体中文](/README.md) | [English](/README.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md) | [Magyar](../doc/README_HU.md)
 
-Sebuah aplikasi penerjemahan komik/manga yang dibantu oleh deep learning.
+BallonsTranslator-Pro adalah fork lanjutan dari [dmMaze/BallonsTranslator](https://github.com/dmMaze/BallonsTranslator) untuk alur kerja terjemahan manga/komik yang serius.
 
-<img src="./src/ui0.jpg" div align=center>
+## Ringkasan alur
 
-<p align=center>
-pratinjau
-</p>
+1. Deteksi balon/area teks
+2. OCR teks
+3. Terjemahkan teks
+4. Hapus teks asli dari artwork (inpaint)
+5. Edit dan ekspor halaman
 
-# Fitur
-* Terjemahan otomatis  
-  - Mendukung pendeteksian, pengenalan, penghapusan, dan penerjemahan teks secara otomatis, performa keseluruhan bergantung pada modul-modul ini.
-  - Peletakkan kata-kata berdasarkan perkiraan letak teks aslinya.
-  - Mendukung format manga dan komik.
-  - Typesetting optimal untuk manga->bahasa Inggris, bahasa Inggris->Mandarin (berdasarkan ekstraksi daerah balon.).
-  
-* Pengeditan gambar  
-  - Mendukung pengeditan mask & inpainting (seperti alat content aware fill di PS) 
-  - Mendukung gambar dengan rasio aspek ekstrim seperti webtoon
-  
-* Pengeditan teks  
-  - Mendukung format rich text dan style teks, teks yang diterjemahkan dapat diedit secara langsung.
-  - Mendukung pencarian & penggantian kata
-  - Mendukung ekspor/impor ke/dari dokumen word
+- Riwayat perubahan: [docs/CHANGELOG.md](../docs/CHANGELOG.md)
 
-# Instalasi
+## Mulai cepat
 
-**Pengguna Windows** dapat unduh Ballonstranslator-x.x.x-core.7z di [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) atau [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) (catatan: Anda juga perlu mengunduh Ballonstranslator-1.3.xx terbaru di rilis GitHub mengekstraknya untuk menimpa **Ballontranslator-1.3.0-core** atau instalasi yang lebih lama agar aplikasi dapat diperbarui.)
+- **Windows (disarankan):** jalankan `launcher.bat`.
+- **Windows cepat:** jalankan `launch_win.bat`.
+- **Lintas platform:** `python launch.py`.
+- Panduan GPU: [docs/GPU_ACCELERATION.md](../docs/GPU_ACCELERATION.md).
 
-## Jalankan kode sumber
+## Instal Google Fonts (di aplikasi)
 
-```bash
-# Clone repo ini
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+1. **Tools → Models → Install Google Font...**
+2. Masukkan nama font (mis. `Bangers`, `Noto Sans JP`).
+3. Font akan diunduh dan didaftarkan otomatis ke `fonts/google/`.
 
-# instal requirements_macOS.txt di macOS
-$ pip install -r requirements.txt
-```
+## Cara clone / download
 
-Instal pytorch-cuda untuk dapat akselerasi GPU jika Anda memiliki GPU NVIDIA.
+- ZIP dari GitHub (**Code → Download ZIP**), lalu jalankan app.
+- Atau:
 
 ```bash
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu116
+git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro
+cd BallonsTranslator-Pro
+python launch.py
 ```
 
-Unduhlah folder **data** dari [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) atau [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) dan pindahkan ke dalam BallonsTranslator/ballontranslator, akhirnya jalankan
-```bash
-python ballontranslator
-```
+## Persyaratan
 
-Untuk pengguna Linux atau MacOS, lihat [script ini](ballontranslator/scripts/download_models.sh) dan jalankan untuk mengunduh semua model
+- Python 3.10.2+
+- Internet untuk setup/model pertama
+- Ruang disk yang cukup untuk model
 
-Untuk menggunakan Sugoi translator (hanya bahasa Jepang-Inggris), unduh [offline model](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm), pindahkan "sugoi_translator" ke dalam BallonsTranslator/ballontranslator/data/models.
+## Dokumen penting
 
-# Penggunaan
-**Disarankan untuk menjalankan program di terminal jika program ini crash dan tidak meninggalkan informasi, lihat gif berikut ini**
-<img src="./src/run.gif">  
-
-- Pilih penerjemah yang diinginkan dan atur sumber dan target bahasa. 
- - Buka folder yang berisi gambar manga/manhua/webtoon yang ingin diterjemahkan.
- - Klik tombol "Run" dan tunggu hingga proses selesai.
-
-
-Format font seperti ukuran font dan warna ditentukan oleh program secara otomatis dalam proses ini, Anda dapat menentukan format tersebut sebelum memulai proses dengan mengubah opsi yang sesuai dari "decide by program" menjadi "use global setting" di panel konfigurasi->Lettering. (pengaturan global adalah format yang ditampilkan oleh panel format font yang tepat ketika Anda tidak mengedit blok teks apa pun di adegan)
-
-## Image editing
-
-### inpaint tool
-<img src="./src/imgedit_inpaint.gif">
-<p align = "center">
-Mode pengeditan gambar, alat inpainting
-</p>
-
-### rect tool
-<img src="./src/rect_tool.gif">
-<p align = "center">
-Alat rect
-</p>
-
-Untuk 'menghapus' hasil inpainting yang tidak diinginkan, gunakan alat inpainting atau alat rect dengan menekan **tombol kanan**.  
-Hasilnya tergantung pada seberapa akurat algoritme ("metode 1" dan "metode 2" dalam gif) mengekstrak mask dari teks. Ini berjalan lebih buruk pada teks & latar belakang yang kompleks.
-
-## Pengeditan teks
-<img src="./src/textedit.gif">
-<p align = "center">
-Mode Pengeditan teks
-</p>
-
-<img src="./src/multisel_autolayout.gif" div align=center>
-<p align=center>
-pemformatan kumpulan tata letak teks secara otomatis
-</p>
-
-<img src="./src/ocrselected.gif" div align=center>
-<p align=center>
-pengenalan kata & menerjemahkan area yang dipilih
-</p>
-
-## Shortcuts
-* ```A```/```D``` atau ```pageUp```/```Down``` untuk pindah halaman.
-* ```Ctrl+Z```, ```Ctrl+Shift+Z``` untuk undo/redo.(catatan: sejarah undo akan dihapus setelah pindah halaman)
-* ```T``` untuk masuk mode text-editting (atau tombol "T" di toolbar bagian bawah).
-*```W``` untuk masuk mode pembuatan text block, lalu seret mouse dengan diklik tombol kanan pada kanvas untuk menambahkan blok teks baru. (lihat gif pengeditan teks)
-* ```P``` untuk mode edit gambar.  
-* Di mode edit gambar, gunakan penggeser di bagian kanan bawah untuk mengontrol transparansi gambar asli.
-* Tombol "OCR" dan "A" di toolbar bagian bawah dapat mengaktifkan OCR dan penerjemahan, jika Anda menonaktifkannya, program hanya akan melakukan deteksi dan penghapusan teks.
-* Mengatur parameter modul otomatis di panel konfigurasi.  
-* ```Ctrl++```/```Ctrl+-``` untuk mengubah ukuran gambar
-* ```Ctrl+G```/```Ctrl+F``` untuk mencari secara global/dalam halaman saat ini.
-
-<img src="./src/configpanel.png">  
-
-
-# Modul otomasi
-Proyek ini sangat bergantung pada [manga-image-translator](https://github.com/zyddnys/manga-image-translator), layanan online dan pelatihan model tidaklah murah, mohon pertimbangkan untuk menyumbangkan proyek ini:  
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>  
-
-Sugoi translator dibuat oleh [mingshiba](https://www.patreon.com/mingshiba).
-  
-## Deteksi teks
-Deteksi teks bahasa Inggris dan Jepang, kode pelatihan, dan rincian lebih lanjut dapat ditemukan di [comic-text-detector](https://github.com/dmMaze/comic-text-detector)
-
-## OCR
-* Model pengenalan teks mit_32px berasal dari manga-image-translator, mendukung pengenalan teks bahasa Inggris dan Jepang dan warna teks.
- * Model pengenalan teks mit_48px berasal dari manga-image-translator, mendukung pengenalan teks bahasa Inggris, Jepang, dan Korea serta warna teks.
- * [manga_ocr] (https://github.com/kha-white/manga-ocr) berasal dari [kha-white] (https://github.com/kha-white),  pengenalan untuk teks bahasa Jepang, dengan fokus utama manga Jepang.
-
-## Inpainting
-  * AOT berasal dari manga-image-translator.
-  * patchmatch adalah sebuah algoritma dari [PyPatchMatch](https://github.com/vacancy/PyPatchMatch), program ini menggunakan [versi dimodifikasi](https://github.com/dmMaze/PyPatchMatchInpaint) dari saya.
-  
-
-## Penerjemah
-
- * <s> Harap ubah url penerjemah goolge dari *.cn ke *.com jika Anda tidak diblokir oleh GFW. </s> Google mematikan layanan terjemahan di Cina, harap setel 'url' yang sesuai di panel konfigurasi ke *.com.
- * Penerjemah Caiyun perlu memerlukan [token] (https://dashboard.caiyunapp.com/).
- * Papago.
- * DeepL & Sugoi translator (dan konversi CT2 Translation-nya), terima kasih kepada [Snowad14](https://github.com/Snowad14).
-
-Untuk menambahkan penerjemah baru, silakan lihat [how_to_add_new_translator](doc/how_to_add_new_translator.md), caranya mudah, cukup dengan membuat subclass dari BaseClass dan mengimplementasikan dua interface, kemudian Anda bisa menggunakannya di dalam aplikasi, Anda dipersilakan untuk berkontribusi pada proyek ini.  
-
-
-## Hal lain
-* Jika komputer Anda memiliki GPU Nvidia, program ini akan mengaktifkan akselerasi cuda untuk semua model secara default dan membutuhkan sekitar 6G memori GPU, Anda dapat menurunkan inpaint_size pada panel konfigurasi untuk menghindari OOM. 
-* Terima kasih kepada [bropines] (https://github.com/bropines) untuk lokalisasi bahasa Rusia.  
-* Menambahkan [saladict](https://saladict.crimx.com) (*Kamus pop-up dan penerjemah halaman profesional lengkap*) di menu mini ketika pilih teks. [Panduan instalasi](doc/saladict.md)
+- [docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md)
+- [docs/QUALITY_RANKINGS.md](../docs/QUALITY_RANKINGS.md)
+- [docs/MODELS_REFERENCE.md](../docs/MODELS_REFERENCE.md)
+- [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](../docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
+- [docs/INDESIGN_LPTXT_WORKFLOW.md](../docs/INDESIGN_LPTXT_WORKFLOW.md)

--- a/doc/README_JA.md
+++ b/doc/README_JA.md
@@ -1,135 +1,49 @@
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | 日本語 | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+# BallonsTranslator-Pro
+[简体中文](/README.md) | [English](/README.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md) | [Magyar](../doc/README_HU.md)
 
-ディープラーニングを活用したマンガ翻訳支援ツール。
+BallonsTranslator-Pro は [dmMaze/BallonsTranslator](https://github.com/dmMaze/BallonsTranslator) の発展フォークで、本格的な漫画翻訳ワークフロー向けです。
 
-<img src="./src/ui0.jpg" div align=center>
+## ワークフロー概要
 
-<p align=center>
-プレビュー
-</p>
+1. 吹き出し/テキスト領域の検出
+2. OCR 認識
+3. 翻訳
+4. 原文の除去（inpaint）
+5. 編集と書き出し
 
-# 特徴
-* 完全自動翻訳
-  - 自動テキスト検出、認識、削除、翻訳をサポートし、全体的な性能はこれらのモジュールに依存します。
-  - 文字配置は、原文の書式推定に基づいています。
-  - 漫画やコミックでまともに動作します。
-  - マンガ->英語、英語->中国語の組版が改善されました（バルーン領域の抽出に基づく）。
+- 変更履歴: [docs/CHANGELOG.md](../docs/CHANGELOG.md)
 
-* 画像編集
-  マスク編集とインペイントのサポート（PSのスポットヒーリングブラシツールのようなもの）
+## クイックスタート
 
-* テキストの編集
-  リッチテキストフォーマットをサポートし、翻訳されたテキストはインタラクティブに編集することができます。
+- **Windows（推奨）:** `launcher.bat`
+- **Windows簡易起動:** `launch_win.bat`
+- **クロスプラットフォーム:** `python launch.py`
+- GPU: [docs/GPU_ACCELERATION.md](../docs/GPU_ACCELERATION.md)
 
-# 使用方法
+## Google Fonts のインストール（アプリ内）
 
-Windowsユーザーは、[腾讯云](https://share.weiyun.com/xoRhz9i4)または[MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) or [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)(note: you also need to download latest Ballonstranslator-1.3.xx from GitHub release and extract it to overwrite **Ballontranslator-1.3.0-core** or older installation to get the app updated.)
+1. **Tools → Models → Install Google Font...**
+2. フォントファミリー名を入力
+3. `fonts/google/` に自動登録
 
-## ソースコードの実行
-
-```bash
-# このリポジトリのクローン
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
-
-# macOSの場合、requirements_macOS.txtをインストール
-$ pip install -r requirements.txt
-```
-
-NVIDIA GPUをお持ちの場合、GPUアクセラレーションを有効にするためにpytorch-cudaをインストールします。
+## クローン / ダウンロード
 
 ```bash
-pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu116
+git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro
+cd BallonsTranslator-Pro
+python launch.py
 ```
 
-[MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) or [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)  から **data** フォルダをダウンロードし、BallonsTranslator/ballontranslatorに移動して、最後に以下を実行します
-```bash
-python ballontranslator
-```
+## 必要条件
 
+- Python 3.10.2+
+- 初回セットアップ/モデル取得用のネット接続
+- モデル保存用のディスク容量
 
-Sugoi Translator（日英のみ）を使用するには、[オフラインモデル](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm)をダウンロードし、"sugoi_translator"をBallonsTranslator/ballontranslator/data/modelsに移動してください。
+## 主要ドキュメント
 
-## 完全自動翻訳
-**万が一、プログラムがクラッシュして情報が残らなかった場合に備えて、以下のgifを参考に、ターミナルで実行することをお勧めします。**また、初回実行時に希望するトランスレータを選択し、ソース言語とターゲット言語を設定してください。翻訳が必要な画像が入ったフォルダを開き、
-「実行」ボタンをクリックして処理が完了するのを待ちます。
-<img src="./src/run.gif">
-
-このとき、フォントサイズや色などのフォントフォーマットはプログラムによって自動的に決定されますが、panel->Letteringで、対応するオプションを"decide by program"から"use global setting"に変更すれば、これらのフォーマットを事前に決定できます（グローバル設定とは、シーン内の
-テキストブロックを編集していないときに右フォントフォーマットパネルで表示されるフォーマットのことです）。
-
-## 画像編集
-
-### 修復ツール
-<img src="./src/imgedit_inpaint.gif">
-<p align = "center">
-画像編集モード、修復ツール
-</p>
-
-### 長方形ツール
-<img src="./src/rect_tool.gif">
-<p align = "center">
-長方形ツール
-</p>
-
-不要なインペイント結果を"消去"するには、**右ボタン**を押した状態でインペイントツールまたは矩形ツールを使用します。
-結果はアルゴリズム(gifの"方法1"と"方法2")がどれだけ正確にテキストマスクを抽出するかに依存します。複雑なテキストと背景の場合、パフォーマンスが低下する可能性があります。
-
-## テキスト編集
-<img src="./src/textedit.gif">
-<p align = "center">
-テキスト編集モード
-</p>
-
-<img src="./src/multisel_autolayout.gif" div align=center>
-<p align=center>
-テキストの一括書式設定と自動レイアウト
-</p>
-
-## ショートカット
-* A/D または pageUp/Down でページをめくります。
-* Ctrl+Z, Ctrl+Y でほとんどの操作を元に戻す/やり直すことができます。
-* T でテキスト編集モード、（または下部のツールバーの「T」ボタン）W を押してテキストブロック作成モードを起動し、右ボタンをクリックしたままキャンバス上でマウスをドラッグすると、新しいテキストブロックが追加されます。(テキスト編集のgifを参照）。
-* Pで画像編集モードへ。
-* 画像編集モードでは、右下のスライダーでオリジナル画像の透明度を調整します。
-* 下のツールバーの「OCR」と「A」ボタンは、OCRと翻訳を有効にするかどうかを制御し、それらを無効にした場合、プログラムはテキストの検出と削除を行いますだけです。
-* 設定パネルで自動モジュールのパラメータを設定します。
-* 画像のサイズを変更するには、Ctrl + +/。
-
-<img src="./src/configpanel.png">
-
-
-# Automation modules
-このプロジェクトは[manga-image-translator](https://github.com/zyddnys/manga-image-translator)に大きく依存しており、オンラインサービスやモデルトレーニングは安くないので、プロジェクトの寄付を検討してください:
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>
-
-Sugoi translatorは、[mingshiba](https://www.patreon.com/mingshiba)によって作成されています。
-
-## 文字検出
-英語と日本語のテキスト検出をサポートし、学習コードと詳細は[comic-text-detector](https://github.com/dmMaze/comic-text-detector)に掲載されています
-
-## OCR
- * mit_32pxのテキスト認識モデルは、manga-image-translatorのもので、英語と日本語の認識とテキスト色の抽出をサポートしています。
- * mit_48pxのテキスト認識モデルは、manga-image-translatorのもので、英語、日本語、韓国語の認識とテキストカラーの抽出をサポートしています。
- * [manga_ocr](https://github.com/kha-white/manga-ocr)は[kha-white](https://github.com/kha-white)からです、
-
-## 修復
-  * AOTは、manga-image-translatorからです
-  * patchmatchは[PyPatchMatch](https://github.com/vacancy/PyPatchMatch)のnondl algrithomで、このプログラムは私による[修正版](https://github.com/dmMaze/PyPatchMatchInpaint)を使用しています。
-
-
-## 翻訳者
-
- * GFW によってブロックされていない場合は、goolge トランスレータの URL を *.cn から *.com に変更してください。
- * Caiyunの翻訳者は[token](https://dashboard.caiyunapp.com/)を必要とします
- * papago
- * DeepL & Sugoi translator(およびCT2変換)、[Snowad14](https://github.com/Snowad14)に感謝します
-
- 新しいトランスレータを追加するには、[how_to_add_new_translator](doc/how_to_add_new_translator.md)を参照してください。これはBaseClassをサブクラスにして、2つのインターフェースを実装するだけでアプリケーションで使用できますので、プロジェクトへのコントリビュートは歓迎します。
-
-
-## その他
-* あなたのコンピュータにNvidia GPUがある場合、プログラムはデフォルトですべてのモデルのcudaアクセラレーションを有効にし、およそ6G GPUメモリを必要とします。
-* ロシア語のローカライズを担当した[bropines](https://github.com/bropines)に感謝します。
+- [docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md)
+- [docs/QUALITY_RANKINGS.md](../docs/QUALITY_RANKINGS.md)
+- [docs/MODELS_REFERENCE.md](../docs/MODELS_REFERENCE.md)
+- [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](../docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
+- [docs/INDESIGN_LPTXT_WORKFLOW.md](../docs/INDESIGN_LPTXT_WORKFLOW.md)

--- a/doc/README_KO.md
+++ b/doc/README_KO.md
@@ -1,252 +1,37 @@
-> [!IMPORTANT]  
-> **번역 결과물을 공개적으로 공유할 때 숙련된 번역가가 번역이나 교정에 참여하지 않았다면, 기계 번역임을 잘 보이는 곳에 표시해 주세요.**
+# BallonsTranslator Pro
 
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | 한국어 | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+> 이 문서는 `README.md` 및 `README_zh_CN.md`와 동기화되었습니다(2026-05-18 기준).
 
-딥러닝으로 구동되는 또 다른 컴퓨터 지원 만화/만화 번역 툴.
+## 개요
 
-<img src="./src/ui0.jpg" div align=center>
+BallonsTranslator Pro는 OCR → 번역 → 텍스트 보정 → 렌더링 파이프라인으로 만화/이미지를 번역하는 도구입니다.
 
-<p align=center>
-미리보기
-</p>
+## 주요 기능
 
-# 특징
-* 완전 자동화된 번역
-  - 자동 텍스트 감지, 인식, 제거 및 번역을 지원합니다. 전반적인 성능은 이러한 모듈에 따라 좌우집니다.
-  - 대사는 원본 텍스트의 서식 추정치를 기반으로 합니다.
-  - 망가와 코믹스 등을 작업할 수 있습니다.
-  - 영어-중국어 및 일본어-영어 조판이 최적화되었습니다. 텍스트 레이아웃은 추출된 배경 풍선을 기반으로 합니다. 중국어 문장은 pkuseg를 기반으로 분할됩니다. 일본어 번역의 세로 레이아웃이 개선되었습니다.
+- 만화/이미지 일괄 처리 워크플로우.
+- 로컬/클라우드 OCR(PaddleOCR, MangaOCR, EasyOCR, LLM/VLM OCR 등).
+- LLM/MT 기반 자동 번역.
+- 말풍선/마스크/텍스트 스타일/폰트 편집.
+- 렌더링 및 내보내기(SVG/자막 워크플로우 포함).
+- 성능 제어(GPU/VRAM/선택 모델).
 
-* 이미지 편집
-  - 마스크 편집 & 인페인팅 지원 (PS에 있는 스팟 힐링 브러쉬 툴 같이)
-  - 웹툰과 같은 길다란 이미지도 편집 가능합니다
+## 빠른 설치
 
-* 텍스트 편집
-  - 풍부한 텍스트 포맷 지원 [텍스트 스타일 프리셋](https://github.com/dmMaze/BallonsTranslator/pull/311) 및, 번역된 텍스트는 대화형으로 편집할 수 있습니다.
-  - 찾기 & 바꾸기 지원
-  - 워드 문서를 불러오기/내보내기 지원
+1. 저장소 클론
+2. `pip install -r requirements.txt`
+3. `python launch.py`
 
-# 설치
+Windows 스크립트: `launch_win.bat`, `build_windows_installer.bat`.
 
-## Windows에서
-Python 및 Git을 직접 설치하고 싶지 않으며 인터넷이 가능하다면:
-다음 링크에서 BallonsTranslator_dev_src_with_gitpython.7z 를 다운로드 하세요. [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) or [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) 그 후 launch_win.bat 를 실행합니다.
-scripts/local_gitpull.bat를 실행하여 최신 업데이트를 받으세요.
-이 제공된 패키지는 Windows 7에서 실행할 수 없습니다. Win 7 사용자는 [Python 3.8](https://www.python.org/downloads/release/python-3810/)를 설치하고 소스 코드를 실행해야합니다.
+## 문서
 
-## 소스 코드를 실행
+`docs/` 폴더에서 번역, GPU, 인페인팅/렌더링, 비디오/자막 문서를 확인하세요.
 
-[Python] 설치 (https://www.python.org/downloads/release/python-31011) **<= 3.12** (Microsoft 스토어에서 설치 한 것을 사용하지 마세요) 및 [Git](https://git-scm.com/downloads).
+## 지원 UI 언어
 
-```bash
-# 이 레포 복사
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+English (`en_US`), 简体中文 (`zh_CN`), Español (`es_MX`), Français (`fr_FR`), Português (Brasil) (`pt_BR`), Русский (`ru_RU`), 한국어 (`ko_KR`), Magyar (`hu_HU`).
 
-# 앱 실행
-$ python3 launch.py
-```
+## 기여
 
-처음 시작하면 필요한 라이브러리 및 모델을 자동으로 다운로드 하여 설치합니다. 다운로드가 실패한 경우, 다음 링크에서 **data** 폴더(또는 터미널에 표기된 누락된 파일)를 다운로드해야 합니다. [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) 또는 [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) 그리고 해당되는 소스코드 폴더에 저장하세요.
-
-## macOS 애플리케이션 빌드 (Intel 및 Apple 실리콘 칩 모두 호환)
-<i>Note macOS는 작동하지 않을 경우 소스 코드를 실행할 수 있습니다.</i>
-
-![녹화화면2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
-
-#### 1. 준비
--   다음 링크에서 라이브러리 및 모델을 다운로드 합니다. [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw "MEGA") 또는 [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)
-
-
-<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  다운로드한 모든 리소스를 data 폴더에 넣습니다. 최종 디렉터리 트리 구조는 다음과 같습니다:
-
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 디렉토리, 23 파일
-```
-
--  파이썬 버전들을 관리하기 위해 pyenv 명령줄 도구를 설치합니다. 홈브류를 통해 설치하는 것을 추천합니다.
-```
-# 홈브류를 통해 설치합니다.
-brew install pyenv
-
-# 공식 스크립트를 통해 설치합니다.
-curl https://pyenv.run | bash
-
-# 설치 후 셀 환경변수를 설정합니다.
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-
-#### 2、응용 프로그램 빌드
-```
-# 작업 경로인 `data` 입력
-cd data
-
-# 레포의 `dev` 브렌치를 복제합니다
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# 작업 경로인 `BallonsTranslator` 를 입력합니다
-cd BallonsTranslator
-
-# 빌드 스크립트를 실행하면, pyinstaller 단계에서 비밀번호를 물어봅니다. 비밀번호를 입력하고 엔터를 누릅니다.
-sh scripts/build-macos-app.sh
-```
-> 📌패키지 응용 프로그램은 ./data/BallonsTranslator/dist/BallonsTranslator.app 에 있으며, macOS 애플리케이션 폴더에 앱을 드래그하여 설치합니다. 추가 Python config 없이  사용할 수 있습니다.
-
-
-</details> 
-
-# 사용법
-
-**충돌시 관련 정보를 남기기 위해 터미널 에서 프로그램을 실행하는 것이 좋습니다. 다음 GIF를 참조하십시오.**
-<img src="./src/run.gif">  
-- 프로그램을 처음 실행하는 경우, 설정 아이콘을 클릭하여 번역기를 선택하고 소스 및 대상 언어를 설정하십시오.
-- 폴더 아이콘을 클릭하여 번역이 필요한 만화(코믹,망가 등)의 이미지를 포함하는 폴더를 엽니다.
-- '실행`버튼을 클릭하고 프로세스를 완료합니다.
-
-이 과정에서 글꼴 크기 및 색상과 같은 글꼴 형식은 프로그램에 의해 자동으로 결정되며, 설정 패널->글꼴 설정에서 해당 옵션을 “프로그램이 결정”에서 “전역 설정 사용”으로 변경하여 해당 형식을 미리 결정할 수 있습니다. (전역 설정은 장면에서 텍스트 블록을 편집하지 않을 때 오른쪽 글꼴 형식 패널에 표시되는 스타일 입니다.)
-<img src="./src/global_font_format.png">  
-
-## 이미지 편집
-
-### 인페인트 도구
-<img src="./src/imgedit_inpaint.gif">
-<p align = "center">
-이미지 편집 모드, 인페인팅 도구
-</p>
-
-### 글상자 도구
-<img src="./src/rect_tool.gif">
-<p align = "center">
-글상자 도구
-</p>
-
-원하지 않는 칠한 결과를 '지우려면' **오른쪽 버튼**을 누른 상태에서 인페인팅 도구 또는 글상자 도구를 사용합니다.  
-결과는 알고리즘('방법 1' 및 '방법 2'의 GIF)이 텍스트 마스크를 얼마나 정확하게 추출하는지에 따라 달라집니다. 복잡한 텍스트 및 배경에서는 성능이 저하될 수 있습니다.  
-
-## 텍스트 편집
-<img src="./src/textedit.gif">
-<p align = "center">
-텍스트 편집 모드
-</p>
-
-<img src="./src/multisel_autolayout.gif" div align=center>
-<p align=center>
-일괄 텍스트 포맷팅 및 자동 레이아웃
-</p>
-
-<img src="./src/ocrselected.gif" div align=center>
-<p align=center>
-선택 영역 OCR 및 번역
-</p>
-
-## 단축키
-* ```A```/```D``` 및 ```pageUp```/```Down``` 으로 페이지를 이동합니다.
-* ```Ctrl+Z```, ```Ctrl+Shift+Z``` 로 대부분의 작업을 취소합니다. (페이지를 이동하면 작업을 취소할 수 없음에 유의하세요)
-* ```T``` 를 눌러 텍스트 편집 모드로 전환합니다(또는 하단 도구 모음의 “T” 버튼).
-* ```W``` 를 눌러 텍스트 블록 생성 모드를 활성화 합니다. 오른쪽 버튼을 클릭한 상태에서 마우스를 캔버스 위로 드래그하여 새 텍스트 블록을 추가합니다. (텍스트 편집 GIF 참조)
-* ```P``` 를 눌러 이미지 편집 모드로 전환합니다.  
-* 이미지 편집 모드에서 오른쪽 하단의 슬라이더를 사용하여 원본 이미지의 투명도를 조절합니다.
-* 제목 표시줄->실행에서 자동 모듈을 활성화하거나 비활성화할 수 있으며, 모든 모듈을 비활성화한 상태로 실행하면 해당 설정에 따라 모든 텍스트가 다시 레터링되고 다시 렌더링됩니다.  
-* 설정 패널에서 자동 모듈의 매개변수를 설정합니다. 
-* ```Ctrl++```/```Ctrl+-``` (또는 ```Ctrl+Shift+=```) 로 이미지 크기를 조절합니다
-* ```Ctrl+G```/```Ctrl+F``` 로 모든페이지 혹은 현재페이지 내에서 검색합니다.
-* ```0-9``` 로 텍스트 레이어의 불투명도를 조정합니다.
-* 텍스트 스타일: 두껍게 - ```Ctrl+B```, 밑줄 - ```Ctrl+U```, 이탤릭 - ```Ctrl+I``` 
-* 텍스트 스타일 패널 -> 효과에서 텍스트 그림자 및 투명도를 설정합니다.  
-* ```Alt+Arrow Keys``` 및 ```Alt+WASD``` (또는 텍스트 편집 모드에서 ```pageDown``` 및 ```pageUp```) 로 텍스트 블록 사이를 전환합니다.
-  
-<img src="./src/configpanel.png">
-
-## 헤드리스 모드 (GUI 없이 실행)
-``` python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-메모: 설정(원본 언어, 목표 언어, 인페인트 모델 등등)은 config/config.json에서 로드합니다.
-렌더링 된 글꼴 크기가 맞지 않다면, ```--ldpi ```를 통해 DPI를 수동으로 지정하세요. 보편적인 값은 96 및 72입니다.
-
-
-# 자동화 모듈
-이 프로젝트는 [manga-image-translator](https://github.com/zyddnys/manga-image-translator)에 크게 의존합니다. 온라인 서비스 및 모델 교육은 저렴하지 않으며 프로젝트 기부를 고려하십시오.
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>  
-
-[Sugoi translator](https://sugoitranslator.com/)는 [mingshiba](https://www.patreon.com/mingshiba)에 의해 개발되었습니다.
-
-## 텍스트 검출
- * 영어 및 일본어의 텍스트 감지를 지원하며, 훈련 코드 및 자세한 내용은 [comic-text-detector](https://github.com/dmMaze/comic-text-detector)에서 확인할 수 있습니다.
-* [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/)의 텍스트 감지를 지원합니다. 사용자 이름과 비밀번호는 입력해야 하며, 매 프로그램 실행 시 자동으로 로그인 됩니다.
-
-   * 자세한 지침에 대해서는 **Tuanzi OCR 지침**: ([Chinese](./团子OCR说明.md) & [Brazilian Portuguese](./Manual_TuanziOCR_pt-BR.md) 만)
-## OCR
- * 모든 mit* 모델은 manga-image-translator 에 기반하며, 영어, 일본어 및 한국어의 인식 및 텍스트 색상 추출을 지원합니다.
- * [kha-white](https://github.com/kha-white) 의 [manga_ocr](https://github.com/kha-white/manga-ocr) 는 , 일본어의 텍스트 인식을 수행하며, 일본어 만화의 초점을 맞췄습니다.
- * [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/) 를 사용한 텍스트 감지를 지원합니다. 사용자 이름과 비밀번호는 입력해야 하며, 매 프로그램 실행 시 자동으로 로그인 됩니다.
-   * 현재 구현은 각 텍스트 블록에 OCR을 개별적으로 사용하며, 속도가 느리고 정확도가 크게 향상되지 않습니다. 추천되지 않습니다. 필요한 경우, 대신 Tuanzi Detector를 사용하십시오.
-   * 텍스트 감지에 대한 Tuanzi 검출기를 사용하는 경우, OCR을 none_ocr로 설정하여 텍스트, 저장 시간을 직접 읽고 요청의 수를 줄이는 것이 좋습니다.
-   * 자세한 지침에 대해서는 **Tuanzi OCR 지침**: ([Chinese](./团子OCR说明.md) & [Brazilian Portuguese](./Manual_TuanziOCR_pt-BR.md) 만)
-* “선택적” PaddleOCR 모듈이 추가되었습니다. 디버그 모드에서는 이 모듈이 없다는 메시지가 표시됩니다. 여기에 설명된 지침에 따라 간단히 설치할 수 있습니다. 패키지를 직접 설치하지 않으려면 paddlepaddle(gpu) 및 paddleocr 줄의 주석(`#` 제거)을 해제하면 됩니다. 자신의 위험과 위험을 감수하고 모든 것을 베팅하세요. 저(브로핀)와 두 명의 테스터에게는 모든 것이 정상적으로 설치되었으므로 오류가 있을 수 있습니다. 이슈에 글을 작성하고 저를 태그하세요.
-
-## 소개
-  * AOT는 [manga-image-translator](https://github.com/zyddnys/manga-image-translator) 에 기반합니다.
-  * 모든 lama*는 [LaMa](https://github.com/advimman/lama) 를 사용하여 파인튜닝 되었습니다.
-  * PatchMatch는 [PyPatchMatch](https://github.com/vacancy/PyPatchMatch) 의 알고리즘입니다. 이 프로그램은 [modified version](https://github.com/dmMaze/PyPatchMatchInpaint)을 사용합니다.
-
-
-## 번역기
-가능한 번역기: Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu. Papago 및 Yandex.
- * Google은 중국의 번역 서비스를 종료하였으니, 설정 패널에서 해당 'URL'을 *.com으로 설정하세요.
- * [Caiyun](https://dashboard.caiyunapp.com/), [ChatGPT](https://platform.openai.com/playground), [Yandex](https://yandex.com/dev/translate/), [Baidu](http://developers.baidu.com/), 및 [DeepL](https://www.deepl.com/docs-api/api-access) 번역기는 토큰 혹은 api 키를 요구합니다.
- * DeepL & Sugoi 번역기 (그리고 그것은 CT2 번역 변환입니다) [Snowad14](https://github.com/Snowad14) 에게 감사를 표합니다.
- * Sugoi는 완전히 오프라인으로 일본어를 영어로 번역합니다. [오프라인 모델](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm) 을 다운로드 하고, "sugoi_translator"를 BallonsTranslator/ballontranslator/data/models 에 이동시키세요.
- * [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame), 로컬 장치로 실행할 때 vram OOM 으로 인한 충돌이 발생하는 경우 설정 패널에서 ```low vram mode``` 를 설정하세요. (기본으로 활성화됨)
- * DeepLX: [Vercel](https://github.com/bropines/Deeplx-vercel) 또는 [deeplx](https://github.com/OwO-Network/DeepLX)를 참조하시기 바랍니다.
- * [Translators](https://github.com/UlionTse/translators) 라이브러리를 추가하여 api 키 없이 일부 번역 서비스에 액세스할 수 있습니다. 지원되는 서비스에 대해 찾을 수 있습니다 [참고](https://github.com/UlionTse/translators#supported-translation-services).
- * OpenAI API와 호환되는 공식 또는 제3자 LLM 제공 업체와 함께 작동하는 두 가지 버전의 OpenAI-compliant 번역기를 지원하며, 설정 패널에서 몇가지 설정을 필요로 합니다.
-    * Non-suffix 버전은 토큰을 더 적게 사용하지만 문장 분할 안정성이 약간 약해 긴 텍스트 번역에 문제가 발생할 수 있습니다.
-    * 'exp' suffix 버전은 더 많은 토큰을 사용하지만 안정성이 더 뛰어나고 프롬프트에 '탈옥'이 포함되어 있어 긴 텍스트 번역에 적합합니다.
-
-다른 좋은 오프라인 영어 번역기를 추가하려면, 다음을 참조하시기 바랍니다 [스레드](https://github.com/dmMaze/BallonsTranslator/discussions/515).
-새로운 번역기를 추가하려면 [how_to_add_new_translator](./how_to_add_new_translator.md)를 참조하시기 바랍니다. BaseClass의 하위 클래스로 두 개의 인터페이스를 구현하는 것처럼 간단합니다. 그런 다음 애플리케이션에서 이를 사용할 수 있으며, 프로젝트에 기여할 수 있습니다.
-
-
-## FAQ 및 기타
-* 만약 Nvidia GPU 또는 Apple silicon을 가지고 있다면, 프로그램은 하드웨어 가속을 가능하게합니다.
-* 텍스트 선택의 미니 메뉴에서 [saladict](https://saladict.crimx.com)(*All-in-one 전문적인 팝업사전과 페이지 번역기*)에 대한 지원 추가. [설치 안내](./saladict.md) 
-* 대부분의 모듈이 [PyTorch](https://pytorch.org/get-started/locally/) 을 사용하므로 [NVIDIA's CUDA](https://pytorch.org/docs/stable/notes/cuda.html) 또는 [AMD's ROCm](https://pytorch.org/docs/stable/notes/hip.html) 장치가 있는 경우 성능을 가속화하세요.
-* 폰트는 시스템에 설치된 폰트입니다.
-* 러시아 현지화를 진행한 [브로핀](https://github.com/bropines) 에 감사드립니다.
-* [bropines](https://github.com/bropines) 에 의해 Photoshop JSX 스크립트로 내보내기를 추가했습니다. </br> 지침을 읽고 코드를 개선한 후 어떻게 작동하는지 확인하려면 'scripts/export to photoshop' -> 'install_manual.md'로 이동하면 됩니다.
+- `CONTRIBUTING.md` 참고
+- `README.md`, `README_zh_CN.md` 변경 시 번역 문서 동기화

--- a/doc/README_PT-BR.md
+++ b/doc/README_PT-BR.md
@@ -1,241 +1,37 @@
-## BallonTranslator
+# BallonsTranslator Pro
 
-[Chinês](/README.md) | [Inglês](/README_EN.md) | pt-BR | [Russo](../doc/README_RU.md) | [Japonês](../doc/README_JA.md) | [Indonésio](../doc/README_ID.md) | [Vietnamita](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+> Esta versão está alinhada com `README.md` e `README_zh_CN.md` (atualizada em 18 de maio de 2026).
 
-BallonTranslator é mais uma ferramenta auxiliada por computador, alimentada por deep learning, para a tradução de quadrinhos/mangás.
+## Visão geral
 
-<img src="../doc/src/ui0.jpg" div align=center>
+BallonsTranslator Pro é uma ferramenta para traduzir quadrinhos/imagens com pipeline OCR → tradução → revisão de texto → renderização.
 
-<p align=center>
-**Pré-Visualização**
-</p>
+## Principais recursos
 
-## Recursos
-* **Tradução totalmente automatizada:** 
-  - Detecta, reconhece, remove e traduz textos automaticamente. O desempenho geral depende desses módulos.
-  - A diagramação é baseada na estimativa de formatação do texto original.
-  - Funciona bem com mangás e quadrinhos.
-  - Diagramação aprimorada para mangás->inglês, inglês->chinês (baseado na extração de regiões de balões).
-  
-* **Edição de imagem:**
-  - Permite editar máscaras e inpainting (similar à ferramenta Pincel de Recuperação para Manchas no Photoshop).
-  - Adaptado para imagens com proporção de aspecto extrema, como webtoons.
-  
-* **Edição de texto:**
-  - Suporta formatação de texto e [predefinições de estilo de texto](https://github.com/dmMaze/BallonsTranslator/pull/311). Textos traduzidos podem ser editados interativamente.
-  - Permite localizar e substituir.
-  - Permite exportar/importar para/de documentos do Word.
+- Fluxo em lote para manga/manhua/manhwa e imagens gerais.
+- OCR local e em nuvem (PaddleOCR, MangaOCR, EasyOCR, OCR com LLM/VLM etc.).
+- Tradução automática com provedores LLM e MT.
+- Edição de balões, máscaras, estilos e tipografia.
+- Renderização/exportação (incluindo SVG e legendas em fluxos compatíveis).
+- Controles de desempenho (GPU/VRAM/modelos opcionais).
 
-## Instalação
+## Instalação rápida
 
-### No Windows
-Se você não deseja instalar o Python e o Git manualmente e tem acesso à Internet:  
-Baixe o BallonsTranslator_dev_src_with_gitpython.7z do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), descompacte e execute launch_win.bat.  
-Execute scripts/local_gitpull.bat para obter a atualização mais recente.
+1. Clone o repositório.
+2. Instale dependências: `pip install -r requirements.txt`.
+3. Execute: `python launch.py`.
 
-### Executando o código-fonte
-Instale o [Python](https://www.python.org/downloads/release/python-31011) **<= 3.12** (não utilize a versão da Microsoft Store) e o [Git](https://git-scm.com/downloads).
+No Windows: `launch_win.bat`, `build_windows_installer.bat`.
 
-```bash
-# Clone este repositório
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+## Documentação
 
-# Inicie o aplicativo
-$ python3 launch.py
-```
+Consulte `docs/` para traduções, GPU, inpainting/renderização e fluxo de vídeo/legendas.
 
-Na primeira execução, as bibliotecas necessárias serão instaladas e os modelos serão baixados automaticamente. Se os downloads falharem, você precisará baixar a pasta **data** (ou os arquivos ausentes mencionados no terminal) do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) e salvá-la no caminho correspondente na pasta do código-fonte.
+## Idiomas de interface suportados
 
-## Construindo o aplicativo para macOS (compatível com chips Intel e Apple Silicon)
+English (`en_US`), 简体中文 (`zh_CN`), Español (`es_MX`), Français (`fr_FR`), Português (Brasil) (`pt_BR`), Русский (`ru_RU`), 한국어 (`ko_KR`), Magyar (`hu_HU`).
 
-*Observação: o macOS também pode executar o código-fonte caso o aplicativo não funcione.*
+## Contribuição
 
-![录屏2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
-
-#### 1. Preparação
--  Baixe as bibliotecas e modelos do [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) ou [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing).
-
-<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  Coloque todos os recursos baixados em uma pasta chamada `data`. A estrutura final do diretório deve ser semelhante a esta:
-  
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 diretórios, 23 arquivos
-```
-
-- Instale a ferramenta de linha de comando pyenv para gerenciar as versões do Python. Recomenda-se a instalação via Homebrew.
-
-```
-# Instalar via Homebrew
-brew install pyenv
-
-# Instalar via script oficial
-curl https://pyenv.run | bash
-
-# Configurar o ambiente shell após a instalação
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-#### 2. Construindo o aplicativo
-```
-# Entre no diretório de trabalho `data`
-cd data
-
-# Clone o branch `dev` do repositório
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# Entre no diretório de trabalho `BallonsTranslator`
-cd BallonsTranslator
-
-# Execute o script de construção, que solicitará a senha na etapa pyinstaller, insira a senha e pressione enter
-sh scripts/build-macos-app.sh
-```
-
-> 📌 O aplicativo empacotado está em ./data/BallonsTranslator/dist/BallonsTranslator.app. Arraste o aplicativo para a pasta de aplicativos do macOS para instalar. Pronto para usar sem configurações extras do Python.
-
-
-</details>
-
-Para usar o Sugoi translator (apenas japonês-inglês), baixe o [modelo offline](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm) e mova a pasta "sugoi_translator" para BallonsTranslator/ballontranslator/data/models.
-
-
-# Utilização
-
-**É recomendado executar o programa em um terminal caso ocorra alguma falha e não sejam fornecidas informações, como mostrado no gif a seguir.**
-<img src="../doc/src/run.gif">  
-
-- Na primeira execução, selecione o tradutor e defina os idiomas de origem e destino clicando no ícone de configurações.
-- Abra uma pasta contendo as imagens do quadrinho (mangá/manhua/manhwa) que precisa de tradução clicando no ícone de pasta.
-- Clique no botão `Run` e aguarde a conclusão do processo.
-
-Os formatos de fonte, como tamanho e cor, são determinados automaticamente pelo programa neste processo. Você pode pré-determinar esses formatos alterando as opções correspondentes de "decidir pelo programa" para "usar configuração global" no painel de configurações->Diagramação. (As configurações globais são os formatos exibidos no painel de formatação de fonte à direita quando você não está editando nenhum bloco de texto na cena.)
-
-## Edição de Imagem
-
-### Ferramenta de Inpainting
-<img src="../doc/src/imgedit_inpaint.gif">
-<p align = "center">
-**Modo de edição de imagem, ferramenta de Inpainting**
-</p>
-
-### Ferramenta Retângulo
-<img src="../doc/src/rect_tool.gif">
-<p align = "center">
-**Ferramenta Retângulo**
-</p>
-
-Para 'apagar' resultados indesejados de inpainting, use a ferramenta de inpainting ou a ferramenta retângulo com o **botão direito do mouse** pressionado. O resultado depende da precisão com que o algoritmo ("método 1" e "método 2" no gif) extrai a máscara de texto. O desempenho pode ser pior em textos e fundos complexos.
-
-## Edição de Texto
-<img src="../doc/src/textedit.gif">
-<p align = "center">
-**Modo de edição de texto**
-</p>
-
-<img src="../doc/src/multisel_autolayout.gif" div align=center>
-<p align=center>
-**Formatação de texto em lote e layout automático**
-</p>
-
-<img src="../doc/src/ocrselected.gif" div align=center>
-<p align=center>
-**OCR e tradução de área selecionada**
-</p>
-
-## Atalhos
-* `A`/`D` ou `pageUp`/`Down` para virar a página
-* `Ctrl+Z`, `Ctrl+Shift+Z` para desfazer/refazer a maioria das operações (a pilha de desfazer é limpa ao virar a página).
-* `T` para o modo de edição de texto (ou o botão "T" na barra de ferramentas inferior).
-* `W` para ativar o modo de criação de bloco de texto, arraste o mouse na tela com o botão direito pressionado para adicionar um novo bloco de texto (veja o gif de edição de texto).
-* `P` para o modo de edição de imagem.
-* No modo de edição de imagem, use o controle deslizante no canto inferior direito para controlar a transparência da imagem original.
-* Desative ou ative qualquer módulo automático através da barra de título->executar. Executar com todos os módulos desativados irá refazer as letras e renderizar todo o texto de acordo com as configurações correspondentes.
-* Defina os parâmetros dos módulos automáticos no painel de configuração.
-* `Ctrl++`/`Ctrl+-` (Também `Ctrl+Shift+=`) para redimensionar a imagem.
-* `Ctrl+G`/`Ctrl+F` para pesquisar globalmente/na página atual.
-* `0-9` para ajustar a opacidade da camada de texto.
-* Para edição de texto: negrito - `Ctrl+B`, sublinhado - `Ctrl+U`, itálico - `Ctrl+I`.
-* Defina a sombra e a transparência do texto no painel de estilo de texto -> Efeito.
-
-<img src="../doc/src/configpanel.png">
-
-## Modo Headless (Executar sem interface gráfica)
-
-```python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-
-A configuração (idioma de origem, idioma de destino, modelo de inpainting, etc.) será carregada de config/config.json. Se o tamanho da fonte renderizada não estiver correto, especifique o DPI lógico manualmente através de `--ldpi`. Os valores típicos são 96 e 72.
-
-## Módulos de Automação
-Este projeto depende fortemente do [manga-image-translator](https://github.com/zyddnys/manga-image-translator). Serviços online e treinamento de modelos não são baratos, considere fazer uma doação ao projeto:
-- Ko-fi: [https://ko-fi.com/voilelabs](https://ko-fi.com/voilelabs)
-- Patreon: [https://www.patreon.com/voilelabs](https://www.patreon.com/voilelabs)
-- 爱发电: [https://afdian.net/@voilelabs](https://afdian.net/@voilelabs)
-
-O [Sugoi translator](https://sugoitranslator.com/) foi criado por [mingshiba](https://www.patreon.com/mingshiba).
-
-## Detecção de Texto
-* Suporta detecção de texto em inglês e japonês. O código de treinamento e mais detalhes podem ser encontrados em [comic-text-detector](https://github.com/dmMaze/comic-text-detector).
-* Suporta o uso de detecção de texto do [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). O nome de usuário e a senha precisam ser preenchidos, e o login automático será realizado a cada vez que o programa for iniciado.
-  * Para instruções detalhadas, consulte [Manual do TuanziOCR](../doc/Manual_TuanziOCR_pt-BR.md).
-
-## OCR
-* Todos os modelos mit* são do manga-image-translator e suportam reconhecimento de inglês, japonês e coreano, além da extração da cor do texto.
-* [manga_ocr](https://github.com/kha-white/manga-ocr) é de [kha-white](https://github.com/kha-white), reconhecimento de texto para japonês, com foco principal em mangás japoneses.
-* Suporta o uso de OCR do [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). O nome de usuário e a senha precisam ser preenchidos, e o login automático será realizado a cada vez que o programa for iniciado.
-  * A implementação atual usa OCR em cada bloco de texto individualmente, resultando em velocidade mais lenta e sem melhoria significativa na precisão. Não é recomendado. Se necessário, use o Tuanzi Detector.
-  * Ao usar o Tuanzi Detector para detecção de texto, recomenda-se definir o OCR como none_ocr para ler o texto diretamente, economizando tempo e reduzindo o número de solicitações.
-  * Para instruções detalhadas, consulte [Manual do TuanziOCR](../doc/Manual_TuanziOCR_pt-BR.md).
-
-## Inpainting
-* O AOT é do [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
-* Todos os lama* são ajustados usando o [LaMa](https://github.com/advimman/lama).
-* PatchMatch é um algoritmo do [PyPatchMatch](https://github.com/vacancy/PyPatchMatch). Este programa usa uma [versão modificada](https://github.com/dmMaze/PyPatchMatchInpaint) por mim.
-
-## Tradutores
-Tradutores disponíveis: Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu, Papago e Yandex.
-* O Google desativou o serviço de tradução na China, defina a 'url' correspondente no painel de configuração para *.com.
-* Os tradutores [Caiyun](https://dashboard.caiyunapp.com/), [ChatGPT](https://platform.openai.com/playground), [Yandex](https://yandex.com/dev/translate/), [Baidu](http://developers.baidu.com/) e [DeepL](https://www.deepl.com/docs-api/api-access) exigem um token ou chave de API.
-* DeepL e Sugoi translator (e sua conversão CT2 Translation) graças a [Snowad14](https://github.com/Snowad14).
-* Sugoi traduz do japonês para o inglês completamente offline.
-* [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame)
-
-Para adicionar um novo tradutor, consulte [Como_add_um_novo_tradutor](../doc/Como_add_um_novo_tradutor.md). É simples como criar uma subclasse de uma classe base e implementar duas interfaces. Em seguida, você pode usá-lo no aplicativo. Contribuições para o projeto são bem-vindas.
-
-## FAQ & Diversos
-* Se o seu computador tiver uma GPU Nvidia ou Apple Silicon, o programa habilitará a aceleração de hardware.
-* Adicione suporte para [saladict](https://saladict.crimx.com) (*Dicionário pop-up profissional e tradutor de páginas tudo-em-um*) no mini menu ao selecionar o texto. [Guia de instalação](../doc/saladict_pt-br.md).
-* Acelere o desempenho se você tiver um dispositivo [NVIDIA CUDA](https://pytorch.org/docs/stable/notes/cuda.html) ou [AMD ROCm](https://pytorch.org/docs/stable/notes/hip.html), pois a maioria dos módulos usa o [PyTorch](https://pytorch.org/get-started/locally/).
-* As fontes são do seu sistema.
-* Agradecimentos a [bropines](https://github.com/bropines) pela localização para o russo.
-* Adicionado script JSX de exportação para o Photoshop por [bropines](https://github.com/bropines). Para ler as instruções, melhorar o código e apenas explorar como funciona, vá para `scripts/export to photoshop` -> `install_manual.md`.
+- Veja `CONTRIBUTING.md`.
+- Mantenha traduções sincronizadas com `README.md` e `README_zh_CN.md`.

--- a/doc/README_RU.md
+++ b/doc/README_RU.md
@@ -1,247 +1,37 @@
-> [!IMPORTANT]   
-> **Если вы публично делитесь переведенным результатом, и опытный переводчик-человек не участвовал в тщательном переводе или проверке, пожалуйста, отметьте его как машинный перевод в заметном месте. Если на нормальном русском. Если вы не способны сделать минимальную проверку качества, перед публикацией, или вы не умеете в тайп, то укажите в описании к загражуемой манге, что это "машинный" перевод. Большинство русских сервисов тупо забанит вам аккаунт после попытки залива "машинного" перевода. Уделите хоть каплю внимания редактуре.**
+# BallonsTranslator Pro
 
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | Русский | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+> Эта версия синхронизирована с `README.md` и `README_zh_CN.md` (обновлено: 18 мая 2026 г.).
 
-Еще один инструмент для компьютерного перевода комиксов/манги на основе глубокого обучения.
+## Обзор
 
-<img src="src/ui0.jpg" div align=center>
+BallonsTranslator Pro — инструмент перевода комиксов/изображений с конвейером OCR → перевод → правка текста → рендер.
 
-<p align=center>
-предпросмотр
-</p>
+## Основные возможности
 
-# Особенности
-* Полностью автоматизированный перевод  
-  - Поддерживает автоматическое обнаружение текста, распознавание, удаление и перевод. Общая производительность зависит от этих модулей.
-  - Верстка основана на оценке форматирования оригинального текста.
-  - Хорошо работает с мангой и комиксами.
-  - Улучшенная верстка манга->английский, английский->китайский (на основе выделения областей баллонов).
-  
-* Редактирование изображений  
-  - Поддерживает редактирование масок и ретушь (что-то вроде инструмента точечного восстановления в Photoshop) 
-  - Адаптирован для изображений с экстремальным соотношением сторон, таких как веб-комиксы
-  
-* Редактирование текста  
-  - Поддерживает богатое форматирование текста и [пресеты стилей текста](https://github.com/dmMaze/BallonsTranslator/pull/311), переведенные тексты можно редактировать интерактивно.
-  - Поддерживает поиск и замену
-  - Поддерживает экспорт/импорт в/из документов Word
+- Пакетная обработка manga/manhua/manhwa и обычных изображений.
+- Локальные и облачные OCR (PaddleOCR, MangaOCR, EasyOCR, LLM/VLM OCR и др.).
+- Автоперевод через LLM/MT провайдеров.
+- Редактирование пузырей, масок, стилей и шрифтов.
+- Рендер и экспорт (включая SVG/субтитры в поддерживаемых сценариях).
+- Настройки производительности (GPU/VRAM/доп. модели).
 
-# Установка
+## Быстрый запуск
 
-## На Windows
-Если вы не хотите устанавливать Python и Git самостоятельно и у вас есть доступ к Интернету:  
-Скачайте BallonsTranslator_dev_src_with_gitpython.7z с [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) или [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), распакуйте его и запустите launch_win.bat.   
-Запустите scripts/local_gitpull.bat, чтобы получить последнее обновление.
+1. Клонируйте репозиторий.
+2. Установите зависимости: `pip install -r requirements.txt`.
+3. Запустите: `python launch.py`.
 
-## Запуск исходного кода
+Для Windows есть `launch_win.bat` и `build_windows_installer.bat`.
 
-Установите [Python](https://www.python.org/downloads/release/python-31011) **<= 3.12** (не используйте версию, установленную из Microsoft Store) и [Git](https://git-scm.com/downloads).
+## Документация
 
-```bash
-# Клонируйте этот репозиторий
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
+См. каталог `docs/`: переводы, GPU, inpainting/рендеринг, видео и субтитры.
 
-# Запустите приложение
-$ python3 launch.py
-```
+## Поддерживаемые языки интерфейса
 
-Обратите внимание, что при первом запуске будут автоматически установлены необходимые библиотеки и загружены модели. Если загрузки не удались, вам нужно будет скачать папку **data** (или отсутствующие файлы, упомянутые в терминале) с [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) или [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) и сохранить ее в соответствующем пути в папке с исходным кодом.
+English (`en_US`), 简体中文 (`zh_CN`), Español (`es_MX`), Français (`fr_FR`), Português (Brasil) (`pt_BR`), Русский (`ru_RU`), 한국어 (`ko_KR`), Magyar (`hu_HU`).
 
-## Сборка приложения для macOS (совместимо как с процессорами Intel, так и с Apple Silicon)
-<i>Обратите внимание, что macOS также может запускать исходный код, если это не работает.</i>  
+## Вклад
 
-![запись экрана 2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
-
-#### 1. Подготовка
--   Загрузите библиотеки и модели с [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw "MEGA") или [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)
-
-
-<img width="1268" alt="скриншот 2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  Поместите все загруженные ресурсы в папку с названием data, конечная структура каталога должна выглядеть так:
-
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 директорий, 23 файла
-```
-
--  Установите инструмент командной строки pyenv для управления версиями Python. Рекомендуется установка через Homebrew.
-```
-# Установка через Homebrew
-brew install pyenv
-
-# Установка через официальный скрипт
-curl https://pyenv.run | bash
-
-# Настройка окружения оболочки после установки
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-
-#### 2. Сборка приложения
-```
-# Перейдите в рабочую директорию `data`
-cd data
-
-# Клонируйте ветку `dev` репозитория
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# Перейдите в рабочую директорию `BallonsTranslator`
-cd BallonsTranslator
-
-# Запустите скрипт сборки, на этапе pyinstaller потребуется ввести пароль, введите пароль и нажмите enter
-sh scripts/build-macos-app.sh
-```
-> 📌Упакованное приложение находится в ./data/BallonsTranslator/dist/BallonsTranslator.app, перетащите приложение в папку приложений macOS для установки. Готово к использованию без дополнительной настройки Python.
-
-
-</details> 
-
-# Использование
-
-**Рекомендуется запускать программу в терминале на случай, если она аварийно завершится и не оставит никакой информации, см. следующий gif.**
-<img src="doc/src/run.gif">  
-- При первом запуске приложения, пожалуйста, выберите переводчик и установите исходный и целевой языки, нажав на значок настроек.
-- Откройте папку, содержащую изображения комикса (манги/маньхуа/манхвы), которые нуждаются в переводе, нажав на значок папки.
-- Нажмите кнопку `Run` и дождитесь завершения процесса.
-
-Форматы шрифта, такие как размер и цвет, определяются программой автоматически в этом процессе. Вы можете предопределить эти форматы, изменив соответствующие опции с "decide by program" на "use global setting" в панели конфигурации->Typesetting. (глобальные настройки - это те форматы, которые отображаются на правой панели форматирования шрифта, когда вы не редактируете ни один текстовый блок на сцене)
-
-## Редактирование изображений
-
-### Инструмент ретуши
-<img src="src/imgedit_inpaint.gif">
-<p align = "center">
-Режим редактирования изображения, инструмент ретуши
-</p>
-
-### Инструмент прямоугольника
-<img src="src/rect_tool.gif">
-<p align = "center">
-Инструмент прямоугольника
-</p>
-
-Чтобы 'стереть' нежелательные результаты ретуши, используйте инструмент ретуши или инструмент прямоугольника с нажатой **правой кнопкой** мыши.  
-Результат зависит от того, насколько точно алгоритм ("метод 1" и "метод 2" на gif) извлекает маску текста. Он может работать хуже на сложном тексте и фоне.  
-
-## Редактирование текста
-<img src="src/textedit.gif">
-<p align = "center">
-Режим редактирования текста
-</p>
-
-<img src="src/multisel_autolayout.gif" div align=center>
-<p align=center>
-Пакетное форматирование текста и автоматическая компоновка
-</p>
-
-<img src="src/ocrselected.gif" div align=center>
-<p align=center>
-OCR и перевод выбранной области
-</p>
-
-## Горячие клавиши
-* ```A```/```D``` или ```pageUp```/```Down``` для перелистывания страниц
-* ```Ctrl+Z```, ```Ctrl+Shift+Z``` для отмены/повтора большинства операций. (обратите внимание, что стек отмены будет очищен после перелистывания страницы)
-* ```T``` для режима редактирования текста (или кнопка "T" на нижней панели инструментов).
-* ```W``` для активации режима создания текстового блока, затем перетащите мышь по холсту с нажатой правой кнопкой, чтобы добавить новый текстовый блок. (см. gif редактирования текста)
-* ```P``` для режима редактирования изображения.  
-* В режиме редактирования изображения используйте ползунок в правом нижнем углу для управления прозрачностью исходного изображения.
-* Отключите или включите любые автоматические модули через строку заголовка->run, запуск со всеми отключенными модулями пересоздаст и перерисует весь текст в соответствии с соответствующими настройками.  
-* Установите параметры автоматических модулей на панели конфигурации.  
-* ```Ctrl++```/```Ctrl+-``` (Также ```Ctrl+Shift+=```) для изменения размера изображения.
-* ```Ctrl+G```/```Ctrl+F``` для глобального поиска/поиска на текущей странице.
-* ```0-9``` для настройки прозрачности текстового слоя
-* Для редактирования текста: жирный - ```Ctrl+B```, подчеркнутый - ```Ctrl+U```, курсив - ```Ctrl+I``` 
-* Установите тень текста и прозрачность на панели стиля текста -> Effect.  
-* ```Alt+Стрелки``` или ```Alt+WASD``` (```pageDown``` или ```pageUp``` в режиме редактирования текста) для переключения между текстовыми блоками.
-  
-<img src="src/configpanel.png">
-
-## Режим без графического интерфейса (Запуск без GUI)
-``` python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-Обратите внимание, что конфигурация (исходный язык, целевой язык, модель ретуши и т.д.) будет загружена из config/config.json.  
-Если отрисованный размер шрифта неправильный, укажите логическое DPI вручную через ```--ldpi ```, типичные значения - 96 и 72.
-
-
-# Модули автоматизации
-Этот проект сильно зависит от [manga-image-translator](https://github.com/zyddnys/manga-image-translator), онлайн-сервис и обучение моделей недешевы, пожалуйста, рассмотрите возможность пожертвования проекту:  
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>  
-
-[Sugoi translator](https://sugoitranslator.com/) создан [mingshiba](https://www.patreon.com/mingshiba).
-  
-## Обнаружение текста
- * Поддерживает обнаружение английского и японского текста, код обучения и подробности можно найти в [comic-text-detector](https://github.com/dmMaze/comic-text-detector)
-* Поддерживает использование обнаружения текста из [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Необходимо заполнить имя пользователя и пароль, автоматический вход будет выполняться при каждом запуске программы.
-
-   * Для подробных инструкций см. **Инструкции по использованию Tuanzi OCR**: (только на [китайском](doc/团子OCR说明.md) и [бразильском португальском](doc/Manual_TuanziOCR_pt-BR.md))
-   
-## OCR
- * Все модели mit* взяты из manga-image-translator, поддерживают распознавание английского, японского и корейского языков и извлечение цвета текста.
- * [manga_ocr](https://github.com/kha-white/manga-ocr) от [kha-white](https://github.com/kha-white), распознавание текста для японского языка, с основным фокусом на японской манге.
- * Поддерживает использование OCR из [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Необходимо заполнить имя пользователя и пароль, автоматический вход будет выполняться при каждом запуске программы.
-   * Текущая реализация использует OCR для каждого текстового блока отдельно, что приводит к более медленной скорости и не дает значительного улучшения точности. Это не рекомендуется. При необходимости используйте вместо этого Tuanzi Detector.
-   * При использовании Tuanzi Detector для обнаружения текста рекомендуется установить OCR в none_ocr для прямого чтения текста, экономя время и уменьшая количество запросов.
-   * Для подробных инструкций см. **Инструкции по использованию Tuanzi OCR**: (только на [китайском](doc/团子OCR说明.md) и [бразильском португальском](doc/Manual_TuanziOCR_pt-BR.md))
-
-## Ретушь
-  * AOT взят из [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
-  * Все lama* дообучены с использованием [LaMa](https://github.com/advimman/lama)
-  * PatchMatch - это алгоритм из [PyPatchMatch](https://github.com/vacancy/PyPatchMatch), эта программа использует [модифицированную версию](https://github.com/dmMaze/PyPatchMatchInpaint) от меня. 
-  
-
-## Переводчики
-Доступные переводчики: Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu. Papago и Yandex.
- * Google закрыл сервис перевода в Китае, пожалуйста, установите соответствующий 'url' в панели конфигурации на *.com.
- * [Caiyun](https://dashboard.caiyunapp.com/), [ChatGPT](https://platform.openai.com/playground), [Yandex](https://yandex.com/dev/translate/), [Baidu](http://developers.baidu.com/) и [DeepL](https://www.deepl.com/docs-api/api-access) переводчики требуют токен или API-ключ.
- * DeepL & Sugoi переводчик (и его преобразование CT2 Translation) благодаря [Snowad14](https://github.com/Snowad14).
- * Sugoi переводит с японского на английский полностью оффлайн. Скачайте [оффлайн модель](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm), переместите "sugoi_translator" в BallonsTranslator/ballontranslator/data/models. 
- * [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame), отметьте ```low vram mode``` в панели конфигурации, если вы запускаете его локально на одном устройстве и столкнулись с сбоем из-за нехватки vram (включено по умолчанию).
- * DeepLX: Пожалуйста, обратитесь к [Vercel](https://github.com/bropines/Deeplx-vercel) или [deeplx](https://github.com/OwO-Network/DeepLX)
- * Добавлена библиотека [Translators](https://github.com/UlionTse/translators) которая поддерживает доступ к некоторым сервисам переводчиков без api ключей. О поддерживаемых сервисах можете узнать [тут](https://github.com/UlionTse/translators#supported-translation-services). 
-
-Для других хороших оффлайн английских переводчиков, пожалуйста, обратитесь к этой [ветке обсуждения](https://github.com/dmMaze/BallonsTranslator/discussions/515).  
-Чтобы добавить новый переводчик, пожалуйста, обратитесь к [how_to_add_new_translator](doc/how_to_add_new_translator.md), это просто как создание подкласса BaseClass и реализация двух интерфейсов, затем вы можете использовать его в приложении, вы можете внести свой вклад в проект.  
-
-
-## FAQ и прочее
-* Если ваш компьютер имеет GPU NVIDIA или Apple Silicon, программа включит аппаратное ускорение. 
-* Добавлена поддержка [saladict](https://saladict.crimx.com) (*Универсальный профессиональный всплывающий словарь и переводчик страниц*) в мини-меню при выделении текста. [Руководство по установке](doc/saladict.md)
-* Ускорение производительности, если у вас есть устройство [NVIDIA's CUDA](https://pytorch.org/docs/stable/notes/cuda.html) или [AMD's ROCm](https://pytorch.org/docs/stable/notes/hip.html), так как большинство модулей использует [PyTorch](https://pytorch.org/get-started/locally/).
-* Шрифты берутся из системных шрифтов вашей системы.
-* Благодарность [bropines](https://github.com/bropines) за русскую локализацию.
-* Добавлен экспорт в скрипт JSX для Photoshop от [bropines](https://github.com/bropines). </br> Чтобы прочитать инструкции, улучшить код и просто покопаться, чтобы увидеть, как это работает, вы можете перейти в `scripts/export to photoshop` -> `install_manual.md`.
+- См. `CONTRIBUTING.md`.
+- Поддерживайте синхронизацию переводов с `README.md` и `README_zh_CN.md`.

--- a/doc/README_VI.md
+++ b/doc/README_VI.md
@@ -1,244 +1,49 @@
-# BallonTranslator
-[简体中文](/README.md) | [English](/README_EN.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | Tiếng Việt | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md)
+# BallonsTranslator-Pro
+[简体中文](/README.md) | [English](/README.md) | [pt-BR](../doc/README_PT-BR.md) | [Русский](../doc/README_RU.md) | [日本語](../doc/README_JA.md) | [Indonesia](../doc/README_ID.md) | [Tiếng Việt](../doc/README_VI.md) | [한국어](../doc/README_KO.md) | [Español](../doc/README_ES.md) | [Français](../doc/README_FR.md) | [Magyar](../doc/README_HU.md)
 
-Lại thêm một công cụ, phần mềm dịch truyện siu xịn khác có áp dụng ML/AI.
+BallonsTranslator-Pro là nhánh nâng cao của [dmMaze/BallonsTranslator](https://github.com/dmMaze/BallonsTranslator), tập trung vào quy trình dịch manga/comic nghiêm túc.
 
-<img src="./src/ui0.jpg" div align=center>
+## Luồng xử lý chính
 
-<p align=center>
-preview
-</p>
+1. Phát hiện bong bóng/vùng chữ
+2. OCR nhận dạng chữ
+3. Dịch văn bản
+4. Xóa chữ gốc khỏi ảnh (inpaint)
+5. Chỉnh sửa và xuất trang
 
-# Đặc trưng
-* Dịch hoàn toàn tự động
-  - Hỗ trợ phát hiện văn bản tự động, nhận dạng, loại bỏ và dịch thuật. Các tính năng xoay quanh hầu hết phụ thuộc vào các đặc tính này.
-  - Font, kích thức chữ được ước tính dựa trên định dạng của văn bản gốc.
-  - Hoạt động tốt với manga và comics.
-  - Dùng siu xịn khi mà Manga -> Tiếng Anh, Tiếng Anh -> tiếng Trung (Zì app này các pháp sư Trung Hoa làm mà :> ).
-  
-* Chỉnh sửa hình ảnh
-  - Hỗ trợ Chỉnh sửa & Inpainting (na ná brush tool trong Photoshop)
-  - Thích nghi với hình ảnh có tỷ lệ khung hình cực cao như Webtoons (?? hem hỉu lém, nhưng mà nói chung sài được với cả webtoons)
-  
-* Chỉnh sửa văn bản
-  - Hỗ trợ RTF (rich text formatting) zà [TSP (text style presets)](https://github.com/dmMaze/BallonsTranslator/pull/311), có thể chỉnh sửa lại các văn bản đã được dịch đó lun nè.
-  - Hỗ trợ Tìm kiếm & Thay thế
-  - Hỗ trợ cả import từ dạng word hoặc export ra dạng đó nữa
+- Lịch sử thay đổi: [docs/CHANGELOG.md](../docs/CHANGELOG.md)
 
-# Cài đặt
+## Khởi chạy nhanh
 
-## Trên Windows
+- **Windows (khuyên dùng):** `launcher.bat`
+- **Windows nhanh:** `launch_win.bat`
+- **Đa nền tảng:** `python launch.py`
+- Hướng dẫn GPU: [docs/GPU_ACCELERATION.md](../docs/GPU_ACCELERATION.md)
 
-Nếu bạn lười cài Python và Git nhưng vẫn có thể truy cập vào Internet, thì có thể tải BallonsTranslator_dev_src_with_gitpython.7z từ [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) hoặc nà [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing), unzip nó rùi chạy ```launch_win.bat```.
-Chạy file ```scripts/local_gitpull.bat``` để cập nhật bản mới nhất nhoa.
+## Cài Google Fonts trong app
 
-## Chạy mã nguồn (từ github)
+1. **Tools → Models → Install Google Font...**
+2. Nhập tên font (ví dụ `Bangers`, `Noto Sans JP`)
+3. Ứng dụng tự tải và đăng ký vào `fonts/google/`
 
-*Phù hợp cho mấy bạn sài linux như tui hehe.*
-
-Cài [Python](https://www.python.org/downloads/release/python-31011) **<= 3.12** (Đừng cóa mà sài cái bản có sẵn trên Microsoft Store) và [Git](https://git-scm.com/downloads).
+## Clone / tải mã nguồn
 
 ```bash
-# Clone this repo
-$ git clone https://github.com/dmMaze/BallonsTranslator.git ; cd BallonsTranslator
-
-# Launch the app
-$ python3 launch.py
+git clone https://github.com/thomaswantstobeaskeleton/BallonsTranslator-Pro
+cd BallonsTranslator-Pro
+python launch.py
 ```
 
-**Lưu ý:** Lần đầu tiên khởi chạy, app sẽ tự động cài đặt các thư viện và tải xuống các models. Nếu tải xuống không thành công, bạn sẽ cần tải xuống thư mục **data** (hoặc các tệp bị thiếu được báo lỗi trong terminal) từ [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw) hoặc [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing) rùi lưu nó ở đường dẫn tương ứng trong thư mục mã nguồn.
+## Yêu cầu
 
-## Chạy ứng dụng trên MacOS (tương thích với cả chip Intel và Apple Silicon)
-<i>Lưu ý MacOS cũng có thể chạy cách bên trên nếu cách này không hoạt động.</i>  
+- Python 3.10.2+
+- Internet cho lần setup/model đầu tiên
+- Đủ dung lượng đĩa cho model
 
-![录屏2023-09-11 14 26 49](https://github.com/hyrulelinks/BallonsTranslator/assets/134026642/647c0fa0-ed37-49d6-bbf4-8a8697bc873e)
+## Tài liệu quan trọng
 
-#### 1. Chuẩn bị
--   Tải libs và models từ [MEGA](https://mega.nz/folder/gmhmACoD#dkVlZ2nphOkU5-2ACb5dKw "MEGA") hoặc [Google Drive](https://drive.google.com/drive/folders/1uElIYRLNakJj-YS0Kd3r3HE-wzeEvrWd?usp=sharing)
-
-
-<img width="1268" alt="截屏2023-09-08 13 44 55_7g32SMgxIf" src="https://github.com/dmMaze/BallonsTranslator/assets/134026642/40fbb9b8-a788-4a6e-8e69-0248abaee21a">
-
--  Chuyển tất cả các tài nguyên đã tải xuống vào thư mục ```data``` (chưa có thì tự tạo nhá), cấu trúc cây thư mục cuối cùng sẽ trông như nè:
-
-```
-data
-├── libs
-│   └── patchmatch_inpaint.dll
-└── models
-    ├── aot_inpainter.ckpt
-    ├── comictextdetector.pt
-    ├── comictextdetector.pt.onnx
-    ├── lama_mpe.ckpt
-    ├── manga-ocr-base
-    │   ├── README.md
-    │   ├── config.json
-    │   ├── preprocessor_config.json
-    │   ├── pytorch_model.bin
-    │   ├── special_tokens_map.json
-    │   ├── tokenizer_config.json
-    │   └── vocab.txt
-    ├── mit32px_ocr.ckpt
-    ├── mit48pxctc_ocr.ckpt
-    └── pkuseg
-        ├── postag
-        │   ├── features.pkl
-        │   └── weights.npz
-        ├── postag.zip
-        └── spacy_ontonotes
-            ├── features.msgpack
-            └── weights.npz
-
-7 directories, 23 files
-```
-
--  Cài đặt pyenv command line tool để quản lý các phiên bản Python. Nên cài qua Homebrew.
-```
-# Install via Homebrew
-brew install pyenv
-
-# Install via official script
-curl https://pyenv.run | bash
-
-# Set shell environment after install
-echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.zshrc
-echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.zshrc
-echo 'eval "$(pyenv init -)"' >> ~/.zshrc
-```
-
-
-#### 2. Chạy ứng dụng
-```
-# Enter the `data` working directory
-cd data
-
-# Clone the `dev` branch of the repo
-git clone -b dev https://github.com/dmMaze/BallonsTranslator.git
-
-# Enter the `BallonsTranslator` working directory
-cd BallonsTranslator
-
-# Run the build script, will ask for password at pyinstaller step, enter password and press enter
-sh scripts/build-macos-app.sh
-```
-> 📌 Ứng dụng được build ra file chạy ở đường dẫn ```./data/BallonsTranslator/dist/BallonsTranslator.app```, kéo cái ```BallonsTranslator.app``` vô thư mục macOS application để cài đặt. Sẵn sàng sử dụng lun mà không cần cấu hình thêm cho Python.
-
-</details>
-
-Để sài Sugoi translator(Japanese-English only), tải [offline model](https://drive.google.com/drive/folders/1KnDlfUM9zbnYFTo6iCbnBaBKabXfnVJm), chuyển "sugoi_translator" vào ```BallonsTranslator/ballontranslator/data/models```.
-
-# Cách sử dụng
-
-**Bạn nên chạy chương trình trong terminal trong trường hợp nó bị crashed và không để lại log, hãy xem gif sau.**
-<img src="./src/run.gif">
-
-- Lần đầu tiên chạy ứng dụng, hãy chọn Chương trình dịch, cài Ngôn ngữ gốc và Ngôn ngữ dịch bằng cách nhấp vào biểu tượng Cài đặt.
-- Mở một thư mục chứa hình ảnh của truyện cần dịch (Manga/Manhua/Manhwa) bằng cách nhấp vào biểu tượng Thư mục.
-- Nhấp vào nút `Run` và chờ quá trình hoàn thành.
-
-Các định dạng phông chữ như kích thước và màu phông chữ được xác định tự động bởi chương trình, bạn có thể xác định trước các định dạng đó bằng cách thay đổi tùy chọn tương ứng từ "decide by program" sang "use global setting" trong Bảng cấu hình (Config Panel) -> Lettering. (Global setting, cấu hình toàn bộ, là những định dạng được hiển thị ở bảng định dạng phía bên phải màn hình, khi bạn đang không chỉnh sửa bất kỳ văn bản nào trong textblock).
-
-## Chỉnh sửa hình ảnh
-
-### Inpaint Tool
-<img src="./src/imgedit_inpaint.gif">
-<p align = "center">
-Chế độ Chỉnh sửa hình ảnh, Inpainting Tool
-</p>
-
-### rect tool
-<img src="./src/rect_tool.gif">
-<p align = "center">
-Chế độ Chỉnh sửa hình ảnh, Rect Tool
-</p>
-
-Để 'Xóa' những phần đã được inpainted không mong muốn, sử dụng Inpainting tool hoặc Rect tool trong khi đang bấm **chuổt phải**.  
-Kết quả sẽ phụ thuộc vào độ chính xác của thuật toán trích xuất ra text mask (lớp mask chữ) (theo "Phương pháp 1" và "Phương pháp 2" trong GIF). Nếu văn bản & nền phức tạp thì kết quả tách có thể chưa tốt lắm.
-
-## Chỉnh sửa văn bản
-<img src="./src/textedit.gif">
-<p align = "center">
-Chế độ Chỉnh sửa văn bản
-</p>
-
-<img src="./src/multisel_autolayout.gif" div align=center>
-<p align=center>
-Định dạng văn bản hàng loạt & Bố cục tự động
-</p>
-
-<img src="./src/ocrselected.gif" div align=center>
-<p align=center>
-OCR & Chỉ dịch văn bản đã chọn
-</p>
-
-## Shortcuts
-* ```A```/```D``` hoặc ```pageUp```/```pageDown``` : Chuyển trang
-* ```Ctrl+Z```, ```Ctrl+Shift+Z``` : Undo/redo hầu hết các hoạt động. (Lưu ý rằng list hoạt động có thể undo sẽ bị xóa sau khi bạn chuyển trang)
-* ```T``` : Để chuyển sang chế độ chỉnh sửa văn bản (hoặc phím "T" ở thanh công cụ bên dưới).
-* ```W``` : Để kích hoạt chế độ tạo khung văn bản, sau đó bấm chuột phải để thêm khung chữ mới trên canvas. (Xem GIF chỉnh sửa văn bản)
-* ```P``` : Để sang chế độ chỉnh sửa hình ảnh.  
-* Trong Chế độ Chỉnh sửa hình ảnh, sử dụng thanh trượt ở phía dưới bên phải để chỉnh sửa độ trong suốt của hình ảnh gốc.
-* Tắt hoặc bật bất kỳ modules tự động nào qua titlebar->run, chạy chương trình khi mà tất cả modules bị vô hiệu sẽ làm lại việc soạn và render tất cả văn bản tùy theo cài đặt tương ứng.
-* Đặt tham số cho các module tự động trong Bảng cấu hình.  
-* ```Ctrl++```/```Ctrl+-``` (hoặc ```Ctrl+Shift+=```) Để thay đổi kích thước hình ảnh.
-* ```Ctrl+G```/```Ctrl+F``` Để tìm kiếm trên tất cả hoặc trong trang hiện tại.
-* ```0-9``` Để điều chỉnh độ trong suốt của lớp chữ
-* Trong chỉnh sửa văn bản: **bold** - ```Ctrl+B```, <u>underline</u> - ```Ctrl+U```, *italics* - ```Ctrl+I``` 
-* Cài đặt đổ bóng và độ trong suốt chữ ở text style panel -> Effect.  
-  
-<img src="./src/configpanel.png">
-
-## Headless mode (Run without GUI)
-``` python
-python launch.py --headless --exec_dirs "[DIR_1],[DIR_2]..."
-```
-**Lưu ý:** Cấu hình (ngôn ngữ nguồn, ngôn ngữ đích, mô hình InPaint, v.v.) sẽ tải từ config/config.json.
-Nếu kích thước phông chữ được render không đúng, hãy chỉ định DPI thủ công theo cách sau: ```--ldpi```, các giá trị thường dùng là 96 và 72.
-
-
-# Các modules tự động
-Dự án này phụ thuộc rất nhiều vào [manga-image-translator](https://github.com/zyddnys/manga-image-translator), Các dịch vụ trực tuyến và model training không rẻ, nếu được thì donate các dự án nè nha (Xin cám mơn :3):  
-- Ko-fi: <https://ko-fi.com/voilelabs>
-- Patreon: <https://www.patreon.com/voilelabs>
-- 爱发电: <https://afdian.net/@voilelabs>  
-
-[Sugoi translator](https://sugoitranslator.com/) is created by [mingshiba](https://www.patreon.com/mingshiba).
-  
-## Xác định văn bản
-* Hỗ trợ phát hiện văn bản tiếng Anh và tiếng Nhật [comic-text-detector](https://github.com/dmMaze/comic-text-detector)
-* Hỗ trợ Sử dụng phát hiện văn bản [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Cần điền username và password, việc đăng nhập tự động sẽ được thực hiện mỗi khi chương trình được khởi chạy.
-   * Hướng dẫn chi tiết, [Tuanzi OCR Instructions (Chinese only)](doc/Tuanzi_OCR_Instructions.md)
-
-## OCR
- * Tất cả các mô hình MIT* đều từ manga-image-translator, hỗ trợ nhận dạng tiếng Anh, Nhật Bản và Hàn Quốc và trích xuất màu văn bản.
- * [manga_ocr](https://github.com/kha-white/manga-ocr) từ [kha-white](https://github.com/kha-white), Nhận dạng văn bản cho tiêng Nhật, tập trung vào manga.
- * Support áp dụng OCR [Starriver Cloud (Tuanzi Manga OCR)](https://cloud.stariver.org.cn/). Cần điền username và password, việc đăng nhập tự động sẽ được thực hiện mỗi khi chương trình được khởi chạy.
-   * Phiên bản hiện tại sử dụng OCR trên mỗi textblock riêng, dẫn đến tốc độ chậm hơn và độ chính xác không được cải thiện tốt. Điều này khum được khuyến khích (thì khum tối ưu mà :<). Nếu cần, hãy sử dụng Tuanzi Detector thay thế.
-   * Khi sài Tuanzi Detector cho việc xác định văn bản, nên đặt OCR thành none_ocr để có thể đọc trực tiếp văn bản, tiết kiệm thời gian và giảm số lượng yêu cầu.
-   * Cụ thể đọc thêm tại đây [Tuanzi OCR Instructions (Chinese only)](doc/Tuanzi_OCR_Instructions.md)
-
-## Inpainting
-  * AOT [manga-image-translator](https://github.com/zyddnys/manga-image-translator).
-  * Tất cả lama* đều là finetuned [LaMa](https://github.com/advimman/lama)
-  * PatchMatch là một thuật toán từ [PyPatchMatch](https://github.com/vacancy/PyPatchMatch), Phần mềm này sử dụng [phiên bản đã được tu luyện (modified version)](https://github.com/dmMaze/PyPatchMatchInpaint) bởi *me*. 
-  
-
-## Dịch thụât
-Trình dịch có sẵn: Google, DeepL, ChatGPT, Sugoi, Caiyun, Baidu. Papago, and Yandex.
- * Google không cung cấp dịch vụ dịch tại Trung Quốc, vui lòng đặt 'URL' tương ứng trong bảng điều khiển thành *.com.
- * [Caiyun](https://dashboard.caiyunapp.com/), [ChatGPT](https://platform.openai.com/playground), [Yandex](https://yandex.com/dev/translate/), [Baidu](http://developers.baidu.com/), èn [DeepL](https://www.deepl.com/docs-api/api-access). Các trình dịch cần có token hoặc api key.
- * DeepL & Sugoi translator (and it's CT2 Translation conversion) thanks to [Snowad14](https://github.com/Snowad14).
- * Sugoi có thể dịch từ Japanese sang English kể cả khi ngoại tuyến (hong có kết nối mạng).
- * [Sakura-13B-Galgame](https://github.com/SakuraLLM/Sakura-13B-Galgame)
-
- Để thêm một trình dịch mới, xem chi tiết hơn ở đây [how_to_add_new_translator](doc/how_to_add_new_translator.md), hiểu đơn giản thì nó như phân lớp của BaseClass và triển khai hai giao diện, sau đó bạn có thể sử dụng trong ứng dụng, rấc welcome đóng góp cho dự án nhe.  
-
-
-## FAQ & Misc
-* Nếu máy tính của bạn có GPU NVIDIA hoặc Apple Silicon, chương trình sẽ có thể kích hoạt việc tăng tốc phần cứng. 
-* Thêm hỗ trợ cho [saladict](https://saladict.crimx.com) (*All-in-one professional pop-up dictionary and page translator*) trong mini menu về lựa chọn text. [Installation guide](doc/saladict.md)
-* Tăng tốc hiệu suất nếu bạn có [NVIDIA's CUDA](https://pytorch.org/docs/stable/notes/cuda.html) hoặc [AMD's ROCm](https://pytorch.org/docs/stable/notes/hip.html) thiết bị, hầu hết các module sử dụng [PyTorch](https://pytorch.org/get-started/locally/).
-* Fonts được lấy từ fonts có trong máy.
-* Gửi lời cảm ơn tới [bropines](https://github.com/bropines) cho việc Nga hóa.
-* Thêm Export to photoshop JSX bởi [bropines](https://github.com/bropines).
-  Để đọc các hướng dẫn, cải thiện code hoặc nà tò mò vọc quanh quanh để xem cách hoạt động, zô `scripts/export to photoshop` -> `install_manual.md`.
+- [docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md)
+- [docs/QUALITY_RANKINGS.md](../docs/QUALITY_RANKINGS.md)
+- [docs/MODELS_REFERENCE.md](../docs/MODELS_REFERENCE.md)
+- [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](../docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
+- [docs/INDESIGN_LPTXT_WORKFLOW.md](../docs/INDESIGN_LPTXT_WORKFLOW.md)

--- a/docs/TRANSLATIONS_ES.md
+++ b/docs/TRANSLATIONS_ES.md
@@ -1,0 +1,21 @@
+# Translation Notes (es_MX)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_FR.md
+++ b/docs/TRANSLATIONS_FR.md
@@ -1,0 +1,21 @@
+# Translation Notes (fr_FR)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_HU.md
+++ b/docs/TRANSLATIONS_HU.md
@@ -1,0 +1,21 @@
+# Translation Notes (hu_HU)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_ID.md
+++ b/docs/TRANSLATIONS_ID.md
@@ -1,0 +1,21 @@
+# Translation Notes (id_ID)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_JA.md
+++ b/docs/TRANSLATIONS_JA.md
@@ -1,0 +1,21 @@
+# Translation Notes (ja_JP)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_KO.md
+++ b/docs/TRANSLATIONS_KO.md
@@ -1,0 +1,21 @@
+# Translation Notes (ko_KR)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_PT-BR.md
+++ b/docs/TRANSLATIONS_PT-BR.md
@@ -1,0 +1,21 @@
+# Translation Notes (pt_BR)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_RU.md
+++ b/docs/TRANSLATIONS_RU.md
@@ -1,0 +1,21 @@
+# Translation Notes (ru_RU)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`

--- a/docs/TRANSLATIONS_VI.md
+++ b/docs/TRANSLATIONS_VI.md
@@ -1,0 +1,21 @@
+# Translation Notes (vi_VN)
+
+This document mirrors `docs/TRANSLATIONS.md` and `docs/TRANSLATIONS_zh_CN.md` structure with localized guidance in progress.
+
+## Current policy
+
+- Keep source of truth in English (`docs/TRANSLATIONS.md`) and Chinese (`docs/TRANSLATIONS_zh_CN.md`).
+- Keep localized README files under `doc/` aligned to top-level READMEs.
+- When UI strings change, update `translate/*.ts` then sync docs.
+
+## Localization checklist
+
+1. Update glossary and style terms.
+2. Sync screenshots and menu names with current UI.
+3. Mark machine translation clearly if no human proofreading occurred.
+
+## Related
+
+- `docs/TRANSLATIONS.md`
+- `docs/TRANSLATIONS_zh_CN.md`
+- `README.md` / `README_zh_CN.md`


### PR DESCRIPTION
### Motivation

- Align localized documentation with the current top-level `README.md` / `README_zh_CN.md` so UI and onboarding guidance are consistent across languages.\
- Provide an English top-level README and formalize per-locale translation guidance to make localization work and machine-translation disclaimers explicit.\
- Reduce clutter in legacy localized files by replacing long, dated content with concise, up-to-date quickstart and feature summaries.\

### Description

- Add `README_EN.md` at the repository root containing the English quickstart, feature summary, Google Fonts instructions, and links to docs.\
- Update many localized readme files under `doc/` (`README_ES.md`, `README_FR.md`, `README_JA.md`, `README_KO.md`, `README_PT-BR.md`, `README_RU.md`, `README_VI.md`, `README_ID.md`, etc.) to shorter, aligned summaries and consistent quickstart/requirements sections.\
- Add new localized files including `doc/README_HU.md` and refreshed links to `launch.py`/bat scripts and docs, plus updates to clone/launch examples (including references to the Pro fork repository).\
- Add per-locale translation guidance files under `docs/` (`TRANSLATIONS_*.md` for `es_MX`, `fr_FR`, `hu_HU`, `id_ID`, `ja_JP`, `ko_KR`, `pt_BR`, `ru_RU`, `vi_VN`) that mirror `docs/TRANSLATIONS.md` and state the localization policy and checklist.\

### Testing

- No automated tests were run for this change because it is documentation-only and does not modify executable code.\
- Documentation changes are textual; verify by visual inspection or local markdown preview as needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b73c4b7e0832c8e92c9a38f7a7fa2)