### PR TITLE
Add automation API audit and route contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ python --version
 - More automatic bubble lettering with shape-aware safe areas, balanced line breaks, density-aware font scaling, and final overflow safety checks (see [Automatic text formatting](doc/AUTOMATIC_TEXT_FORMATTING.md))
 - LLM-aided review chain for quality/consistency
 - Strong defaults for fast onboarding
+- Local automation/API documentation for headless and MCP-style workflows (see [Local Automation API](docs/LOCAL_AUTOMATION_API.md))
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -92,6 +92,7 @@ python --version
 - 更好的批处理与长章节流程支持
 - 基于 LLM 的审校链（质量/一致性）
 - 默认配置更友好，上手更快
+- 提供本地自动化/API 文档，便于无头模式与 MCP 风格工作流（见 [Local Automation API](docs/LOCAL_AUTOMATION_API.md)）
 
 ---
 

--- a/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
+++ b/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,113 @@
+# Alternatives Feature Gap Implementation Plan
+
+Last updated: 2026-05-18
+
+This document is the safety baseline for closing gaps versus manga-image-translator, Koharu, ImageTrans, manga-translator-ui, and focused cleanup tools. The rule for every phase is: audit first, extend existing Pro systems, do not duplicate equivalent functionality, and do not remove existing Pro behavior.
+
+## Safety and PR checklist baseline
+
+Every implementation PR in this roadmap must verify:
+
+- README.md and README_zh_CN.md parity for user-facing changes.
+- Startup entrypoints are unchanged or explicitly verified (`launch.py`, `launch_win.bat`, `launcher.bat`, `launch_win_with_autoupdate.bat`).
+- First-run model picker behavior remains compatible when startup/model code is touched.
+- Local automation route discovery still reports existing and new routes through `GET /routes`.
+- Export/proof-pack behavior and manifests remain backward compatible.
+- Project save-state behavior remains compatible with existing project JSON.
+- Manual UX validation path is documented in PR notes.
+- Risks and rollback notes are included, especially for optional dependencies, PSD editability, renderer shaping, and config migration.
+
+## Phase 0 — Audit and safety baseline
+
+| Feature/check | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Audit plan | Partially implemented → updated here | `docs/FEATURE_PARITY_MATRIX.md` existed, but this detailed per-phase plan was missing | `docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md`, `docs/FEATURE_PARITY_MATRIX.md` | Low | Documentation review |
+| Local automation API route discovery | Partially implemented | `utils/local_automation_api.py`, `tests/test_local_automation_api.py` | `utils/local_automation_api.py`, `utils/automation_api_contract.py`, `docs/LOCAL_AUTOMATION_API.md` | Low; JSON shape now includes `events`, `mcp_routes`, `job_routes`, `event_stream` | Route sorting, auth, health, `/routes`, SSE snapshot |
+| Export/proof-pack behavior | Already implemented baseline | `utils/lettering_proof_export.py`, `utils/export_manifest.py`, `tests/test_lettering_proof_export.py`, `tests/test_export_manifest.py` | Same plus export callers | Medium when adding formats | Manifest correctness, proof pack contents, fallback source warnings |
+| Project save-state behavior | Partially implemented | `ui/mainwindow.py` API edit path marks save state; project tests exist | `utils/proj_imgtrans.py`, `ui/mainwindow.py` | Medium; project JSON compatibility is critical | Save/load with new fields absent/present; undoable API edits |
+| Startup entrypoints | Already implemented; untouched in this PR | `launch.py`, Windows batch files | Same | High if touched | Compile/argument smoke, Windows script snapshot |
+| First-run model picker | Already implemented; untouched in this PR | model picker tests and startup translations | `ui/model_manager_dialog.py`, `launch.py`, `translate/startup_model_ui.*.json` | High if touched | Existing model package selector/defaulting tests |
+
+## Phase 1 — Automation, headless, and MCP parity
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Stable JSON scene operation API | Partially implemented | `utils/api_edit_ops.py`, `ui/mainwindow.py` `_api_apply_edit`, `tests/test_api_edit_ops*.py` | Extend edit-op dataclasses, stable block IDs, undo command integration | Medium; current UI edit path mutates blocks directly for some ops | Payload validation, stable IDs, undo/redo, invalid page/index errors |
+| Job manager | Partially implemented | `ui/mainwindow.py` job routes; new contract helper normalizes task aliases | Extract/extend job lifecycle helpers without duplicating UI behavior | Medium; cancellation is cooperative | job_start/status/cancel/logs/result/list; SSE snapshot; warning propagation |
+| MCP-compatible command surface | Partially implemented | handlers include `open_project`, `project_status`, `list_pages`, `apply_edit`, `run_pipeline`, `render`, `export`, `undo`, `redo`; route discovery now marks MCP routes | `ui/mainwindow.py`, `utils/automation_api_contract.py`, docs | Low | Route discovery contract tests |
+| CLI/headless mode | Partially implemented | `launch.py --headless`, `scripts/batch_translate.py` | Add stable CLI contract and exit codes | Medium; must not break current GUI launch | Headless open/run/export smoke with mocked modules |
+| Route discovery docs/tests | Partially implemented → improved | `docs/LOCAL_AUTOMATION_API.md`, tests | Same | Low | Authenticated and unauthenticated discovery; `/events` content type |
+
+## Phase 2 — Secure provider/model setup wizard
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| OS keyring credential storage | Partially implemented | `utils/credential_store.py`, `tests/test_credential_store.py` | Config migration path, provider settings UI/API | High; must not silently overwrite config or leak keys | keyring mocks, fallback opt-in, no-secret serialization |
+| Provider setup wizard | Not implemented as full wizard | Provider modules/settings exist, but no unified onboarding wizard | `ui/configpanel.py`, provider utilities, local API | Medium | connection test mocks, endpoint preset serialization |
+| Runtime profiles | Partially implemented | runtime/profile/data-path tests exist | config/runtime utilities, model manager UI | Medium | low VRAM/CPU fallback diagnostics |
+| Translation options/retry policy | Partially implemented | translator batch mode tests exist | base translator/provider settings | Medium | per-block/page mode, retry behavior |
+
+## Phase 3 — Professional export and interchange
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Truthful editable PSD strategy | Partially implemented | `utils/layered_psd_export.py`, `tests/test_layered_psd_export.py` | PSD handoff docs/manifests; optional PSD text only behind flag if feasible | Medium/high due PSD compatibility claims | no silent raster-only PSD claims |
+| XLIFF/Excel/Word/LabelPlus/XML/HTML/searchable PDF/TXT/JSON | Partially implemented | structured OCR, SVG/PSD/proof exports exist | new interchange utils and export dialog/API | Medium | format snapshots and optional dependency skips |
+| Roundtrip imports | Not implemented broadly | project ops protocol can update text | import utilities/API/UI | High; geometry/block matching can corrupt projects | stable ID/source/page/geometry matching tests |
+| Export manifests | Already/partially implemented | `utils/export_manifest.py` | add renderer/pro format warnings | Low/medium | fallback source, missing font, clipped text warnings |
+
+## Phase 4 — CAT-tool features and translation QA
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Translation memory | Not implemented as reusable TM | Some context/glossary docs exist | new TM storage utilities/UI/API | Medium | fuzzy match, import/export |
+| Termbase/glossary | Partially implemented | `modules/llm_quality.py` glossary enforcement | glossary store/dialog/API | Medium | hard/soft violations, no destructive replacement |
+| Corpus concordance | Not implemented | Search widgets exist but not CAT concordance | corpus index/search utilities | Low/medium | provenance search |
+| SFX dictionary | Not implemented | style/prompt concepts exist | SFX dictionary data/UI | Low | lookup/import/export |
+| Auto glossary extraction | Not implemented | LLM quality utilities can be extended | extraction utility + approval UI | Medium | candidate categories, approval persistence |
+| Post-translation QA/retry | Partially implemented | `modules/llm_quality.py`, translation review tests | QA report/API/UI | Medium | thresholds, retry behavior |
+| Prompt profiles | Partially implemented | prompt/profile docs and translator settings | prompt profile store | Low/medium | profile selection by block type |
+
+## Phase 5 — OCR, reading order, and editor UX
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| OCR crop inspector | Partially implemented | `ui/ocr_crop_inspector_widget.py` and pipeline button exist | inspector rerun hooks | Medium | crop extraction/rerun metadata |
+| Hybrid OCR workflow | Not implemented | multiple OCR engines exist | OCR compare utility/UI/API | Medium | primary/secondary compare |
+| Reading-order editor | Partially implemented | `ui/reading_order_editor_dialog.py` exists | persistence/export integration | Medium | reorder persistence, structured export order |
+| Batch find/replace | Partially implemented | regex profiles and global replace exist | preview/apply API and UI | Medium | regex preview/apply undo |
+| Import translated image workflow | Not implemented | OCR/project utilities exist | alignment utility/UI/API | High | IoU/order matching tests |
+
+## Phase 6 — Advanced renderer fidelity
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Renderer stack audit | Partially implemented | rendering docs/tests exist | text rendering docs and diagnostics | Low | doc + fixture review |
+| Optional shaping backend | Not implemented fully | Qt rendering and text rendering utilities exist | optional uharfbuzz/freetype path | High; packaging/Windows risk | optional dependency skip tests |
+| Keep Qt default | Already required | current renderer is Qt-based | config/render settings | Low | default config compatibility |
+| Diagnostics | Partially implemented | rendering QA tests exist | renderer diagnostics/export manifests | Medium | missing glyph/clipping/shaping fallback |
+| Visual regression tests | Partially implemented | text rendering tests exist | deterministic fixtures | Medium | image snapshots/tolerances |
+
+## Phase 7 — Cleanup, segmentation, and mask quality
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Bubble-aware mask expansion | Partially implemented | mask diagnostics/textbox masking tests | mask generation utilities | Medium | inside/outside dilation fixtures |
+| Edge-halo detector | Partially implemented | `tests/test_mask_diagnostics.py` | diagnostics utility/UI/API | Medium | halo fixtures |
+| Mask-aware text flow | Partially implemented | auto layout/mask-safe diagnostics | text layout/rendering utilities | High | irregular flow fallback tests |
+| Cleanup-only workflow | Partially implemented | inpaint/export modules; no stable CLI/API contract yet | API/headless/export | Medium | cleanup-only CLI/API path |
+
+## Phase 8 — Batch, archive, and packaging parity
+
+| Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
+|---|---|---|---|---|---|
+| Parent/child CBZ/folder processing | Partially implemented | `utils/zip_batch.py`, batch queue UI, headless dirs | batch queue/headless API | Medium | parent/child queue, resume state |
+| Streaming ZIP/CBZ export | Partially implemented | API archive export exists; manifests exist | export utilities/job progress | Medium | progress/cancel/manifest |
+| Docker/web/API mode docs | Not implemented fully | local API exists | docs, sample client | Low | docs smoke snippets |
+| Data path manager | Partially implemented | `tests/test_data_path_manager.py` | config/UI migration helper | Medium | free-space and migration tests |
+
+## Immediate implementation order
+
+1. Finish Phase 1 API contract: stable IDs/errors for scene ops, deeper job cancellation checkpoints, and headless CLI exit-code contract.
+2. Start Phase 2 secret migration using `utils/credential_store.py` and explicit insecure fallback warnings.
+3. Expand Phase 3 interchange only after export/import schemas are documented and tests are in place.

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -12,8 +12,8 @@ This matrix tracks BallonsTranslator-Pro parity progress against major alternati
 - **Phase 1 (Automation/headless/MCP):** 🟨 **actively in progress**
   - Added typed edit-op validation and batch scene-edit surface.
   - Added job lifecycle routes (`job_start/status/cancel/logs/result/list`).
-  - Added MCP-friendly aliases and deterministic route discovery tests.
-  - Remaining: deeper task cancellation hooks, CLI/headless runner contract, SSE/WS stream.
+  - Added MCP-friendly aliases, deterministic route discovery tests, and an SSE-compatible `/events` job snapshot endpoint.
+  - Remaining: deeper task cancellation hooks, CLI/headless runner contract, live SSE/WS streaming loop.
 - **Phase 2+ (Secure providers, interchange, CAT, OCR UX, renderer fidelity, cleanup, batch parity):** ❌ **not started in implementation yet**
 
 ## Relative parity (high-level)

--- a/docs/LOCAL_AUTOMATION_API.md
+++ b/docs/LOCAL_AUTOMATION_API.md
@@ -1,0 +1,70 @@
+# Local Automation API and MCP Command Surface
+
+Last updated: 2026-05-18
+
+BallonsTranslator-Pro exposes a localhost-only automation API when `automation_api_enabled` is enabled in config. The API is designed for headless helpers, MCP-style tools, and external workflow scripts while keeping existing UI progress behavior intact.
+
+## Discovery and health
+
+- `GET /health` returns service status plus the same route catalog as `/routes`.
+- `GET /routes` returns stable sorted POST routes, GET routes, MCP-compatible command routes, job routes, and the SSE event-stream template.
+- `GET /events?job_id=<job_id>` returns a Server-Sent Events snapshot for a job. The current implementation sends a bounded status/log snapshot; future work can extend this to a live streaming loop without changing the endpoint.
+
+If `automation_api_key` is set, send it as `X-API-Key` for every request, including discovery and events.
+
+## MCP-friendly commands
+
+The route catalog marks these commands as MCP-compatible when the UI registers them:
+
+- `open_project`
+- `project_status`
+- `list_pages`
+- `apply_edit`
+- `run_pipeline`
+- `render`
+- `export`
+- `undo`
+- `redo`
+
+Aliases such as `project_open`, `pipeline_run`, `scene_edit`, and `render_page` remain supported for compatibility.
+
+## Long-running jobs
+
+Use `POST /job_start` for long-running operations. Supported task names and aliases normalize to a small stable set:
+
+| Canonical task | Accepted aliases |
+|---|---|
+| `run_pipeline` | `run_pipeline`, `pipeline_run` |
+| `render_page` | `render`, `render_page`, `render_current_page` |
+| `export` | `export` |
+| `batch_export` | `batch_export`, `export_archive` |
+| `proof_pack` | `proof_pack`, `export_lettering_proof`, `lettering_proof` |
+
+Job lifecycle routes:
+
+- `POST /job_status` with `{"job_id": "..."}`
+- `POST /job_cancel` with `{"job_id": "..."}`
+- `POST /job_logs` with `{"job_id": "..."}`
+- `POST /job_result` with `{"job_id": "..."}`
+- `POST /jobs_list` with optional `{"limit": 50}`
+
+Cancellation is cooperative. A queued job can be cancelled immediately; a running job exposes `cancel_requested` so deeper pipeline stages can progressively add cancellation checkpoints.
+
+## Example curl flow
+
+```bash
+curl http://127.0.0.1:39542/routes
+curl -X POST http://127.0.0.1:39542/open_project \
+  -H 'Content-Type: application/json' \
+  -d '{"path":"/path/to/project-or-folder"}'
+curl -X POST http://127.0.0.1:39542/job_start \
+  -H 'Content-Type: application/json' \
+  -d '{"task":"run_pipeline","payload":{}}'
+curl http://127.0.0.1:39542/events?job_id=job_123
+```
+
+## Current limitations
+
+- The event stream currently returns a status/log snapshot rather than an infinite stream.
+- Job cancellation is exposed through the API but still depends on individual task implementations to check cancellation during expensive work.
+- The API remains bound to `127.0.0.1` by design; do not expose it directly on untrusted networks.

--- a/tests/test_automation_api_contract.py
+++ b/tests/test_automation_api_contract.py
@@ -1,0 +1,25 @@
+import pytest
+
+from utils.automation_api_contract import build_route_discovery, normalize_job_task
+
+
+def test_route_discovery_marks_mcp_and_job_routes():
+    payload = build_route_discovery({
+        "project_status": lambda body: {},
+        "job_status": lambda body: {},
+        "apply_edit": lambda body: {},
+        "z_extra": lambda body: {},
+    })
+    assert payload["routes"] == ["apply_edit", "job_status", "project_status", "z_extra"]
+    assert payload["methods"]["GET"] == ["events", "health", "routes"]
+    assert payload["mcp_routes"] == ["apply_edit", "project_status"]
+    assert payload["job_routes"] == ["job_status"]
+    assert payload["event_stream"] == "/events?job_id=<job_id>"
+
+
+def test_normalize_job_task_aliases_and_rejects_unknown():
+    assert normalize_job_task("render_current_page") == "render_page"
+    assert normalize_job_task("proof_pack") == "proof_pack"
+    assert normalize_job_task("export_archive") == "batch_export"
+    with pytest.raises(ValueError):
+        normalize_job_task("not_a_task")

--- a/tests/test_local_automation_api.py
+++ b/tests/test_local_automation_api.py
@@ -44,7 +44,7 @@ def test_local_automation_api_health_lists_routes():
     assert out['status'] == 'ok'
     assert out['count'] == 1
     assert 'ping' in out['routes']
-    assert out['methods']['GET'] == ['health', 'routes']
+    assert out['methods']['GET'] == ['events', 'health', 'routes']
     assert out['methods']['POST'] == ['ping']
 
 
@@ -62,7 +62,7 @@ def test_local_automation_api_routes_endpoint_shape():
     assert out['ok'] is True
     assert out['count'] == 2
     assert out['routes'] == ['open_project', 'project_status']
-    assert out['methods']['GET'] == ['health', 'routes']
+    assert out['methods']['GET'] == ['events', 'health', 'routes']
     assert out['methods']['POST'] == ['open_project', 'project_status']
 
 
@@ -80,3 +80,29 @@ def test_local_automation_api_routes_are_sorted_for_stability():
     server.stop()
     assert out['routes'] == ['alpha', 'mid', 'zeta']
     assert out['methods']['POST'] == ['alpha', 'mid', 'zeta']
+
+
+def test_local_automation_api_event_stream_job_snapshot():
+    jobs = {
+        "job_1": {"job_id": "job_1", "status": "running", "warnings": [], "logs": ["started"]}
+    }
+
+    def status(body):
+        job = jobs[body["job_id"]]
+        return {"job_id": job["job_id"], "status": job["status"], "warnings": job["warnings"]}
+
+    def logs(body):
+        job = jobs[body["job_id"]]
+        return {"job_id": job["job_id"], "logs": job["logs"], "warnings": job["warnings"]}
+
+    server = LocalAutomationApiServer('127.0.0.1', 39604, {'job_status': status, 'job_logs': logs})
+    server.start()
+    req = urllib.request.Request('http://127.0.0.1:39604/events?job_id=job_1', method='GET')
+    with urllib.request.urlopen(req, timeout=2) as resp:
+        body = resp.read().decode('utf-8')
+        content_type = resp.headers.get('Content-Type')
+    server.stop()
+    assert content_type == 'text/event-stream'
+    assert body.startswith('event: job\n')
+    assert '"status": "running"' in body
+    assert 'started' in body

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -78,6 +78,7 @@ from utils.svg_text_export import build_svg_text_handoff
 from utils.lettering_proof_export import build_lettering_proof_pack
 from utils.text_rendering import locale_aware_upper
 from utils.local_automation_api import LocalAutomationApiServer
+from utils.automation_api_contract import normalize_job_task
 from utils.workflow_presets import apply_workflow_preset, list_workflow_presets, workflow_stage_vector
 from utils.model_manager import get_available_module_keys
 from modules.llm_quality import enforce_glossary, back_translation_drift_score
@@ -882,7 +883,10 @@ class MainWindow(mainwindow_cls):
             'undo': self._api_undo,
             'redo': self._api_redo,
             'export': self._api_export,
+            'batch_export': self._api_batch_export,
+            'proof_pack': self._api_export_lettering_proof,
             'render': self._api_render_current_page,  # MCP alias
+            'render_page': self._api_render_current_page,
             'layout_review': self._api_layout_review,
             'page_state': self._api_page_state,
             'list_pages': self._api_list_pages,
@@ -948,10 +952,8 @@ class MainWindow(mainwindow_cls):
         return {'opened': path}
 
     def _api_job_start(self, body: dict):
-        task = str((body or {}).get('task', '') or '').strip().lower()
+        task = normalize_job_task(str((body or {}).get('task', '') or ''))
         payload = dict((body or {}).get('payload') or {})
-        if task not in {'run_pipeline', 'render_current_page', 'export', 'export_lettering_proof'}:
-            raise ValueError('task must be one of: run_pipeline, render_current_page, export, export_lettering_proof')
         job_id = f"job_{int(time.time() * 1000)}_{threading.get_ident()}"
         job = {
             'job_id': job_id, 'task': task, 'status': 'queued',
@@ -979,10 +981,12 @@ class MainWindow(mainwindow_cls):
             try:
                 if task == 'run_pipeline':
                     rst = self._api_run_pipeline(payload)
-                elif task == 'render_current_page':
+                elif task == 'render_page':
                     rst = self._api_render_current_page(payload)
                 elif task == 'export':
                     rst = self._api_export(payload)
+                elif task == 'batch_export':
+                    rst = self._api_batch_export(payload)
                 else:
                     rst = self._api_export_lettering_proof(payload)
                 with self._api_jobs_lock:
@@ -1291,6 +1295,11 @@ class MainWindow(mainwindow_cls):
         if kind in {'lettering_proof', 'proof_pack', 'typography_proof'}:
             return self._api_export_lettering_proof_ui(body)
         raise ValueError(f'unknown export kind: {kind}')
+
+    def _api_batch_export(self, body: dict):
+        payload = dict(body or {})
+        payload.setdefault('kind', 'batch')
+        return self._api_export(payload)
 
     def _api_layout_review(self, body: dict):
         return self._api_call_ui(self._api_layout_review_ui, body)

--- a/utils/automation_api_contract.py
+++ b/utils/automation_api_contract.py
@@ -1,0 +1,80 @@
+"""Automation API route and job contract helpers.
+
+This module is intentionally UI-free so route discovery, docs generation, and
+headless tests can share one stable contract without importing PyQt.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Set
+
+
+MCP_COMMAND_ROUTES: Set[str] = {
+    "open_project",
+    "project_status",
+    "list_pages",
+    "apply_edit",
+    "run_pipeline",
+    "render",
+    "export",
+    "undo",
+    "redo",
+}
+
+JOB_TASK_ALIASES: Mapping[str, str] = {
+    "run_pipeline": "run_pipeline",
+    "pipeline_run": "run_pipeline",
+    "render": "render_page",
+    "render_page": "render_page",
+    "render_current_page": "render_page",
+    "export": "export",
+    "batch_export": "batch_export",
+    "export_archive": "batch_export",
+    "proof_pack": "proof_pack",
+    "export_lettering_proof": "proof_pack",
+    "lettering_proof": "proof_pack",
+}
+
+JOB_TASKS: Set[str] = set(JOB_TASK_ALIASES.values())
+
+
+@dataclass(frozen=True)
+class RouteDiscovery:
+    routes: List[str]
+    get_routes: List[str] = field(default_factory=lambda: ["health", "routes", "events"])
+    mcp_routes: List[str] = field(default_factory=list)
+    job_routes: List[str] = field(default_factory=list)
+
+    def to_payload(self) -> Dict[str, Any]:
+        return {
+            "ok": True,
+            "routes": self.routes,
+            "count": len(self.routes),
+            "methods": {
+                "GET": self.get_routes,
+                "POST": self.routes,
+            },
+            "mcp_routes": self.mcp_routes,
+            "job_routes": self.job_routes,
+            "event_stream": "/events?job_id=<job_id>",
+        }
+
+
+def normalize_job_task(task: str) -> str:
+    key = str(task or "").strip().lower()
+    if key not in JOB_TASK_ALIASES:
+        valid = ", ".join(sorted(JOB_TASK_ALIASES))
+        raise ValueError(f"task must be one of: {valid}")
+    return JOB_TASK_ALIASES[key]
+
+
+def build_route_discovery(handlers: Mapping[str, Any], *, get_routes: Optional[Iterable[str]] = None) -> Dict[str, Any]:
+    routes = sorted(str(k) for k in handlers.keys())
+    get_list = sorted(set(str(r) for r in (get_routes or ["health", "routes", "events"])))
+    discovery = RouteDiscovery(
+        routes=routes,
+        get_routes=get_list,
+        mcp_routes=[r for r in routes if r in MCP_COMMAND_ROUTES],
+        job_routes=[r for r in routes if r.startswith("job_") or r == "jobs_list"],
+    )
+    return discovery.to_payload()

--- a/utils/local_automation_api.py
+++ b/utils/local_automation_api.py
@@ -3,6 +3,9 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Callable, Dict, Any
+from urllib.parse import parse_qs, urlparse
+
+from utils.automation_api_contract import build_route_discovery
 
 
 class LocalAutomationApiServer:
@@ -20,16 +23,7 @@ class LocalAutomationApiServer:
         handlers = self.handlers
 
         def _routes_payload():
-            routes = sorted(handlers.keys())
-            return {
-                'ok': True,
-                'routes': routes,
-                'count': len(routes),
-                'methods': {
-                    'GET': ['health', 'routes'],
-                    'POST': routes,
-                },
-            }
+            return build_route_discovery(handlers)
 
         class H(BaseHTTPRequestHandler):
             def _auth_ok(self):
@@ -41,7 +35,8 @@ class LocalAutomationApiServer:
                 return True
 
             def do_GET(self):
-                route = self.path.strip('/')
+                parsed = urlparse(self.path)
+                route = parsed.path.strip('/')
                 if route in {'', 'health'}:
                     if not self._auth_ok():
                         return
@@ -51,6 +46,11 @@ class LocalAutomationApiServer:
                     if not self._auth_ok():
                         return
                     self._send(200, _routes_payload())
+                    return
+                if route == 'events':
+                    if not self._auth_ok():
+                        return
+                    self._send_events(parsed.query)
                     return
                 self._send(404, {'ok': False, 'error': f'unknown route: {route}'})
 
@@ -81,6 +81,31 @@ class LocalAutomationApiServer:
                 data = json.dumps(obj).encode('utf-8')
                 self.send_response(code)
                 self.send_header('Content-Type', 'application/json')
+                self.send_header('Content-Length', str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+            def _send_events(self, query: str):
+                qs = parse_qs(query or '')
+                job_id = (qs.get('job_id') or [''])[0]
+                payload: Dict[str, Any] = {'ok': True, 'job_id': job_id}
+                status_fn = handlers.get('job_status')
+                logs_fn = handlers.get('job_logs')
+                if job_id and status_fn is not None:
+                    try:
+                        payload['status'] = status_fn({'job_id': job_id}) or {}
+                    except Exception as e:
+                        self._send(404, {'ok': False, 'error': str(e)})
+                        return
+                if job_id and logs_fn is not None:
+                    try:
+                        payload['logs'] = logs_fn({'job_id': job_id}) or {}
+                    except Exception as e:
+                        payload['warnings'] = [str(e)]
+                data = ('event: job\n' + 'data: ' + json.dumps(payload) + '\n\n').encode('utf-8')
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/event-stream')
+                self.send_header('Cache-Control', 'no-cache')
                 self.send_header('Content-Length', str(len(data)))
                 self.end_headers()
                 self.wfile.write(data)


### PR DESCRIPTION
### Motivation
- Provide a Phase 0 audit and safety baseline for closing feature gaps (automation, headless/MCP parity, secure providers, interchange, CAT workflows) without regressing existing Pro behavior.  
- Centralize the automation API discovery/job contract so headless clients and docs/tests can rely on a stable route payload shape and normalized job task names.  
- Surface MCP-friendly aliases and a simple SSE-compatible job snapshot endpoint to improve headless/job observability while keeping existing API-key auth and UI progress behavior intact.

### Description
- Add a Phase 0 audit and implementation plan in `docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md` documenting per-phase status, target files, migration risk, and PR checklist expectations.  
- Add `docs/LOCAL_AUTOMATION_API.md` documenting `GET /health`, `GET /routes`, `GET /events?job_id=<job_id>`, MCP command surface, supported job task aliases, job lifecycle routes, and current limitations.  
- Introduce a UI-free contract helper `utils/automation_api_contract.py` providing `build_route_discovery`, `normalize_job_task`, MCP route classification, job-task alias table, and the discovery payload shape.  
- Update `utils/local_automation_api.py` to use the shared contract for discovery and add a bounded SSE-compatible `/events` job snapshot implementation (preserving `X-API-Key` auth).  
- Extend `ui/mainwindow.py` automation handlers with MCP-friendly aliases and normalized job dispatching (`render_page`, `batch_export`, `proof_pack`) and add a `_api_batch_export` wrapper so job tasks map consistently.  
- Add tests `tests/test_automation_api_contract.py` and extend `tests/test_local_automation_api.py` to cover route discovery metadata and the event-stream snapshot case, and update `docs/FEATURE_PARITY_MATRIX.md` and README/README_zh_CN parity links to the new docs.

### Testing
- Performed Python compile/syntax checks on changed modules: `utils/local_automation_api.py`, `utils/automation_api_contract.py`, `ui/mainwindow.py`, and test modules; the compile step succeeded.  
- Ran targeted test suites with `pytest` covering automation and related API behavior: `tests/test_local_automation_api.py`, `tests/test_automation_api_contract.py`, and related API/export tests; all tests passed (18 passed).  
- Added automated tests for route discovery payload shape and job event snapshot which succeeded, and preserved existing automation/edit/export tests to detect regressions.  
- Manual validation path documented in the PR notes and `docs/LOCAL_AUTOMATION_API.md` showing how to call `GET /routes`, `POST /job_start`, and `GET /events?job_id=<job_id>`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0b8dff3970832ca7e3677141ee690e)