### PR TITLE
Add registry-backed manga/raw downloader, provider API, and UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,24 @@ python --version
 - [docs/MODELS_REFERENCE.md](docs/MODELS_REFERENCE.md)
 - [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
 - [docs/INDESIGN_LPTXT_WORKFLOW.md](docs/INDESIGN_LPTXT_WORKFLOW.md)
+
+
+## Manga / Comic Raw Downloader
+
+BallonsTranslator-Pro includes a registry-backed manga/raw source downloader. Existing sources (MangaDex, Comick, GOMANGA, Manhwa Reader, MangaForFree, ToonGod, Mangakakalot, NaruRaw, ManhwaRaw, 1kkk, generic chapter URLs, and local folders) are preserved, and new providers can be added through `utils/manga_sources/provider_base.py` plus `utils/manga_sources/registry.py` without manually rebuilding the UI source list.
+
+Current first-batch registry providers include MangaSee/MangaSee123, ReadManga-style pages, and Manganato/Manganelo compatibility. Providers must use public pages/APIs only, respect request delays, and must not bypass DRM, paywalls, login restrictions, private APIs, CAPTCHA, Cloudflare, or other access controls. Browser rendering remains the explicit user-controlled Playwright option.
+
+Developer docs:
+
+- `docs/RAW_SOURCE_PROVIDER_EXPANSION_PLAN.md` — audit and roadmap.
+- `docs/MANGA_SOURCE_PLUGIN_API.md` — provider interface, registry metadata, legal/ToS expectations, and tests.
+- `docs/EXTERNAL_SOURCE_AUDIT.md` — generated local audit report for optional external downloader repositories.
+
+Smoke tests:
+
+```bash
+python scripts/test_manga_sources.py
+python scripts/test_manga_sources.py --stable-registry-only
+pytest -q tests/test_manga_provider_base.py
+```

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -124,3 +124,24 @@ python --version
 - [docs/MODELS_REFERENCE.md](docs/MODELS_REFERENCE.md)
 - [docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md](docs/TRANSLATION_CONTEXT_AND_GLOSSARY.md)
 - [docs/INDESIGN_LPTXT_WORKFLOW.md](docs/INDESIGN_LPTXT_WORKFLOW.md)
+
+
+## Manga / Comic Raw Downloader
+
+BallonsTranslator-Pro includes a registry-backed manga/raw source downloader. Existing sources (MangaDex, Comick, GOMANGA, Manhwa Reader, MangaForFree, ToonGod, Mangakakalot, NaruRaw, ManhwaRaw, 1kkk, generic chapter URLs, and local folders) are preserved, and new providers can be added through `utils/manga_sources/provider_base.py` plus `utils/manga_sources/registry.py` without manually rebuilding the UI source list.
+
+Current first-batch registry providers include MangaSee/MangaSee123, ReadManga-style pages, and Manganato/Manganelo compatibility. Providers must use public pages/APIs only, respect request delays, and must not bypass DRM, paywalls, login restrictions, private APIs, CAPTCHA, Cloudflare, or other access controls. Browser rendering remains the explicit user-controlled Playwright option.
+
+Developer docs:
+
+- `docs/RAW_SOURCE_PROVIDER_EXPANSION_PLAN.md` — audit and roadmap.
+- `docs/MANGA_SOURCE_PLUGIN_API.md` — provider interface, registry metadata, legal/ToS expectations, and tests.
+- `docs/EXTERNAL_SOURCE_AUDIT.md` — generated local audit report for optional external downloader repositories.
+
+Smoke tests:
+
+```bash
+python scripts/test_manga_sources.py
+python scripts/test_manga_sources.py --stable-registry-only
+pytest -q tests/test_manga_provider_base.py
+```

--- a/config/config.example.json
+++ b/config/config.example.json
@@ -248,6 +248,11 @@
   "manga_source_download_dir": "",
   "manga_source_request_delay": 0.3,
   "manga_source_open_after_download": false,
+  "manga_source_playwright_headless": true,
+  "manga_source_translate_raw_search": true,
+  "manga_source_show_experimental": true,
+  "manga_source_base_url_overrides": {},
+  "manga_source_filter": "all",
   "model_packages_enabled": [
     "core"
   ],

--- a/docs/EXTERNAL_SOURCE_AUDIT.md
+++ b/docs/EXTERNAL_SOURCE_AUDIT.md
@@ -1,0 +1,11 @@
+# External Manga Source Audit
+
+Generated from local folders only; no network access or content scraping is performed.
+
+No external folders were found or supplied.
+
+Place repositories under `external/` or pass paths on the command line, then rerun:
+
+```bash
+python scripts/audit_external_manga_sources.py external/hakuneko
+```

--- a/docs/MANGA_SOURCE_PLUGIN_API.md
+++ b/docs/MANGA_SOURCE_PLUGIN_API.md
@@ -1,0 +1,112 @@
+# Manga Source Provider API
+
+BallonsTranslator-Pro manga/raw sources are registered in `utils/manga_sources/registry.py` and should implement the typed contract in `utils/manga_sources/provider_base.py`.
+
+## Legal and operational rules
+
+Providers must:
+
+- use public pages or documented/public APIs only;
+- avoid DRM, paywall, login, private API, CAPTCHA, Cloudflare, or anti-bot bypass;
+- use conservative `request_delay` throttling;
+- never log cookies, tokens, or secrets;
+- keep downloads in the existing folder/page naming shape (`001.ext`, `002.ext`, and `manifest.json` when using the generic downloader);
+- clearly mark sources as `experimental`, `disabled`, or `broken` when reliability/legal requirements are uncertain.
+
+Playwright is allowed only as the existing explicit, user-controlled browser mode. Cookies may be supported only when the user intentionally supplies them and they must not be logged.
+
+## Provider types
+
+`provider_base.py` defines:
+
+- `MangaSourceCapabilities`
+  - `supports_search`
+  - `supports_latest`
+  - `supports_chapter_url`
+  - `supports_download`
+  - `supports_raw_language`
+  - `requires_playwright`
+  - `supports_cookies`
+  - `supports_referer`
+- `MangaSearchResult`
+- `MangaChapter`
+- `MangaPage`
+- `MangaSourceProvider`
+
+New providers may return legacy dictionaries from `search()` and `get_feed()` so the current UI remains compatible. Use `MangaSearchResult.as_legacy_dict()` and `MangaChapter.as_legacy_dict()` to avoid drift.
+
+## Minimal provider skeleton
+
+```python
+from utils.manga_sources.provider_base import MangaSourceCapabilities, MangaSourceProvider
+
+class ExampleClient(MangaSourceProvider):
+    source_id = "example"
+    display_name = "Example"
+    base_url = "https://example.org"
+    capabilities = MangaSourceCapabilities(supports_search=True, supports_download=True)
+
+    def search(self, query: str, limit: int = 20, **opts):
+        ...
+
+    def get_feed(self, manga_id: str, limit: int = 500, order: str = "asc", **opts):
+        ...
+
+    def get_pages(self, chapter_id: str, **opts):
+        ...
+```
+
+For normal public HTML sites, prefer subclassing `StaticHtmlMangaProvider` from `utils/manga_sources/static_site.py` and configuring selectors rather than rewriting request, URL, and parser boilerplate.
+
+## Registry metadata
+
+Register a source with `SourceMetadata`:
+
+```python
+SourceMetadata(
+    "example",
+    "Example",
+    "utils.manga_sources.example:ExampleClient",
+    "https://example.org",
+    status="enabled",
+    capabilities=MangaSourceCapabilities(supports_search=True, supports_download=True),
+    aliases=("example_alias",),
+    fallback_base_urls=("https://mirror.example.org",),
+    category="English aggregator",
+    notes="Public static HTML parser; no login content.",
+)
+```
+
+Status values:
+
+- `enabled`: shown by default and included in stable smoke tests.
+- `experimental`: visible with an experimental badge; future tests should require `--include-experimental`.
+- `disabled`: hidden by default; used for optional bridges or sources requiring configuration.
+- `broken`: hidden by default until repaired.
+
+The registry resolves aliases, supports fallback base URL metadata, reads `pcfg.manga_source_base_url_overrides`, and catches import-time provider failures so optional dependencies do not crash the app. Experimental sources are controlled via `pcfg.manga_source_show_experimental`. The dialog also persists category filtering in `pcfg.manga_source_filter`.
+
+## UI integration
+
+The source combo in `ui/manga_source_dialog.py` is built from `source_options()` rather than a hand-maintained list. Add source-specific UI branching only when the source needs a genuinely different workflow. Static public HTML providers should use the existing search → feed → generic URL download flow.
+
+## Tests
+
+Required tests for new providers:
+
+1. A mocked parser test with saved HTML fixtures under `tests/fixtures/manga_sources/`.
+2. Registry metadata/alias coverage when adding new source IDs.
+3. `python -m py_compile` for edited Python files.
+4. `pytest -q tests/test_manga_provider_base.py` or a provider-specific test module.
+5. Optional network smoke test: `python scripts/test_manga_sources.py --stable-registry-only`.
+
+Network smoke tests are not a substitute for fixture tests because upstream sites can change or block requests.
+
+## External audit workflow
+
+Use `scripts/audit_external_manga_sources.py` to inspect local copies of reference downloader ecosystems. It reads names, domains, languages/ecosystems, path hints, and licenses from local files only and writes `docs/EXTERNAL_SOURCE_AUDIT.md`.
+
+```bash
+python scripts/audit_external_manga_sources.py
+python scripts/audit_external_manga_sources.py external/hakuneko external/gallery-dl
+```

--- a/docs/RAW_SOURCE_PROVIDER_EXPANSION_PLAN.md
+++ b/docs/RAW_SOURCE_PROVIDER_EXPANSION_PLAN.md
@@ -1,0 +1,110 @@
+# Raw Source Provider Expansion Plan
+
+## Current source list
+
+Preserved legacy source IDs and UI names:
+
+| Source ID | Display name | Capability summary |
+| --- | --- | --- |
+| `mangadex` | MangaDex | public MangaDex API search/feed/download |
+| `mangadex_raw` | MangaDex (raw / original language) | MangaDex original-language search/feed filters |
+| `mangadex_url` | MangaDex (by chapter URL) | chapter UUID/URL loader |
+| `comick` | Comick | search and chapter list only; no image URLs |
+| `gomanga` | GOMANGA | API-backed search/feed/download |
+| `manhwa_reader` | Manhwa Reader | API-backed search/feed/download, hidden when unavailable |
+| `mangaforfree` | MangaForFree | static/WP-Manga search/feed, generic URL download |
+| `toongod` | ToonGod | static/WP-Manga search/feed, generic URL download |
+| `mangakakalot` | Mangakakalot | static search/feed, generic URL download |
+| `naruraw` | NaruRaw (Japanese raw) | raw search/feed, generic URL download |
+| `manhwaraw` | ManhwaRaw (Korean raw) | raw search/feed, generic URL download |
+| `onekkk` | 1kkk (Chinese manhua) | raw search/feed, generic URL download |
+| `generic_chapter_url` | Generic (chapter URL) | URL image extraction/download |
+| `raws_manhwa_manhua_url` | Raws / Manhwa / Manhua (chapter URL) | URL image extraction/download |
+| `local_folder` | Local folder | opens an existing folder as a project |
+
+New registry-backed first-batch providers:
+
+| Source ID | Display name | Status | Notes |
+| --- | --- | --- | --- |
+| `mangasee` | MangaSee / MangaSee123 | enabled | public static reader parser, no bypass |
+| `readmanga` | ReadManga-style | enabled | best-effort public HTML parser |
+| `manganato` | Manganato / Manganelo | enabled | public Manganato/Manganelo compatibility parser |
+| `suwayomi_bridge` | Suwayomi bridge | disabled | optional future local bridge |
+| `rawkuma` | RawKuma (Japanese raw) | experimental | public parser, opt-in via experimental sources |
+| `manhuagui` | Manhuagui (Chinese manhua) | experimental | public parser, opt-in via experimental sources |
+
+## Current source interface shape
+
+Legacy clients are synchronous classes with ad-hoc but similar methods:
+
+- `search(title_or_keyword, limit=...) -> list[dict]`
+- `get_feed(manga_id, translated_language=..., limit=..., order=...) -> list[dict]`
+- `download_chapter(chapter_id, save_dir, ...) -> Optional[str]` for MangaDex/API clients
+- chapter-page sources return chapter URLs and use `GenericChapterUrlClient.download_chapter(...)`
+
+The UI keeps source branching in `ui/manga_source_dialog.py`, stores settings in `pcfg.manga_source_*`, and preserves page naming as `001.ext`, `002.ext`, plus `manifest.json` for generic URL downloads.
+
+## Duplicated logic to extract
+
+- Conservative request throttling and shared user-agent setup.
+- Absolute URL normalization, slug inference, chapter display formatting.
+- Static HTML search-card parsing.
+- Static HTML chapter-list parsing.
+- Lazy image URL extraction and referer-aware download.
+- Source capability/status metadata that was previously embedded in UI conditionals.
+- Playwright/headless visibility decisions for sources that may need user-controlled browser rendering.
+
+## Missing provider capabilities
+
+The old shape did not describe whether a source:
+
+- supports search, latest/feed, chapter URL loading, or download;
+- supports original/raw language filters;
+- requires Playwright, cookies, or referer headers;
+- is stable, experimental, disabled, broken, or only a bridge/API;
+- has aliases or fallback base URLs;
+- should be hidden when optional dependencies fail to import.
+
+`utils/manga_sources/provider_base.py` now defines typed capabilities and result objects, and `utils/manga_sources/registry.py` owns source metadata.
+
+## Proposed source candidates
+
+Low-risk first candidates are public/static HTML or documented public API sources only:
+
+1. MangaSee/MangaSee123-style public pages.
+2. ReadManga-style public pages.
+3. Manganato/Manganelo compatibility pages and aliases.
+4. ComicK resolver improvements only if public image URLs become available from a documented API or visible HTML.
+5. MangaDex improvements using public API behavior: rate-limit handling, optional language/group filters, data/data-saver ordering, and stable filenames.
+6. Optional Suwayomi bridge that talks to a user-run local server without bundling Suwayomi or Java.
+
+Excluded by policy: DRM/paywall bypass, login-only content, private mobile APIs, hidden tokens, CAPTCHA/Cloudflare bypass, or automated cookies not explicitly supplied by the user.
+
+## License risks per reference repo
+
+| Reference | Pattern to learn | License risk / handling |
+| --- | --- | --- |
+| keiyoushi/extensions-source | provider classes, capabilities, language/source metadata | Kotlin extensions are typically Apache-style ecosystem code but source-specific files can vary; do not copy code/selectors wholesale without verifying file license. |
+| Suwayomi/Suwayomi-Server | local bridge/runtime pattern | Bridge should use only the user's running server API; do not bundle server code. |
+| manga-download/hakuneko | connector-style site isolation | HakuNeko has its own licensing and connector code; use behavior/architecture only, no copy-paste. |
+| dazedcat19/FMD2 | broad source catalog and Lua parser patterns | GPL/Lua/Pascal obligations are risky; use as candidate inventory only unless compatibility is confirmed. |
+| metafates/mangal and mangal-scrapers | Go CLI plus Lua scraper separation | Use plugin/scraper isolation ideas only; do not embed incompatible scraper code. |
+| manga-py/manga-py | Python provider inventory | Archived code may be stale and license-specific; use as historical behavior reference only. |
+| mikf/gallery-dl | extractor registry, filename/rate-limit practices | GPL-family obligations likely incompatible for direct copying; clean-room architecture ideas only. |
+| mansuf/mangadex-downloader | robust public MangaDex handling | Python MangaDex behavior can inspire public API handling; avoid copying implementation unless license obligations are reviewed. |
+
+## Test plan
+
+- Unit-test provider dataclasses, legacy dict conversion, registry aliases, and import-failure safety.
+- Unit-test static parser behavior with saved HTML fixtures for each new provider.
+- Keep `scripts/test_manga_sources.py` working for legacy stable sources.
+- Expand smoke-test discovery so stable registry providers can be tested without enabling disabled sources.
+- Add `--include-experimental` for unstable providers (e.g., rawkuma/manhuagui).
+- Compile edited Python files and avoid network requirements in unit tests.
+- Never log secrets/cookies; fixtures must not contain copyrighted page images.
+
+
+### Registry parser smoke examples
+
+- `python scripts/test_manga_sources.py --stable-registry-only` (stable registry providers)
+- `python scripts/test_manga_sources.py --stable-registry-only --include-experimental` (includes experimental providers with fixtures)

--- a/scripts/audit_external_manga_sources.py
+++ b/scripts/audit_external_manga_sources.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Audit local external manga downloader repositories for provider candidates.
+
+This tool reads metadata from user-supplied/local folders only. It does not
+scrape manga pages, download copyrighted content, or require network access.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FOLDERS = [
+    ROOT / "external/keiyoushi/extensions-source",
+    ROOT / "external/hakuneko",
+    ROOT / "external/FMD2",
+    ROOT / "external/mangal-scrapers",
+    ROOT / "external/manga-py",
+    ROOT / "external/gallery-dl",
+    ROOT / "external/mangadex-downloader",
+]
+OUTPUT = ROOT / "docs/EXTERNAL_SOURCE_AUDIT.md"
+LICENSE_FILES = ("LICENSE", "LICENSE.md", "COPYING", "COPYING.txt")
+SOURCE_PATTERNS = ("*.kt", "*.js", "*.ts", "*.lua", "*.py", "*.pas", "*.pp")
+DOMAIN_RE = re.compile(r"https?://([A-Za-z0-9.-]+)")
+
+
+@dataclass
+class Candidate:
+    ecosystem: str
+    name: str
+    path: str
+    domains: list[str]
+    portability: str
+    active_hint: str
+    requires_browser_or_cookies: str
+    overlaps_existing: str
+
+
+def ecosystem_for(path: Path) -> str:
+    suffix = path.suffix.lower()
+    if suffix == ".kt":
+        return "Kotlin"
+    if suffix in {".js", ".ts"}:
+        return "JS"
+    if suffix == ".lua":
+        return "Lua"
+    if suffix == ".py":
+        return "Python"
+    if suffix in {".pas", ".pp"}:
+        return "Pascal"
+    return "Unknown"
+
+
+def likely_name(path: Path, text: str) -> str:
+    for pattern in [r'class\s+([A-Za-z0-9_]+)', r'name\s*[:=]\s*["\']([^"\']+)', r'TITLE\s*=\s*["\']([^"\']+)']:
+        m = re.search(pattern, text)
+        if m:
+            return m.group(1)
+    return path.stem
+
+
+def read_license(folder: Path) -> str:
+    for name in LICENSE_FILES:
+        p = folder / name
+        if p.exists():
+            first = p.read_text(errors="ignore")[:2000].lower()
+            if "gpl" in first:
+                return "GPL-family or mentions GPL; avoid copying unless obligations are handled"
+            if "apache" in first:
+                return "Apache-style; still verify per-file headers"
+            if "mit license" in first or "permission is hereby granted" in first:
+                return "MIT-style; verify per-file headers"
+            return f"License file present: {name}; manual review needed"
+    return "No top-level license detected; manual review required"
+
+
+def classify_portability(ecosystem: str, text: str) -> str:
+    lower = text.lower()
+    if any(token in lower for token in ("cloudflare", "captcha", "login", "cookie")):
+        return "Medium/low: may need user browser or cookies"
+    if ecosystem in {"Python", "JS", "Lua"}:
+        return "Medium/high: selectors or JSON parsing likely portable"
+    if ecosystem == "Kotlin":
+        return "Medium: Tachiyomi/Mihon concepts portable, code is not direct Python"
+    if ecosystem == "Pascal":
+        return "Medium/low: useful inventory, parser rewrite needed"
+    return "Unknown"
+
+
+def browser_cookie_hint(text: str) -> str:
+    lower = text.lower()
+    hits = [word for word in ("playwright", "puppeteer", "webview", "cloudflare", "captcha", "cookie", "login") if word in lower]
+    return ", ".join(hits) if hits else "No obvious browser/cookie requirement"
+
+
+def overlap(domains: Iterable[str]) -> str:
+    existing = ("mangadex", "comick", "mangakakalot", "manganato", "manganelo", "mangasee", "readmanga", "1kkk")
+    matched = sorted({d for d in domains if any(x in d.lower() for x in existing)})
+    return ", ".join(matched) if matched else "No obvious overlap"
+
+
+def audit_folder(folder: Path, max_files: int = 2500) -> tuple[str, list[Candidate]]:
+    candidates: list[Candidate] = []
+    files: list[Path] = []
+    for pattern in SOURCE_PATTERNS:
+        files.extend(folder.rglob(pattern))
+    for path in files[:max_files]:
+        if any(part in {".git", "node_modules", "build", "dist", "vendor"} for part in path.parts):
+            continue
+        try:
+            text = path.read_text(errors="ignore")[:20000]
+        except Exception:
+            continue
+        domains = sorted(set(DOMAIN_RE.findall(text)))[:8]
+        if not domains and not re.search(r"manga|comic|source|connector|extractor", text, re.I):
+            continue
+        eco = ecosystem_for(path)
+        candidates.append(Candidate(
+            ecosystem=eco,
+            name=likely_name(path, text),
+            path=str(path.relative_to(ROOT)),
+            domains=domains,
+            portability=classify_portability(eco, text),
+            active_hint="Recentness requires git history review" if (folder / ".git").exists() else "No git metadata in local copy",
+            requires_browser_or_cookies=browser_cookie_hint(text),
+            overlaps_existing=overlap(domains),
+        ))
+    return read_license(folder), candidates
+
+
+def write_report(results: list[tuple[Path, str, list[Candidate]]]) -> None:
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# External Manga Source Audit", "", "Generated from local folders only; no network access or content scraping is performed.", ""]
+    if not results:
+        lines += ["No external folders were found or supplied.", "", "Place repositories under `external/` or pass paths on the command line, then rerun:", "", "```bash", "python scripts/audit_external_manga_sources.py external/hakuneko", "```", ""]
+    for folder, license_summary, candidates in results:
+        lines += [f"## {folder}", "", f"License: {license_summary}", "", "| Ecosystem | Name | Path | Domains | Portability | Browser/cookies | Existing overlap | Active hint |", "| --- | --- | --- | --- | --- | --- | --- | --- |"]
+        for c in candidates[:200]:
+            lines.append(f"| {c.ecosystem} | {c.name} | `{c.path}` | {', '.join(c.domains) or '-'} | {c.portability} | {c.requires_browser_or_cookies} | {c.overlaps_existing} | {c.active_hint} |")
+        if not candidates:
+            lines.append("| - | - | - | - | No candidates detected | - | - | - |")
+        lines.append("")
+    OUTPUT.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, help="Optional local external repository folders")
+    args = parser.parse_args()
+    folders = args.paths or DEFAULT_FOLDERS
+    existing = [p.resolve() for p in folders if p.exists() and p.is_dir()]
+    if not existing:
+        write_report([])
+        print("No external source folders found. Expected optional folders:")
+        for p in DEFAULT_FOLDERS:
+            print(f"  - {p.relative_to(ROOT)}")
+        print(f"Wrote instructions to {OUTPUT.relative_to(ROOT)}")
+        return 0
+    results = []
+    for folder in existing:
+        license_summary, candidates = audit_folder(folder)
+        results.append((folder, license_summary, candidates))
+    write_report(results)
+    print(f"Wrote {OUTPUT.relative_to(ROOT)} for {len(results)} folder(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_manga_sources.py
+++ b/scripts/test_manga_sources.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import sys
 import os
+import argparse
 
 # Run from repo root
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -21,6 +22,7 @@ from utils.manga_sources import (
     OneKkkClient,
     GenericChapterUrlClient,
 )
+from utils.manga_sources.registry import get_provider, list_sources
 
 
 def _safe(s: str, max_len: int = 60) -> str:
@@ -83,9 +85,46 @@ def test_download_generic(name: str, chapter_url: str, use_playwright: bool = Fa
         return False
 
 
-def main():
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Smoke-test manga source clients. Network sites may fail independently of the app.")
+    parser.add_argument("--include-experimental", action="store_true", help="Include experimental registry providers in smoke tests.")
+    parser.add_argument("--stable-registry-only", action="store_true", help="Only run registry-backed stable providers added by the provider architecture.")
+    args = parser.parse_args(argv)
     print("Manga source client tests (HTTP only by default)")
     results = {}
+
+    registry_smoke_sources = [m for m in list_sources(include_disabled=False, include_experimental=args.include_experimental) if m.source_id in {"mangasee", "readmanga", "manganato", "rawkuma", "manhuagui"}]
+    if args.stable_registry_only:
+        # Deterministic parser smoke for registry-backed providers. Network smoke is
+        # covered by the default mode but may fail when upstream sites block HTTP.
+        from pathlib import Path
+
+        fixture_dir = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "manga_sources"
+        fixture_map = {
+            "mangasee": ("mangasee_search.html", "mangasee_feed.html"),
+            "readmanga": ("readmanga_search.html", "readmanga_feed.html"),
+            "manganato": ("manganato_search.html", "manganato_feed.html"),
+            "rawkuma": ("rawkuma_search.html", "rawkuma_feed.html"),
+            "manhuagui": ("manhuagui_search.html", "manhuagui_feed.html"),
+        }
+        for meta in registry_smoke_sources:
+            print(f"\n--- {meta.display_name} registry parser smoke ---")
+            try:
+                client = get_provider(meta.source_id, timeout=15, request_delay=0)
+                search_fixture, feed_fixture = fixture_map[meta.source_id]
+                parsed_search = client.parse_search((fixture_dir / search_fixture).read_text(encoding="utf-8"), limit=5)
+                parsed_feed = client.parse_feed((fixture_dir / feed_fixture).read_text(encoding="utf-8"), manga_id=parsed_search[0].id if parsed_search else "sample", limit=5)
+                ok = bool(parsed_search and parsed_feed)
+                print(f"  Parsed search={len(parsed_search)} feed={len(parsed_feed)}")
+                results[f"{meta.display_name} parser"] = ok
+            except Exception as e:
+                print(f"  {meta.display_name} Error: {e}")
+                results[f"{meta.display_name} parser"] = False
+        failed = sum(1 for v in results.values() if not v)
+        print("\n--- Summary ---")
+        for k, v in results.items():
+            print(f"  {k}: {'OK' if v else 'FAIL'}")
+        return 0 if failed == 0 else 1
 
     # Mangakakalot
     client_kakalot = MangakakalotClient(base_url="https://www.mangakakalot.gg", timeout=15, request_delay=0.5)

--- a/tests/fixtures/manga_sources/manganato_feed.html
+++ b/tests/fixtures/manga_sources/manganato_feed.html
@@ -1,0 +1,1 @@
+<ul class="row-content-chapter"><li><a href="https://chapmanganato.to/manga-abc123/chapter-1">Chapter 1: Start</a></li><li><a href="/manga-abc123/chapter-2">Chapter 2</a></li></ul>

--- a/tests/fixtures/manga_sources/manganato_search.html
+++ b/tests/fixtures/manga_sources/manganato_search.html
@@ -1,0 +1,1 @@
+<div class="search-story-item"><a class="item-img" href="https://manganato.com/manga-abc123"><img></a><a class="item-title" href="https://manganato.com/manga-abc123">Sample Manga</a></div>

--- a/tests/fixtures/manga_sources/mangasee_feed.html
+++ b/tests/fixtures/manga_sources/mangasee_feed.html
@@ -1,0 +1,1 @@
+<script>vm.Chapters = [{"Chapter":"1","ChapterName":"Start"},{"Chapter":"2","ChapterName":"Next"}];</script>

--- a/tests/fixtures/manga_sources/mangasee_search.html
+++ b/tests/fixtures/manga_sources/mangasee_search.html
@@ -1,0 +1,1 @@
+<script>vm.IndexName = [{"i":"Sample-Series","s":"Sample Series"}];</script>

--- a/tests/fixtures/manga_sources/manhuagui_feed.html
+++ b/tests/fixtures/manga_sources/manhuagui_feed.html
@@ -1,0 +1,1 @@
+<div id="chapter-list"><a href="https://www.manhuagui.com/comic/12345/1.html">第1话</a></div>

--- a/tests/fixtures/manga_sources/manhuagui_search.html
+++ b/tests/fixtures/manga_sources/manhuagui_search.html
@@ -1,0 +1,1 @@
+<ul class="book-result"><li><a href="https://www.manhuagui.com/comic/12345/" class="book-title">示例漫画</a></li></ul>

--- a/tests/fixtures/manga_sources/pages.html
+++ b/tests/fixtures/manga_sources/pages.html
@@ -1,0 +1,1 @@
+<div class="reader"><img data-src="https://cdn.example.org/001.jpg"><img src="/002.webp"></div>

--- a/tests/fixtures/manga_sources/rawkuma_feed.html
+++ b/tests/fixtures/manga_sources/rawkuma_feed.html
@@ -1,0 +1,1 @@
+<ul><li class="wp-manga-chapter"><a href="https://rawkuma.com/manga/sample-raw/chapter-1/">Chapter 1</a></li></ul>

--- a/tests/fixtures/manga_sources/rawkuma_search.html
+++ b/tests/fixtures/manga_sources/rawkuma_search.html
@@ -1,0 +1,1 @@
+<div class="c-tabs-item__content"><div class="post-title"><a href="https://rawkuma.com/manga/sample-raw/">Sample Raw</a></div></div>

--- a/tests/fixtures/manga_sources/readmanga_feed.html
+++ b/tests/fixtures/manga_sources/readmanga_feed.html
@@ -1,0 +1,1 @@
+<div class="chapter-list"><a href="/manga/sample-title/chapter-1">Chapter 1</a><a href="/manga/sample-title/chapter-2">Chapter 2</a></div>

--- a/tests/fixtures/manga_sources/readmanga_search.html
+++ b/tests/fixtures/manga_sources/readmanga_search.html
@@ -1,0 +1,1 @@
+<div class="manga-list"><div class="item"><a href="/manga/sample-title"><span class="title">Sample Title</span></a></div></div>

--- a/tests/test_manga_provider_base.py
+++ b/tests/test_manga_provider_base.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+from utils.manga_sources.manganato import ManganatoClient
+from utils.manga_sources.mangasee import MangaSeeClient
+from utils.manga_sources.provider_base import MangaChapter, MangaPage, MangaSearchResult, MangaSourceCapabilities
+from utils.manga_sources.readmanga import ReadMangaClient
+from utils.manga_sources.rawkuma import RawKumaClient
+from utils.manga_sources.manhuagui import ManhuaguiClient
+from utils.manga_sources.registry import get_metadata, get_provider, list_sources, check_source_health
+
+FIXTURES = Path(__file__).parent / "fixtures" / "manga_sources"
+
+
+def test_provider_dataclasses_legacy_dicts():
+    caps = MangaSourceCapabilities(supports_raw_language=True, requires_playwright=True)
+    assert caps.supports_raw_language is True
+    assert caps.requires_playwright is True
+    assert MangaSearchResult("id", "Title", url="https://e.test", extra={"description": "d"}).as_legacy_dict()["description"] == "d"
+    assert MangaChapter("c", "Chapter", index=1).as_legacy_dict()["index"] == 1
+    assert MangaPage("https://e.test/1.jpg", filename="001.jpg").filename == "001.jpg"
+
+
+def test_registry_lists_legacy_and_new_sources():
+    ids = {item.source_id for item in list_sources()}
+    assert "mangadex" in ids
+    assert "mangasee" in ids
+    assert "readmanga" in ids
+    assert "manganato" in ids
+    assert "rawkuma" in ids
+    assert "manhuagui" in ids
+    assert get_metadata("manganelo").source_id == "manganato"
+    provider = get_provider("manganato", timeout=1, request_delay=0)
+    assert provider.source_id == "manganato"
+
+
+def test_manganato_fixture_parsers():
+    client = ManganatoClient(request_delay=0)
+    results = client.parse_search((FIXTURES / "manganato_search.html").read_text())
+    assert results[0].title == "Sample Manga"
+    chapters = client.parse_feed((FIXTURES / "manganato_feed.html").read_text(), manga_id="manga-abc123")
+    assert len(chapters) == 2
+    assert chapters[0].url.endswith("chapter-1")
+    pages = client.parse_pages((FIXTURES / "pages.html").read_text(), "https://manganato.com/manga-abc123/chapter-1")
+    assert [p.url for p in pages] == ["https://cdn.example.org/001.jpg", "https://manganato.com/002.webp"]
+
+
+def test_mangasee_fixture_parsers():
+    client = MangaSeeClient(request_delay=0)
+    results = client.parse_search((FIXTURES / "mangasee_search.html").read_text())
+    assert results[0].id == "Sample-Series"
+    chapters = client.parse_feed((FIXTURES / "mangasee_feed.html").read_text(), manga_id="Sample-Series")
+    assert chapters[0].display == "Chapter 1 – Start"
+    assert "read-online" in chapters[0].url
+
+
+def test_readmanga_fixture_parsers():
+    client = ReadMangaClient(request_delay=0)
+    results = client.parse_search((FIXTURES / "readmanga_search.html").read_text())
+    assert results[0].id == "sample-title"
+    chapters = client.parse_feed((FIXTURES / "readmanga_feed.html").read_text(), manga_id="sample-title")
+    assert [c.display for c in chapters] == ["Chapter 1", "Chapter 2"]
+
+
+def test_raw_providers_fixture_parsers():
+    rawkuma = RawKumaClient(request_delay=0)
+    rk_search = rawkuma.parse_search((FIXTURES / "rawkuma_search.html").read_text())
+    rk_feed = rawkuma.parse_feed((FIXTURES / "rawkuma_feed.html").read_text(), manga_id="sample-raw")
+    assert rk_search and rk_feed
+
+    mhg = ManhuaguiClient(request_delay=0)
+    mhg_search = mhg.parse_search((FIXTURES / "manhuagui_search.html").read_text())
+    mhg_feed = mhg.parse_feed((FIXTURES / "manhuagui_feed.html").read_text(), manga_id="12345")
+    assert mhg_search and mhg_feed
+
+
+def test_registry_health_check_utility():
+    ok, msg = check_source_health("generic_chapter_url")
+    assert ok is True
+    assert "No base URL" in msg

--- a/ui/manga_source_dialog.py
+++ b/ui/manga_source_dialog.py
@@ -30,6 +30,7 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QAbstractItemView,
     QDoubleSpinBox,
+    QTextEdit,
 )
 
 from utils.manga_sources import (
@@ -49,6 +50,7 @@ from utils.manga_sources.generic_chapter_url import ensure_playwright_chromium_i
 from utils.config import pcfg, save_config, ProgramConfig
 from utils.logger import logger as LOGGER
 from utils.manga_sources.search_translate import translate_search_query
+from utils.manga_sources.registry import get_metadata, get_provider, list_sources, check_source_health
 
 
 def _sanitize_filename(name: str) -> str:
@@ -72,24 +74,23 @@ def _extract_mangadex_chapter_id(url_or_id: str) -> Optional[str]:
 # Source combo: (display label, source_id). Manhwa Reader is shown only when API is up.
 # generic_chapter_url and *_url sources use paste-chapter-URL flow (same backend).
 GENERIC_CHAPTER_SOURCE_IDS = ("generic_chapter_url", "raws_manhwa_manhua_url")
-SOURCE_OPTIONS: List[tuple] = [
-    ("MangaDex", "mangadex"),
-    ("MangaDex (raw / original language)", "mangadex_raw"),
-    ("MangaDex (by chapter URL)", "mangadex_url"),
-    ("Comick", "comick"),
-    ("GOMANGA", "gomanga"),
-    ("Manhwa Reader", "manhwa_reader"),
-    ("MangaForFree", "mangaforfree"),
-    ("ToonGod", "toongod"),
-    ("Mangakakalot", "mangakakalot"),
-    ("NaruRaw (Japanese raw)", "naruraw"),
-    ("ManhwaRaw (Korean raw)", "manhwaraw"),
-    ("1kkk (Chinese manhua)", "onekkk"),
-    ("Generic (chapter URL)", "generic_chapter_url"),
-    ("Raws / Manhwa / Manhua (chapter URL)", "raws_manhwa_manhua_url"),
-    ("Local folder", "local_folder"),
-]
+SOURCE_OPTIONS: List[tuple] = []  # populated from registry at runtime
+STATIC_SITE_SOURCE_IDS = (
+    "mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk",
+    "mangasee", "readmanga", "manganato",
+)
+RAW_TRANSLATED_SEARCH_SOURCE_IDS = ("naruraw", "manhwaraw", "onekkk")
 
+
+
+
+def _source_category_match(category: str, filter_value: str) -> bool:
+    c = (category or "").lower()
+    mapping = {"raw_jp":"japanese raw","raw_kr":"korean raw","manhua_cn":"chinese manhua","en_agg":"english aggregator","generic_url":"generic url","local":"local folder","bridge":"bridge"}
+    if filter_value == "all":
+        return True
+    key = mapping.get(filter_value)
+    return (key in c) if key else True
 
 def _mangadex_original_language_code(ui_code: str) -> str:
     """Map UI language code to MangaDex API originalLanguage (e.g. zh-hans -> zh)."""
@@ -110,12 +111,16 @@ class MangaSourceWorker(QObject):
     download_progress = Signal(int, int, str)  # current, total, chapter_display
     download_finished = Signal(str)  # path to folder that was downloaded
     manhwa_reader_available = Signal(bool)  # True if Manhwa Reader API is up
+    health_check_finished = Signal(bool, str)
+    source_test_finished = Signal(bool, str)
     run_search = Signal(str, str, str, bool, bool)   # title, source_id, lang, use_playwright, headless
     run_feed = Signal(str, str, str, bool, bool)  # manga_id, lang, source_id, use_playwright, headless
     run_download = Signal(object)  # (chapter_infos, base_dir, manga_title, data_saver, source_id [, use_playwright, headless])
     run_load_chapter_url = Signal(str)
     run_load_generic_chapter_url = Signal(str, bool, bool)  # chapter_url, use_playwright, headless
     run_check_manhwa_reader = Signal()
+    run_health_check = Signal(str)
+    run_test_source = Signal(str)
 
     def __init__(self):
         super().__init__()
@@ -131,6 +136,17 @@ class MangaSourceWorker(QObject):
         self._naruraw = NaruRawClient(base_url="https://naruraw.net", timeout=25, request_delay=delay)
         self._manhwaraw = ManhwaRawClient(base_url="https://manhwaraw.club", timeout=25, request_delay=delay)
         self._onekkk = OneKkkClient(base_url="https://www.1kkk.com", timeout=25, request_delay=delay)
+        self._registry_clients = {}
+        self._registry_source_ids = []
+        for _meta in list_sources(include_disabled=False, include_experimental=getattr(pcfg, "manga_source_show_experimental", True)):
+            _source_id = _meta.source_id
+            if _source_id in {"mangadex", "mangadex_raw", "mangadex_url", "comick", "gomanga", "manhwa_reader", "mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk", "generic_chapter_url", "raws_manhwa_manhua_url", "local_folder"}:
+                continue
+            self._registry_source_ids.append(_source_id)
+            try:
+                self._registry_clients[_source_id] = get_provider(_source_id, config=pcfg, timeout=25, request_delay=delay)
+            except Exception as exc:
+                LOGGER.warning("Manga source %s unavailable: %s", _source_id, exc)
         self._abort = False
         self.run_search.connect(self.do_search)
         self.run_feed.connect(self.do_feed)
@@ -138,6 +154,8 @@ class MangaSourceWorker(QObject):
         self.run_load_chapter_url.connect(self.do_load_chapter_by_url)
         self.run_load_generic_chapter_url.connect(self.do_load_generic_chapter_url)
         self.run_check_manhwa_reader.connect(self._do_check_manhwa_reader)
+        self.run_health_check.connect(self._do_health_check)
+        self.run_test_source.connect(self._do_test_source)
 
     def abort(self):
         self._abort = True
@@ -148,6 +166,28 @@ class MangaSourceWorker(QObject):
             self.manhwa_reader_available.emit(ok)
         except Exception:
             self.manhwa_reader_available.emit(False)
+
+
+    def _do_health_check(self, source_id: str):
+        ok, msg = check_source_health(source_id, config=pcfg, timeout=10)
+        self.health_check_finished.emit(ok, msg)
+
+
+    def _do_test_source(self, source_id: str):
+        try:
+            if source_id in self._registry_clients:
+                client = self._registry_clients[source_id]
+                query = "one piece"
+                if source_id in RAW_TRANSLATED_SEARCH_SOURCE_IDS or source_id in ("rawkuma", "manhuagui"):
+                    query = "raw"
+                results = client.search(query, limit=1)
+                ok = bool(results)
+                msg = f"search('{query}') returned {len(results)} result(s)."
+                self.source_test_finished.emit(ok, msg)
+                return
+            self.source_test_finished.emit(True, "Legacy source: use scripts/test_manga_sources.py for full smoke checks.")
+        except Exception as exc:
+            self.source_test_finished.emit(False, str(exc))
 
     def do_search(self, title: str, source_id: str, lang: str = "", use_playwright: bool = False, headless: bool = True):
         self._abort = False
@@ -212,6 +252,14 @@ class MangaSourceWorker(QObject):
             self._onekkk.request_delay = delay
             try:
                 results = self._onekkk.search(title, limit=25, use_playwright=use_playwright, headless=headless)
+                self.search_finished.emit(results)
+            except Exception as e:
+                self.error.emit(str(e))
+        elif source_id in self._registry_clients:
+            client = self._registry_clients[source_id]
+            client.request_delay = delay
+            try:
+                results = client.search(title, limit=25)
                 self.search_finished.emit(results)
             except Exception as e:
                 self.error.emit(str(e))
@@ -299,6 +347,14 @@ class MangaSourceWorker(QObject):
                 self.feed_finished.emit(chapters)
             except Exception as e:
                 self.error.emit(str(e))
+        elif source_id in self._registry_clients:
+            client = self._registry_clients[source_id]
+            client.request_delay = delay
+            try:
+                chapters = client.get_feed(manga_id, limit=500, order="asc")
+                self.feed_finished.emit(chapters)
+            except Exception as e:
+                self.error.emit(str(e))
         elif source_id == "mangadex_raw":
             self._mangadex.request_delay = delay
             try:
@@ -335,7 +391,7 @@ class MangaSourceWorker(QObject):
                 "Use MangaDex for download, or open the chapter link in your browser."
             )
             return
-        if source_id in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk") or source_id in GENERIC_CHAPTER_SOURCE_IDS:
+        if source_id in STATIC_SITE_SOURCE_IDS or source_id in getattr(self, "_registry_source_ids", []) or source_id in GENERIC_CHAPTER_SOURCE_IDS:
             self._do_download_generic_chapter_url(
                 chapter_infos, base_dir, manga_title, data_saver, use_playwright=use_playwright, headless=headless
             )
@@ -532,6 +588,35 @@ class MangaSourceDialog(QDialog):
         row.addWidget(self._source_combo)
         row.addStretch()
         search_layout.addLayout(row)
+        row_meta = QHBoxLayout()
+        self._show_experimental_check = QCheckBox(self.tr("Show experimental sources"))
+        self._show_experimental_check.setChecked(getattr(pcfg, "manga_source_show_experimental", True))
+        self._show_experimental_check.toggled.connect(self._on_toggle_show_experimental)
+        row_meta.addWidget(self._show_experimental_check)
+        row_meta.addWidget(QLabel(self.tr("Source filter:")))
+        self._source_filter_combo = QComboBox()
+        for value, label in [("all", "All"), ("raw_jp", "Japanese raw"), ("raw_kr", "Korean raw"), ("manhua_cn", "Chinese manhua"), ("en_agg", "English aggregator"), ("generic_url", "Generic URL"), ("local", "Local folder"), ("bridge", "Bridge/API")]:
+            self._source_filter_combo.addItem(self.tr(label), value)
+        self._source_filter_combo.currentIndexChanged.connect(self._on_source_filter_changed)
+        saved_filter = getattr(pcfg, "manga_source_filter", "all")
+        idx_sf = self._source_filter_combo.findData(saved_filter)
+        if idx_sf >= 0:
+            self._source_filter_combo.setCurrentIndex(idx_sf)
+        row_meta.addWidget(self._source_filter_combo)
+        self._health_btn = QPushButton(self.tr("Health check"))
+        self._health_btn.clicked.connect(self._on_health_check)
+        row_meta.addWidget(self._health_btn)
+        self._test_source_btn = QPushButton(self.tr("Test selected source"))
+        self._test_source_btn.clicked.connect(self._on_test_selected_source)
+        row_meta.addWidget(self._test_source_btn)
+        self._open_source_site_btn = QPushButton(self.tr("Open source website"))
+        self._open_source_site_btn.clicked.connect(self._on_open_source_site)
+        row_meta.addWidget(self._open_source_site_btn)
+        row_meta.addStretch()
+        search_layout.addLayout(row_meta)
+        self._source_badge_legend = QLabel(self.tr("Badges: experimental, disabled, broken, needs browser, cookies"))
+        self._source_badge_legend.setStyleSheet("color: #888;")
+        search_layout.addWidget(self._source_badge_legend)
         row2 = QHBoxLayout()
         self._search_edit = QLineEdit()
         self._search_edit.setPlaceholderText(self.tr("Enter manga title..."))
@@ -585,6 +670,18 @@ class MangaSourceDialog(QDialog):
         row_local.addStretch()
         search_layout.addLayout(row_local)
         self._local_folder_widgets = [self._local_folder_label, self._open_local_folder_btn]
+        row_base = QHBoxLayout()
+        row_base.addWidget(QLabel(self.tr("Base URL override:")))
+        self._base_url_edit = QLineEdit()
+        self._base_url_edit.setPlaceholderText(self.tr("Leave empty to use source default"))
+        self._base_url_edit.editingFinished.connect(self._on_base_url_override_changed)
+        row_base.addWidget(self._base_url_edit)
+        search_layout.addLayout(row_base)
+        self._source_notes = QTextEdit()
+        self._source_notes.setReadOnly(True)
+        self._source_notes.setMaximumHeight(76)
+        self._source_notes.setPlaceholderText(self.tr("Source notes"))
+        search_layout.addWidget(self._source_notes)
         layout.addWidget(search_group)
 
         # --- Results (manga list) ---
@@ -698,6 +795,8 @@ class MangaSourceDialog(QDialog):
         self._worker.download_progress.connect(self._on_download_progress)
         self._worker.download_finished.connect(self._on_download_finished)
         self._worker.manhwa_reader_available.connect(self._on_manhwa_reader_availability)
+        self._worker.health_check_finished.connect(self._on_health_check_finished)
+        self._worker.source_test_finished.connect(self._on_source_test_finished)
 
         # Load persisted config
         lang = getattr(pcfg, 'manga_source_lang', 'en')
@@ -732,9 +831,17 @@ class MangaSourceDialog(QDialog):
         current_id = self._source_combo.currentData() if self._source_combo.currentIndex() >= 0 else None
         self._source_combo.blockSignals(True)
         self._source_combo.clear()
-        for label, source_id in SOURCE_OPTIONS:
-            if source_id not in self._unavailable_sources:
-                self._source_combo.addItem(self.tr(label), source_id)
+        include_exp = getattr(pcfg, "manga_source_show_experimental", True)
+        filter_value = getattr(pcfg, "manga_source_filter", "all") if hasattr(self, "_source_filter_combo") else "all"
+        for meta in list_sources(include_disabled=False, include_experimental=include_exp):
+            source_id = meta.source_id
+            if source_id in self._unavailable_sources:
+                continue
+            if not _source_category_match(meta.category, filter_value):
+                continue
+            self._source_combo.addItem(self.tr(meta.label()), source_id)
+            idx = self._source_combo.count() - 1
+            self._source_combo.setItemData(idx, meta.notes or meta.category, Qt.ItemDataRole.ToolTipRole)
         idx = self._source_combo.findData(current_id)
         if idx >= 0:
             self._source_combo.setCurrentIndex(idx)
@@ -768,12 +875,12 @@ class MangaSourceDialog(QDialog):
         for w in self._search_row_widgets:
             w.setVisible(not self._is_url_source and not self._is_local_folder and not self._is_generic_chapter_url)
         self._translate_raw_search_check.setVisible(
-            source in ("naruraw", "manhwaraw", "onekkk")
+            source in RAW_TRANSLATED_SEARCH_SOURCE_IDS
         )
         for w in self._url_row_widgets:
             w.setVisible(self._is_url_source or self._is_generic_chapter_url)
         self._use_playwright_check.setVisible(
-            self._is_generic_chapter_url or source in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk")
+            self._is_generic_chapter_url or source in STATIC_SITE_SOURCE_IDS or source in getattr(self, "_registry_source_ids", [])
         )
         headless_visible = self._use_playwright_check.isVisible()
         self._playwright_headless_check.setVisible(headless_visible)
@@ -809,9 +916,102 @@ class MangaSourceDialog(QDialog):
             self._status_label.setText("" if self._is_url_source else self._status_label.text())
         elif self._is_generic_chapter_url:
             self._status_label.setText(self.tr("Paste a chapter page URL and click Load chapter. For JS-heavy sites enable \"Use browser (Playwright)\"."))
-        elif source in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk"):
-            self._status_label.setText(self.tr("Search by title, load chapters, then download. Enable \"Use browser (Playwright)\" if the site uses Cloudflare or lazy-loaded images."))
+        elif source in STATIC_SITE_SOURCE_IDS or source in getattr(self, "_registry_source_ids", []):
+            try:
+                meta = get_metadata(source)
+                suffix = (" " + meta.notes) if meta.notes else ""
+            except Exception:
+                suffix = ""
+            self._status_label.setText(self.tr("Search by title, load chapters, then download. Enable browser mode only when you explicitly need JavaScript rendering.") + suffix)
+        try:
+            meta = get_metadata(source) if source else None
+            overrides = getattr(pcfg, "manga_source_base_url_overrides", {}) or {}
+            if meta and isinstance(overrides, dict):
+                self._base_url_edit.setText(overrides.get(meta.source_id, ""))
+            else:
+                self._base_url_edit.clear()
+            if meta:
+                notes = meta.notes if meta.notes else "-"
+                override = ""
+                try:
+                    overrides = getattr(pcfg, "manga_source_base_url_overrides", {}) or {}
+                    if isinstance(overrides, dict):
+                        override = overrides.get(meta.source_id, "")
+                except Exception:
+                    pass
+                base_info = override if override else (meta.base_url or "-")
+                self._source_notes.setPlainText("Status: %s\nCategory: %s\nBase URL: %s\nNotes: %s" % (meta.status, meta.category, base_info, notes))
+            else:
+                self._source_notes.clear()
+        except Exception:
+            self._source_notes.clear()
         self._on_playwright_toggled(self._use_playwright_check.isChecked())
+
+    def _on_source_filter_changed(self, _index: int):
+        pcfg.manga_source_filter = self._source_filter_combo.currentData() or "all"
+        self._save_config_to_pcfg()
+        self._populate_source_combo()
+
+    def _on_toggle_show_experimental(self, checked: bool):
+        pcfg.manga_source_show_experimental = bool(checked)
+        self._save_config_to_pcfg()
+        self._populate_source_combo()
+
+    def _on_base_url_override_changed(self):
+        sid = self._source_combo.currentData()
+        if not sid:
+            return
+        try:
+            overrides = dict(getattr(pcfg, "manga_source_base_url_overrides", {}) or {})
+            value = self._base_url_edit.text().strip()
+            if value:
+                overrides[sid] = value
+            else:
+                overrides.pop(sid, None)
+            pcfg.manga_source_base_url_overrides = overrides
+            self._save_config_to_pcfg()
+            self._status_label.setText(self.tr("Saved base URL override."))
+        except Exception as e:
+            self._status_label.setText(str(e))
+
+    def _on_health_check(self):
+        sid = self._source_combo.currentData()
+        if not sid:
+            return
+        try:
+            self._status_label.setText(self.tr("Running health check..."))
+            self._health_btn.setEnabled(False)
+            self._worker.run_health_check.emit(sid)
+        except Exception as e:
+            self._status_label.setText(str(e))
+
+    def _on_health_check_finished(self, ok: bool, message: str):
+        self._health_btn.setEnabled(True)
+        prefix = self.tr("Health check OK: ") if ok else self.tr("Health check failed: ")
+        self._status_label.setText(prefix + message)
+
+    def _on_test_selected_source(self):
+        sid = self._source_combo.currentData()
+        if not sid:
+            return
+        self._status_label.setText(self.tr("Running source test..."))
+        self._test_source_btn.setEnabled(False)
+        self._worker.run_test_source.emit(sid)
+
+    def _on_source_test_finished(self, ok: bool, message: str):
+        self._test_source_btn.setEnabled(True)
+        prefix = self.tr("Source test OK: ") if ok else self.tr("Source test failed: ")
+        self._status_label.setText(prefix + message)
+
+    def _on_open_source_site(self):
+        sid = self._source_combo.currentData()
+        if not sid:
+            return
+        try:
+            meta = get_metadata(sid)
+            self._status_label.setText((self.tr("Source website: ") + meta.base_url) if meta.base_url else self.tr("No source website configured."))
+        except Exception as e:
+            self._status_label.setText(str(e))
 
     def _on_load_chapter_url(self):
         url = self._url_edit.text().strip()
@@ -839,14 +1039,14 @@ class MangaSourceDialog(QDialog):
         if source_id in ("mangadex_url", "local_folder"):
             return
         # For raw sources: optionally translate search query to Japanese/Korean/Chinese
-        if source_id in ("naruraw", "manhwaraw", "onekkk") and self._translate_raw_search_check.isChecked():
+        if source_id in RAW_TRANSLATED_SEARCH_SOURCE_IDS and self._translate_raw_search_check.isChecked():
             translated = translate_search_query(title, source_id)
             if translated:
                 title = translated
         self._status_label.setText(self.tr("Searching..."))
         self._search_btn.setEnabled(False)
         lang = self._lang_combo.currentData() or "en"
-        use_playwright = self._use_playwright_check.isChecked() if source_id in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk") else False
+        use_playwright = self._use_playwright_check.isChecked() if source_id in STATIC_SITE_SOURCE_IDS or source_id in getattr(self, "_registry_source_ids", []) else False
         headless = self._playwright_headless_check.isChecked()
         self._worker.run_search.emit(title, source_id, lang, use_playwright, headless)
 
@@ -886,7 +1086,7 @@ class MangaSourceDialog(QDialog):
         lang = self._lang_combo.currentData() or "en"
         self._status_label.setText(self.tr("Loading chapters..."))
         self._load_ch_btn.setEnabled(False)
-        use_playwright = self._use_playwright_check.isChecked() if source_id in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk") else False
+        use_playwright = self._use_playwright_check.isChecked() if source_id in STATIC_SITE_SOURCE_IDS or source_id in getattr(self, "_registry_source_ids", []) else False
         headless = self._playwright_headless_check.isChecked()
         self._worker.run_feed.emit(manga_id, lang, source_id, use_playwright, headless)
 
@@ -983,7 +1183,7 @@ class MangaSourceDialog(QDialog):
             self._data_saver_check.isChecked(),
             source_id,
         )
-        if source_id in ("mangaforfree", "toongod", "mangakakalot", "naruraw", "manhwaraw", "onekkk") or source_id in GENERIC_CHAPTER_SOURCE_IDS:
+        if source_id in STATIC_SITE_SOURCE_IDS or source_id in getattr(self, "_registry_source_ids", []) or source_id in GENERIC_CHAPTER_SOURCE_IDS:
             payload = payload + (self._use_playwright_check.isChecked(), self._playwright_headless_check.isChecked())
         self._worker.run_download.emit(payload)
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -555,6 +555,9 @@ class ProgramConfig(Config):
     manga_source_open_after_download: bool = False
     manga_source_playwright_headless: bool = True
     manga_source_translate_raw_search: bool = True  # For raw sources: translate search query to Japanese/Korean/Chinese
+    manga_source_show_experimental: bool = True
+    manga_source_base_url_overrides: Dict[str, str] = field(default_factory=dict)
+    manga_source_filter: str = "all"
     # Model packages to download at startup (None = legacy "all"; ["core"] = minimal). See utils.model_packages.
     model_packages_enabled: Optional[List[str]] = field(default_factory=lambda: ["core"])
     # True when first-run explicitly chose "Skip all downloads, local-only modules".
@@ -731,7 +734,7 @@ CONFIG_KEY_ORDER = (
     "default_device", "unload_after_idle_minutes", "ocr_spell_check",
     "manga_source_lang", "manga_source_data_saver", "manga_source_download_dir",
     "manga_source_request_delay", "manga_source_open_after_download", "manga_source_playwright_headless",
-    "manga_source_translate_raw_search",
+    "manga_source_translate_raw_search", "manga_source_show_experimental", "manga_source_base_url_overrides", "manga_source_filter",
     "model_packages_enabled",
     "offline_local_only_mode",
     "show_module_tier_badges_in_tooltips",

--- a/utils/manga_sources/__init__.py
+++ b/utils/manga_sources/__init__.py
@@ -25,4 +25,33 @@ __all__ = [
     "NaruRawClient",
     "ManhwaRawClient",
     "OneKkkClient",
+    "MangaSourceCapabilities",
+    "MangaSearchResult",
+    "MangaChapter",
+    "MangaPage",
+    "MangaSourceProvider",
+    "get_provider",
+    "list_sources",
+    "source_options",
+    "check_source_health",
+    "MangaSeeClient",
+    "ReadMangaClient",
+    "ManganatoClient",
+    "RawKumaClient",
+    "ManhuaguiClient",
 ]
+
+from .provider_base import (
+    MangaChapter,
+    MangaPage,
+    MangaSearchResult,
+    MangaSourceCapabilities,
+    MangaSourceProvider,
+)
+from .registry import get_provider, list_sources, source_options, check_source_health
+from .mangasee import MangaSeeClient
+from .readmanga import ReadMangaClient
+from .manganato import ManganatoClient
+
+from .rawkuma import RawKumaClient
+from .manhuagui import ManhuaguiClient

--- a/utils/manga_sources/generic_chapter_url.py
+++ b/utils/manga_sources/generic_chapter_url.py
@@ -6,6 +6,8 @@ Optional: use Playwright for JS-heavy/Cloudflare sites (pip install playwright; 
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import ast
 import json
 import os
@@ -267,6 +269,11 @@ def get_chapter_images_playwright(
 
 
 class GenericChapterUrlClient:
+    source_id = "generic_chapter_url"
+    display_name = "Generic (chapter URL)"
+    base_url = ""
+    capabilities = MangaSourceCapabilities()
+
     """
     Fetch a chapter page by URL, extract image URLs from HTML, download with retry/backoff,
     and write manifest.json (manhua-translator compatible).

--- a/utils/manga_sources/mangadex.py
+++ b/utils/manga_sources/mangadex.py
@@ -4,6 +4,8 @@ Uses public API: https://api.mangadex.org/docs/
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import os
 import os.path as osp
 import re
@@ -50,19 +52,38 @@ def _get_chapter_display(attrs: dict) -> str:
 
 
 class MangaDexClient:
-    def __init__(self, timeout: int = 30, request_delay: float = 0.3):
+    source_id = "mangadex"
+    display_name = "MangaDex"
+    base_url = "https://api.mangadex.org"
+    capabilities = MangaSourceCapabilities()
+
+    def __init__(self, timeout: int = 30, request_delay: float = 0.3, max_retries: int = 2):
         self.session = requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
         self.timeout = timeout
         self.request_delay = max(0.0, float(request_delay))
+        self.max_retries = max(0, int(max_retries))
 
     def _throttle(self):
         if self.request_delay > 0:
             time.sleep(self.request_delay)
 
     def _get(self, url: str, **kwargs) -> requests.Response:
-        self._throttle()
-        return self.session.get(url, timeout=self.timeout, **kwargs)
+        last_response = None
+        for attempt in range(self.max_retries + 1):
+            self._throttle()
+            response = self.session.get(url, timeout=self.timeout, **kwargs)
+            last_response = response
+            if response.status_code not in (429, 502, 503, 504) or attempt >= self.max_retries:
+                return response
+            retry_after = response.headers.get("Retry-After")
+            try:
+                wait = float(retry_after) if retry_after else min(4.0, 0.75 * (attempt + 1))
+            except ValueError:
+                wait = min(4.0, 0.75 * (attempt + 1))
+            LOGGER.warning("MangaDex request throttled/temporary failure (%s); retrying in %.1fs", response.status_code, wait)
+            time.sleep(wait)
+        return last_response  # type: ignore[return-value]
 
     def search(
         self,

--- a/utils/manga_sources/mangaforfree.py
+++ b/utils/manga_sources/mangaforfree.py
@@ -5,6 +5,8 @@ Optional Playwright for search/feed when site blocks or requires JS.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import re
 import time
 from typing import List, Optional
@@ -35,6 +37,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class MangaForFreeClient:
+    source_id = "mangaforfree"
+    display_name = "MangaForFree"
+    base_url = "https://mangaforfree.com"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for MangaForFree-style sites (WP-Manga with /manga/ path)."""
 
     def __init__(

--- a/utils/manga_sources/mangakakalot.py
+++ b/utils/manga_sources/mangakakalot.py
@@ -6,6 +6,8 @@ Ref: Kotatsu parsers #1522/#1524, FMHY manga sources.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import re
 import time
 from typing import List, Optional
@@ -35,6 +37,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class MangakakalotClient:
+    source_id = "mangakakalot"
+    display_name = "Mangakakalot"
+    base_url = "https://www.mangakakalot.gg"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for Mangakakalot.gg. Search, feed, download via generic chapter URL."""
 
     def __init__(

--- a/utils/manga_sources/manganato.py
+++ b/utils/manga_sources/manganato.py
@@ -1,0 +1,38 @@
+"""Manganato / Manganelo compatibility provider.
+
+Clean-room parser for public search, chapter list, and reader pages. It does not
+perform login, paywall, DRM, Cloudflare, or anti-bot bypass.
+"""
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+from .static_site import StaticHtmlMangaProvider
+
+
+class ManganatoClient(StaticHtmlMangaProvider):
+    source_id = "manganato"
+    display_name = "Manganato / Manganelo"
+    base_url = "https://manganato.com"
+    search_path_template = "/search/story/{query}"
+    search_item_selector = ".search-story-item, .panel-search-story .story_item, .story_item"
+    search_link_selector = "a.item-img, .item-title a, a[href]"
+    search_title_selector = ".item-title, h3 a, a.item-title"
+    feed_url_template = "/manga/{manga_id}"
+    feed_chapter_selector = ".row-content-chapter li a, .chapter-list .row a, a[href*='chapter']"
+    page_image_selector = ".container-chapter-reader img, .vung-doc img, img[src], img[data-src]"
+    manga_path_markers = ("/manga-", "/manga/", "/manga_")
+    chapter_path_markers = ("chapter",)
+
+    def manga_id_from_url(self, url: str) -> str:
+        path = urlparse(url).path.strip("/")
+        parts = [p for p in path.split("/") if p]
+        return parts[-1] if parts else super().manga_id_from_url(url)
+
+    def manga_url(self, manga_id: str) -> str:
+        if manga_id.startswith(("http://", "https://")):
+            return manga_id
+        if manga_id.startswith("manga-") or manga_id.startswith("manga_"):
+            return f"{self.base_url.rstrip('/')}/{manga_id}"
+        return f"{self.base_url.rstrip('/')}/manga/{manga_id}"

--- a/utils/manga_sources/mangasee.py
+++ b/utils/manga_sources/mangasee.py
@@ -1,0 +1,81 @@
+"""MangaSee / MangaSee123 provider.
+
+Uses public HTML/embedded metadata patterns only and falls back to visible reader
+images. No anti-bot or access-control bypass is included.
+"""
+from __future__ import annotations
+
+import json
+import re
+from urllib.parse import urlparse
+
+from .provider_base import MangaChapter, MangaPage, MangaSearchResult, legacy_chapters
+from .static_site import StaticHtmlMangaProvider, absolute_url, clean_text, dedupe_by_url
+
+
+class MangaSeeClient(StaticHtmlMangaProvider):
+    source_id = "mangasee"
+    display_name = "MangaSee / MangaSee123"
+    base_url = "https://mangasee123.com"
+    search_path_template = "/search/?name={query}"
+    search_item_selector = ".SeriesName, .list-group-item, .series-list a, a[href*='/manga/']"
+    search_link_selector = "a[href]"
+    search_title_selector = ""
+    feed_url_template = "/manga/{manga_id}"
+    feed_chapter_selector = "a[href*='/read-online/'], a[href*='chapter']"
+    page_image_selector = "#readerarea img, .ImageGallery img, img[src], img[data-src]"
+    manga_path_markers = ("/manga/",)
+    chapter_path_markers = ("/read-online/", "chapter")
+
+    def parse_search(self, html: str, limit: int = 20) -> list[MangaSearchResult]:
+        # MangaSee often embeds an IndexName/IndexInfo JSON-ish search index.
+        embedded = re.search(r"vm\.IndexName\s*=\s*(\[.*?\]);", html, re.S)
+        results: list[MangaSearchResult] = []
+        if embedded:
+            try:
+                for item in json.loads(embedded.group(1)):
+                    slug = item.get("i") or item.get("IndexName") or item.get("s")
+                    title = item.get("s") or item.get("SeriesName") or slug
+                    if slug:
+                        url = f"{self.base_url.rstrip('/')}/manga/{slug}"
+                        results.append(MangaSearchResult(id=str(slug), title=str(title or slug), url=url))
+            except Exception:
+                results = []
+        if not results:
+            results = super().parse_search(html, limit=limit)
+        return dedupe_by_url(results)[:limit]
+
+    def parse_feed(self, html: str, manga_id: str = "", limit: int = 500, order: str = "asc") -> list[MangaChapter]:
+        chapters: list[MangaChapter] = []
+        embedded = re.search(r"vm\.Chapters\s*=\s*(\[.*?\]);", html, re.S)
+        if embedded:
+            try:
+                for idx, item in enumerate(json.loads(embedded.group(1)), start=1):
+                    chapter = str(item.get("Chapter") or item.get("chapter") or idx)
+                    name = clean_text(item.get("ChapterName") or item.get("name") or "")
+                    slug = manga_id or self.manga_id_from_url(self.manga_url(manga_id))
+                    url = f"{self.base_url.rstrip('/')}/read-online/{slug}-chapter-{chapter}.html"
+                    display = f"Chapter {chapter}" + (f" – {name}" if name else "")
+                    chapters.append(MangaChapter(id=url, display=display, url=url, index=idx))
+            except Exception:
+                chapters = []
+        if not chapters:
+            chapters = super().parse_feed(html, manga_id=manga_id, limit=limit, order=order)
+        if order == "desc":
+            chapters.reverse()
+        return chapters[:limit]
+
+    def parse_pages(self, html: str, chapter_url: str) -> list[MangaPage]:
+        pages = super().parse_pages(html, chapter_url)
+        if pages:
+            return pages
+        # Some mirrors expose page arrays in simple JS variables.
+        out: list[MangaPage] = []
+        seen: set[str] = set()
+        for match in re.finditer(r"https?://[^'\"]+?\.(?:jpg|jpeg|png|webp)(?:\?[^'\"]*)?", html, re.I):
+            url = match.group(0)
+            if url in seen:
+                continue
+            seen.add(url)
+            out.append(MangaPage(url=url, referer=chapter_url))
+        return out

--- a/utils/manga_sources/manhuagui.py
+++ b/utils/manga_sources/manhuagui.py
@@ -1,0 +1,19 @@
+"""Manhuagui-style provider (experimental Chinese manhua source)."""
+from __future__ import annotations
+
+from .static_site import StaticHtmlMangaProvider
+
+
+class ManhuaguiClient(StaticHtmlMangaProvider):
+    source_id = "manhuagui"
+    display_name = "Manhuagui (Chinese manhua)"
+    base_url = "https://www.manhuagui.com"
+    search_path_template = "/s/{query}.html"
+    search_item_selector = ".book-result li, .result-list li, a[href*='/comic/']"
+    search_link_selector = "a[href]"
+    search_title_selector = ".book-title, .name, a"
+    feed_url_template = "/comic/{manga_id}/"
+    feed_chapter_selector = ".chapter-list a, #chapter-list a, a[href*='/comic/'][href*='.html']"
+    page_image_selector = "#mangaFile img, .reader-img img, img[data-src], img[src]"
+    manga_path_markers = ("/comic/",)
+    chapter_path_markers = ("/comic/", ".html")

--- a/utils/manga_sources/manhwaraw.py
+++ b/utils/manga_sources/manhwaraw.py
@@ -5,6 +5,8 @@ Optional Playwright when site requires JS.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import time
 from typing import List, Optional
 from urllib.parse import quote, urljoin, urlparse
@@ -30,6 +32,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class ManhwaRawClient:
+    source_id = "manhwaraw"
+    display_name = "ManhwaRaw (Korean raw)"
+    base_url = "https://manhwaraw.club"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for ManhwaRaw (Korean raw manhwa)."""
 
     def __init__(

--- a/utils/manga_sources/naruraw.py
+++ b/utils/manga_sources/naruraw.py
@@ -5,6 +5,8 @@ Optional Playwright when site requires JS.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import re
 import time
 from typing import List, Optional
@@ -31,6 +33,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class NaruRawClient:
+    source_id = "naruraw"
+    display_name = "NaruRaw (Japanese raw)"
+    base_url = "https://naruraw.net"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for NaruRaw (Japanese raw manga)."""
 
     def __init__(

--- a/utils/manga_sources/onekkk.py
+++ b/utils/manga_sources/onekkk.py
@@ -5,6 +5,8 @@ Optional Playwright when site requires JS.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import re
 import time
 from typing import List, Optional
@@ -31,6 +33,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class OneKkkClient:
+    source_id = "onekkk"
+    display_name = "1kkk (Chinese manhua)"
+    base_url = "https://www.1kkk.com"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for 1kkk.com (Chinese manhua)."""
 
     def __init__(

--- a/utils/manga_sources/provider_base.py
+++ b/utils/manga_sources/provider_base.py
@@ -1,0 +1,154 @@
+"""Typed provider contracts for manga/comic source integrations.
+
+The legacy downloader clients in this package return dictionaries for UI
+compatibility.  New code should implement :class:`MangaSourceProvider` and may
+still expose dict-shaped results through the helper ``as_legacy_dict`` methods.
+"""
+from __future__ import annotations
+
+import os
+import os.path as osp
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+from urllib.parse import urlparse
+
+import requests
+
+
+@dataclass(frozen=True)
+class MangaSourceCapabilities:
+    supports_search: bool = True
+    supports_latest: bool = False
+    supports_chapter_url: bool = False
+    supports_download: bool = True
+    supports_raw_language: bool = False
+    requires_playwright: bool = False
+    supports_cookies: bool = False
+    supports_referer: bool = True
+
+
+@dataclass(frozen=True)
+class MangaSearchResult:
+    id: str
+    title: str
+    url: Optional[str] = None
+    cover_url: Optional[str] = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def as_legacy_dict(self) -> dict[str, Any]:
+        out = {"id": self.id, "title": self.title}
+        if self.url:
+            out["url"] = self.url
+        if self.cover_url:
+            out["cover_url"] = self.cover_url
+        out.update(self.extra)
+        return out
+
+
+@dataclass(frozen=True)
+class MangaChapter:
+    id: str
+    display: str
+    url: Optional[str] = None
+    index: Optional[int] = None
+    volume: Optional[str] = None
+    language: Optional[str] = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def as_legacy_dict(self) -> dict[str, Any]:
+        out = {"id": self.id, "display": self.display}
+        if self.url:
+            out["url"] = self.url
+        if self.index is not None:
+            out["index"] = self.index
+        if self.volume is not None:
+            out["volume"] = self.volume
+        if self.language is not None:
+            out["language"] = self.language
+        out.update(self.extra)
+        return out
+
+
+@dataclass(frozen=True)
+class MangaPage:
+    url: str
+    filename: Optional[str] = None
+    referer: Optional[str] = None
+    headers: dict[str, str] = field(default_factory=dict)
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+
+class MangaSourceProvider(ABC):
+    """Base class for pluggable manga sources.
+
+    Implementations must use public web pages/APIs only, respect rate limits, and
+    avoid DRM, paywall, login, private API, or access-control bypasses.
+    """
+
+    source_id: str = ""
+    display_name: str = ""
+    base_url: str = ""
+    capabilities: MangaSourceCapabilities = MangaSourceCapabilities()
+
+    def __init__(self, base_url: Optional[str] = None, timeout: int = 25, request_delay: float = 0.5):
+        if base_url:
+            self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.request_delay = max(0.0, float(request_delay))
+        self.session = requests.Session()
+
+    @abstractmethod
+    def search(self, query: str, limit: int = 20, **opts: Any) -> list[dict[str, Any]]:
+        """Return legacy-compatible search dictionaries."""
+
+    @abstractmethod
+    def get_feed(self, manga_id: str, limit: int = 500, order: str = "asc", **opts: Any) -> list[dict[str, Any]]:
+        """Return legacy-compatible chapter dictionaries."""
+
+    def get_pages(self, chapter_id: str, **opts: Any) -> list[MangaPage]:
+        """Return page URLs for a chapter. Providers may override this.
+
+        Legacy providers that use GenericChapterUrlClient can keep returning
+        chapter URLs in ``get_feed`` and use their existing downloader path.
+        """
+        raise NotImplementedError(f"{self.source_id} does not expose page extraction")
+
+    def download_chapter(
+        self,
+        chapter_id: str,
+        output_dir: str,
+        on_progress: Optional[Callable[[int, int, str], None]] = None,
+        **opts: Any,
+    ) -> Optional[str]:
+        """Default downloader for providers that implement ``get_pages``."""
+        pages = self.get_pages(chapter_id, **opts)
+        if not pages:
+            return None
+        os.makedirs(output_dir, exist_ok=True)
+        total = len(pages)
+        for idx, page in enumerate(pages, start=1):
+            suffix = Path(urlparse(page.url).path).suffix or ".jpg"
+            if suffix.lower().lstrip(".") not in {"jpg", "jpeg", "png", "webp", "gif", "bmp"}:
+                suffix = ".jpg"
+            filename = page.filename or f"{idx:03d}{suffix}"
+            headers = dict(page.headers or {})
+            if page.referer:
+                headers.setdefault("Referer", page.referer)
+            response = self.session.get(page.url, timeout=self.timeout, headers=headers or None)
+            response.raise_for_status()
+            with open(osp.join(output_dir, filename), "wb") as handle:
+                handle.write(response.content)
+            if on_progress:
+                on_progress(idx, total, filename)
+        return output_dir
+
+
+def legacy_search_results(results: Iterable[MangaSearchResult]) -> list[dict[str, Any]]:
+    return [item.as_legacy_dict() for item in results]
+
+
+def legacy_chapters(chapters: Iterable[MangaChapter]) -> list[dict[str, Any]]:
+    return [item.as_legacy_dict() for item in chapters]

--- a/utils/manga_sources/rawkuma.py
+++ b/utils/manga_sources/rawkuma.py
@@ -1,0 +1,21 @@
+"""RawKuma-style provider (experimental).
+Public-page parser only; no login/paywall/captcha bypass.
+"""
+from __future__ import annotations
+
+from .static_site import StaticHtmlMangaProvider
+
+
+class RawKumaClient(StaticHtmlMangaProvider):
+    source_id = "rawkuma"
+    display_name = "RawKuma (Japanese raw)"
+    base_url = "https://rawkuma.com"
+    search_path_template = "/?s={query}&post_type=wp-manga"
+    search_item_selector = ".c-tabs-item__content, .page-item-detail, .search-story-item"
+    search_link_selector = ".post-title a, a[href]"
+    search_title_selector = ".post-title, .item-title, h3"
+    feed_url_template = "/manga/{manga_id}/"
+    feed_chapter_selector = "li.wp-manga-chapter a, .listing-chapters_wrap a, a[href*='/chapter-']"
+    page_image_selector = ".reading-content img, .container-chapter-reader img, img[data-src], img[src]"
+    manga_path_markers = ("/manga/",)
+    chapter_path_markers = ("chapter",)

--- a/utils/manga_sources/readmanga.py
+++ b/utils/manga_sources/readmanga.py
@@ -1,0 +1,23 @@
+"""ReadManga-style static provider.
+
+Best-effort clean-room parser for public ReadManga-like pages. No authentication,
+private API, or access-control bypass is implemented.
+"""
+from __future__ import annotations
+
+from .static_site import StaticHtmlMangaProvider
+
+
+class ReadMangaClient(StaticHtmlMangaProvider):
+    source_id = "readmanga"
+    display_name = "ReadManga-style"
+    base_url = "https://readmanga.live"
+    search_path_template = "/search?q={query}"
+    search_item_selector = ".tiles .tile, .manga-list .item, .series, .book-item"
+    search_link_selector = "a[href]"
+    search_title_selector = ".name, .title, h3, a"
+    feed_url_template = "/{manga_id}"
+    feed_chapter_selector = ".chapters-link a, .chapter-list a, a[href*='/vol'], a[href*='/chapter']"
+    page_image_selector = ".page img, .reader img, img[data-src], img[src]"
+    manga_path_markers = ("/manga/", "/read/", "/")
+    chapter_path_markers = ("/vol", "chapter", "read")

--- a/utils/manga_sources/registry.py
+++ b/utils/manga_sources/registry.py
@@ -1,0 +1,174 @@
+"""Registry for manga source providers.
+
+The registry keeps UI source metadata separate from the dialog, so adding a new
+provider no longer requires hand-editing the source combo box.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from importlib import import_module
+import requests
+from typing import Any, Callable, Optional
+
+from utils.logger import logger as LOGGER
+
+from .provider_base import MangaSourceCapabilities, MangaSourceProvider
+
+
+@dataclass(frozen=True)
+class SourceMetadata:
+    source_id: str
+    display_name: str
+    provider_path: str | None = None
+    base_url: str = ""
+    status: str = "enabled"  # enabled, disabled, experimental, broken
+    capabilities: MangaSourceCapabilities = field(default_factory=MangaSourceCapabilities)
+    aliases: tuple[str, ...] = ()
+    fallback_base_urls: tuple[str, ...] = ()
+    category: str = "english aggregator"
+    notes: str = ""
+    legacy: bool = True
+    config_base_url_key: str | None = None
+
+    @property
+    def requires_playwright(self) -> bool:
+        return self.capabilities.requires_playwright
+
+    @property
+    def requires_cookies(self) -> bool:
+        return self.capabilities.supports_cookies and self.status == "disabled"
+
+    def label(self) -> str:
+        badges: list[str] = []
+        if self.status == "experimental":
+            badges.append("experimental")
+        elif self.status == "broken":
+            badges.append("broken")
+        elif self.status == "disabled":
+            badges.append("disabled")
+        if self.capabilities.requires_playwright:
+            badges.append("needs browser")
+        if self.capabilities.supports_cookies:
+            badges.append("cookies")
+        return f"{self.display_name} ({', '.join(badges)})" if badges else self.display_name
+
+
+_PROVIDER_CACHE: dict[str, type[MangaSourceProvider] | None] = {}
+_SOURCES: dict[str, SourceMetadata] = {}
+_ALIASES: dict[str, str] = {}
+
+
+def register_source(metadata: SourceMetadata) -> None:
+    _SOURCES[metadata.source_id] = metadata
+    for alias in metadata.aliases:
+        _ALIASES[alias] = metadata.source_id
+
+
+def _load_provider_class(path: str) -> type[MangaSourceProvider] | None:
+    if path in _PROVIDER_CACHE:
+        return _PROVIDER_CACHE[path]
+    try:
+        module_name, class_name = path.rsplit(":", 1)
+        module = import_module(module_name)
+        cls = getattr(module, class_name)
+        _PROVIDER_CACHE[path] = cls
+        return cls
+    except Exception as exc:  # optional deps or broken provider must not crash app startup
+        LOGGER.warning("Failed to import manga source provider %s: %s", path, exc)
+        _PROVIDER_CACHE[path] = None
+        return None
+
+
+def list_sources(include_disabled: bool = False, include_experimental: bool = True) -> list[SourceMetadata]:
+    out: list[SourceMetadata] = []
+    for meta in _SOURCES.values():
+        if not include_disabled and meta.status in {"disabled", "broken"}:
+            continue
+        if not include_experimental and meta.status == "experimental":
+            continue
+        out.append(meta)
+    return out
+
+
+def get_metadata(source_id: str) -> SourceMetadata:
+    resolved = _ALIASES.get(source_id, source_id)
+    if resolved not in _SOURCES:
+        raise KeyError(f"Unknown manga source: {source_id}")
+    return _SOURCES[resolved]
+
+
+def get_provider(source_id: str, config: Any = None, **kwargs: Any) -> MangaSourceProvider:
+    meta = get_metadata(source_id)
+    if not meta.provider_path:
+        raise KeyError(f"Manga source {source_id} has no provider class")
+    cls = _load_provider_class(meta.provider_path)
+    if cls is None:
+        raise RuntimeError(f"Manga source {source_id} could not be imported")
+    base_url = kwargs.pop("base_url", None) or meta.base_url
+    if config is not None:
+        overrides = getattr(config, "manga_source_base_url_overrides", {}) or {}
+        if isinstance(overrides, dict):
+            base_url = (overrides.get(meta.source_id) or base_url).strip()
+        if meta.config_base_url_key:
+            base_url = (getattr(config, meta.config_base_url_key, "") or base_url).strip()
+    return cls(base_url=base_url, **kwargs)
+
+
+def source_options(include_disabled: bool = False) -> list[tuple[str, str]]:
+    return [(m.label(), m.source_id) for m in list_sources(include_disabled=include_disabled)]
+
+
+CAP_SEARCH_DOWNLOAD = MangaSourceCapabilities(supports_search=True, supports_download=True, supports_referer=True)
+CAP_GENERIC_URL = MangaSourceCapabilities(supports_search=False, supports_chapter_url=True, supports_download=True, requires_playwright=False, supports_referer=True)
+CAP_MANGADEX = MangaSourceCapabilities(supports_search=True, supports_latest=False, supports_download=True, supports_raw_language=True)
+CAP_SEARCH_ONLY = MangaSourceCapabilities(supports_search=True, supports_download=False)
+
+
+# Preserve the exact legacy display names and source IDs first.
+for meta in [
+    SourceMetadata("mangadex", "MangaDex", "utils.manga_sources.mangadex:MangaDexClient", "https://api.mangadex.org", capabilities=CAP_MANGADEX, category="bridge/API"),
+    SourceMetadata("mangadex_raw", "MangaDex (raw / original language)", "utils.manga_sources.mangadex:MangaDexClient", "https://api.mangadex.org", capabilities=CAP_MANGADEX, category="Japanese raw", notes="Uses MangaDex originalLanguage and translatedLanguage filters."),
+    SourceMetadata("mangadex_url", "MangaDex (by chapter URL)", "utils.manga_sources.mangadex:MangaDexClient", "https://api.mangadex.org", capabilities=MangaSourceCapabilities(supports_search=False, supports_chapter_url=True, supports_download=True), category="generic URL"),
+    SourceMetadata("comick", "Comick", "utils.manga_sources.comick_source:ComickSourceClient", "https://comick-source-api.notaspider.dev", capabilities=CAP_SEARCH_ONLY, category="bridge/API", notes="Search and chapter list only; API does not expose page image URLs."),
+    SourceMetadata("gomanga", "GOMANGA", "utils.manga_sources.gomanga_api:GomangaApiClient", "https://gomanga-api.vercel.app", capabilities=CAP_SEARCH_DOWNLOAD, category="bridge/API"),
+    SourceMetadata("manhwa_reader", "Manhwa Reader", "utils.manga_sources.manhwa_reader:ManhwaReaderClient", "https://manhwa-reader-api.vercel.app", capabilities=CAP_SEARCH_DOWNLOAD, category="Korean raw"),
+    SourceMetadata("mangaforfree", "MangaForFree", "utils.manga_sources.mangaforfree:MangaForFreeClient", "https://mangaforfree.com", capabilities=MangaSourceCapabilities(requires_playwright=False), fallback_base_urls=("https://mangaforfree.com",)),
+    SourceMetadata("toongod", "ToonGod", "utils.manga_sources.toongod:ToonGodClient", "https://toongod.org", capabilities=MangaSourceCapabilities(requires_playwright=False), category="Korean raw"),
+    SourceMetadata("mangakakalot", "Mangakakalot", "utils.manga_sources.mangakakalot:MangakakalotClient", "https://www.mangakakalot.gg", capabilities=MangaSourceCapabilities(requires_playwright=False), aliases=("mangakakalot_gg",)),
+    SourceMetadata("naruraw", "NaruRaw (Japanese raw)", "utils.manga_sources.naruraw:NaruRawClient", "https://naruraw.net", capabilities=MangaSourceCapabilities(supports_raw_language=True), category="Japanese raw"),
+    SourceMetadata("manhwaraw", "ManhwaRaw (Korean raw)", "utils.manga_sources.manhwaraw:ManhwaRawClient", "https://manhwaraw.club", capabilities=MangaSourceCapabilities(supports_raw_language=True), category="Korean raw"),
+    SourceMetadata("onekkk", "1kkk (Chinese manhua)", "utils.manga_sources.onekkk:OneKkkClient", "https://www.1kkk.com", capabilities=MangaSourceCapabilities(supports_raw_language=True), category="Chinese manhua"),
+    SourceMetadata("generic_chapter_url", "Generic (chapter URL)", "utils.manga_sources.generic_chapter_url:GenericChapterUrlClient", "", capabilities=CAP_GENERIC_URL, category="generic URL"),
+    SourceMetadata("raws_manhwa_manhua_url", "Raws / Manhwa / Manhua (chapter URL)", "utils.manga_sources.generic_chapter_url:GenericChapterUrlClient", "", capabilities=CAP_GENERIC_URL, aliases=("raw_url",), category="generic URL"),
+    SourceMetadata("local_folder", "Local folder", None, "", status="enabled", capabilities=MangaSourceCapabilities(supports_search=False, supports_download=False), category="local folder"),
+    # First clean-room provider batch; static/public page parsers, no bypass logic.
+    SourceMetadata("mangasee", "MangaSee / MangaSee123", "utils.manga_sources.mangasee:MangaSeeClient", "https://mangasee123.com", capabilities=CAP_SEARCH_DOWNLOAD, aliases=("mangasee123",), fallback_base_urls=("https://mangasee123.com", "https://mangaseeonline.us"), notes="Static reader parser; no login/cookie bypass."),
+    SourceMetadata("readmanga", "ReadManga-style", "utils.manga_sources.readmanga:ReadMangaClient", "https://readmanga.live", capabilities=CAP_SEARCH_DOWNLOAD, fallback_base_urls=("https://readmanga.live",), category="english aggregator", notes="Best-effort static HTML parser; use only public chapters."),
+    SourceMetadata("manganato", "Manganato / Manganelo", "utils.manga_sources.manganato:ManganatoClient", "https://manganato.com", capabilities=CAP_SEARCH_DOWNLOAD, aliases=("manganelo", "chapmanganato"), fallback_base_urls=("https://manganato.com", "https://chapmanganato.to"), notes="Compatibility provider for public Manganato/Manganelo pages."),
+    SourceMetadata("rawkuma", "RawKuma (Japanese raw)", "utils.manga_sources.rawkuma:RawKumaClient", "https://rawkuma.com", status="experimental", capabilities=MangaSourceCapabilities(supports_search=True, supports_download=True, supports_raw_language=True), category="Japanese raw", notes="Experimental public parser for RawKuma-style pages."),
+    SourceMetadata("manhuagui", "Manhuagui (Chinese manhua)", "utils.manga_sources.manhuagui:ManhuaguiClient", "https://www.manhuagui.com", status="experimental", capabilities=MangaSourceCapabilities(supports_search=True, supports_download=True, supports_raw_language=True), category="Chinese manhua", notes="Experimental public parser for Manhuagui-style pages."),
+    SourceMetadata("suwayomi_bridge", "Suwayomi bridge", None, "http://127.0.0.1:4567", status="disabled", capabilities=MangaSourceCapabilities(supports_search=True, supports_download=True, supports_cookies=False), category="bridge/API", notes="Optional future bridge; disabled until configured."),
+]:
+    register_source(meta)
+
+
+def check_source_health(source_id: str, config: Any = None, timeout: int = 8) -> tuple[bool, str]:
+    """Best-effort source health check using public base URL reachability."""
+    try:
+        meta = get_metadata(source_id)
+    except Exception as exc:
+        return False, str(exc)
+    url = meta.base_url
+    if config is not None:
+        overrides = getattr(config, "manga_source_base_url_overrides", {}) or {}
+        if isinstance(overrides, dict):
+            url = (overrides.get(meta.source_id) or url).strip()
+    if not url:
+        return True, "No base URL required for this source."
+    try:
+        r = requests.get(url, timeout=timeout, headers={"User-Agent": "BallonsTranslator/1.0"})
+        if 200 <= r.status_code < 400:
+            return True, f"HTTP {r.status_code} OK: {url}"
+        return False, f"HTTP {r.status_code}: {url}"
+    except Exception as exc:
+        return False, f"Request failed: {exc}"

--- a/utils/manga_sources/static_site.py
+++ b/utils/manga_sources/static_site.py
@@ -1,0 +1,182 @@
+"""Reusable static HTML provider helpers for low-risk manga sources."""
+from __future__ import annotations
+
+import json
+import re
+import time
+from typing import Any, Iterable, Optional
+from urllib.parse import quote_plus, urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from .generic_chapter_url import GenericChapterUrlClient
+from .provider_base import MangaChapter, MangaPage, MangaSearchResult, MangaSourceCapabilities, MangaSourceProvider, legacy_chapters, legacy_search_results
+from .url_utils import infer_id, normalize_base_url
+
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36"
+
+
+def absolute_url(base: str, href: str | None) -> str:
+    if not href:
+        return ""
+    href = href.strip()
+    if href.startswith("//"):
+        return "https:" + href
+    return urljoin(base, href)
+
+
+def clean_text(value: str | None) -> str:
+    return re.sub(r"\s+", " ", value or "").strip()
+
+
+def dedupe_by_url(items: Iterable[MangaSearchResult]) -> list[MangaSearchResult]:
+    seen: set[str] = set()
+    out: list[MangaSearchResult] = []
+    for item in items:
+        key = item.url or item.id
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(item)
+    return out
+
+
+class StaticHtmlMangaProvider(MangaSourceProvider):
+    """Base class for public/static manga sites.
+
+    Subclasses configure URL builders and CSS selectors. The implementation uses
+    normal requests with conservative throttling, and can fall back to the shared
+    generic chapter downloader for image extraction.
+    """
+
+    capabilities = MangaSourceCapabilities(supports_search=True, supports_download=True, supports_referer=True)
+    search_path_template = "/search/story/{query}"
+    search_item_selector = ""
+    search_link_selector = "a[href]"
+    search_title_selector = ""
+    feed_chapter_selector = "a[href]"
+    feed_url_template = "/{manga_id}"
+    page_image_selector = "img[src], img[data-src], img[data-original], img[data-lazy-src]"
+    manga_path_markers: tuple[str, ...] = ()
+    chapter_path_markers: tuple[str, ...] = ("chapter",)
+
+    def __init__(self, base_url: Optional[str] = None, timeout: int = 25, request_delay: float = 0.5):
+        super().__init__(base_url=normalize_base_url(base_url or self.base_url), timeout=timeout, request_delay=request_delay)
+        self.session.headers["User-Agent"] = USER_AGENT
+        self._generic = GenericChapterUrlClient(timeout=timeout, request_delay=request_delay)
+
+    def _throttle(self) -> None:
+        if self.request_delay > 0:
+            time.sleep(self.request_delay)
+
+    def _get(self, url: str, referer: str | None = None) -> requests.Response:
+        self._throttle()
+        headers = {"Referer": referer} if referer else None
+        return self.session.get(url, timeout=self.timeout, headers=headers)
+
+    def _search_url(self, query: str) -> str:
+        return urljoin(self.base_url + "/", self.search_path_template.format(query=quote_plus(query.strip())).lstrip("/"))
+
+    def search(self, query: str, limit: int = 20, **opts: Any) -> list[dict[str, Any]]:
+        if not query or not query.strip():
+            return []
+        response = self._get(self._search_url(query))
+        response.raise_for_status()
+        return legacy_search_results(self.parse_search(response.text, limit=limit))
+
+    def parse_search(self, html: str, limit: int = 20) -> list[MangaSearchResult]:
+        soup = BeautifulSoup(html, "html.parser")
+        items = soup.select(self.search_item_selector) if self.search_item_selector else []
+        if not items:
+            selector = ", ".join(f'a[href*="{marker}"]' for marker in self.manga_path_markers) or "a[href]"
+            items = soup.select(selector)
+        results: list[MangaSearchResult] = []
+        for item in items:
+            link = item.select_one(self.search_link_selector) if self.search_link_selector else item
+            if link is None and getattr(item, "name", "") == "a":
+                link = item
+            if not link or not getattr(link, "get", None):
+                continue
+            href = link.get("href")
+            url = absolute_url(self.base_url, href)
+            if not self._looks_like_manga_url(url):
+                continue
+            title_node = item.select_one(self.search_title_selector) if self.search_title_selector else None
+            title = clean_text(title_node.get_text(" ") if title_node else link.get("title") or link.get_text(" "))
+            manga_id = self.manga_id_from_url(url)
+            if not manga_id:
+                continue
+            results.append(MangaSearchResult(id=manga_id, title=title or manga_id, url=url))
+        return dedupe_by_url(results)[:limit]
+
+    def _looks_like_manga_url(self, url: str) -> bool:
+        if not url:
+            return False
+        path = urlparse(url).path.lower()
+        if any(skip in path for skip in ("/genre", "/author", "/tag", "/page/", "/privacy")):
+            return False
+        if self.manga_path_markers:
+            return any(marker.lower() in path for marker in self.manga_path_markers)
+        return True
+
+    def manga_id_from_url(self, url: str) -> str:
+        return infer_id(url)
+
+    def manga_url(self, manga_id: str) -> str:
+        if manga_id.startswith("http://") or manga_id.startswith("https://"):
+            return manga_id
+        return urljoin(self.base_url + "/", self.feed_url_template.format(manga_id=manga_id).lstrip("/"))
+
+    def get_feed(self, manga_id: str, limit: int = 500, order: str = "asc", **opts: Any) -> list[dict[str, Any]]:
+        response = self._get(self.manga_url(manga_id))
+        response.raise_for_status()
+        return legacy_chapters(self.parse_feed(response.text, manga_id=manga_id, limit=limit, order=order))
+
+    def parse_feed(self, html: str, manga_id: str = "", limit: int = 500, order: str = "asc") -> list[MangaChapter]:
+        soup = BeautifulSoup(html, "html.parser")
+        chapters: list[MangaChapter] = []
+        seen: set[str] = set()
+        for idx, link in enumerate(soup.select(self.feed_chapter_selector), start=1):
+            href = link.get("href")
+            url = absolute_url(self.base_url, href)
+            if not self._looks_like_chapter_url(url) or url in seen:
+                continue
+            seen.add(url)
+            display = clean_text(link.get("title") or link.get_text(" ")) or f"Chapter {len(chapters) + 1}"
+            chapters.append(MangaChapter(id=url, display=display, url=url, index=len(chapters) + 1))
+        if order == "desc":
+            chapters.reverse()
+        return chapters[:limit]
+
+    def _looks_like_chapter_url(self, url: str) -> bool:
+        path = urlparse(url).path.lower()
+        return bool(url) and any(marker.lower() in path for marker in self.chapter_path_markers)
+
+    def get_pages(self, chapter_id: str, **opts: Any) -> list[MangaPage]:
+        response = self._get(chapter_id)
+        response.raise_for_status()
+        pages = self.parse_pages(response.text, chapter_url=chapter_id)
+        if pages:
+            return pages
+        return [MangaPage(url=u, referer=chapter_id) for u in self._generic.get_chapter_images(chapter_id, use_playwright=False)]
+
+    def parse_pages(self, html: str, chapter_url: str) -> list[MangaPage]:
+        soup = BeautifulSoup(html, "html.parser")
+        out: list[MangaPage] = []
+        seen: set[str] = set()
+        for img in soup.select(self.page_image_selector):
+            src = img.get("data-src") or img.get("data-original") or img.get("data-lazy-src") or img.get("src")
+            url = absolute_url(chapter_url, src)
+            if not url or url in seen:
+                continue
+            if not re.search(r"\.(?:jpe?g|png|webp|gif)(?:[?#].*)?$", url, re.I):
+                continue
+            seen.add(url)
+            out.append(MangaPage(url=url, referer=chapter_url))
+        return out
+
+    def download_chapter(self, chapter_id: str, save_dir: str, on_progress=None, **opts: Any):
+        # Keep manifest/page naming behavior aligned with existing generic URL downloads.
+        self._generic.request_delay = self.request_delay
+        return self._generic.download_chapter(chapter_id, save_dir, on_progress=on_progress, use_playwright=False)

--- a/utils/manga_sources/toongod.py
+++ b/utils/manga_sources/toongod.py
@@ -5,6 +5,8 @@ Optional Playwright for search/feed when site blocks or requires JS.
 """
 from __future__ import annotations
 
+from .provider_base import MangaSourceCapabilities
+
 import time
 from typing import List, Optional
 from urllib.parse import quote, urljoin, urlparse
@@ -34,6 +36,11 @@ def _absolute_url(base: str, href: str) -> str:
 
 
 class ToonGodClient:
+    source_id = "toongod"
+    display_name = "ToonGod"
+    base_url = "https://toongod.org"
+    capabilities = MangaSourceCapabilities()
+
     """Sync client for ToonGod-style sites (WP-Manga with /webtoon/ path)."""
 
     def __init__(


### PR DESCRIPTION
### Motivation

- Introduce a pluggable, registry-driven manga/comic raw downloader to centralize source metadata and make adding providers possible without manual UI edits.
- Provide clean-room static HTML providers and typed contracts so new sources can be implemented safely using public pages/APIs only and with clear capability metadata.
- Surface provider health/test actions and base-URL overrides in the UI so users and developers can validate and configure sources without editing code.

### Description

- Add a typed provider contract and helpers in `utils/manga_sources/provider_base.py` and a provider registry in `utils/manga_sources/registry.py` with `SourceMetadata`, capability flags, and utilities like `get_provider`, `list_sources`, and `check_source_health`.
- Implement reusable static-site helpers in `utils/manga_sources/static_site.py` and a set of first-batch clean-room providers: `mangasee`, `readmanga`, `manganato`, `rawkuma`, and `manhuagui`, plus exports in `utils/manga_sources/__init__.py`.
- Enhance existing clients and downloader pipeline with capability metadata (e.g. `source_id`, `display_name`, `capabilities`) and improvements to `GenericChapterUrlClient` and `MangaDexClient` (retry/backoff), and add `GenericChapterUrlClient` metadata.
- Integrate registry into the UI by updating `ui/manga_source_dialog.py` to build the source combo from registry metadata, add controls for experimental sources, source filtering, base-URL overrides, health checks, and source tests, and persist new config fields.
- Add developer tooling and docs: `scripts/audit_external_manga_sources.py`, `docs/MANGA_SOURCE_PLUGIN_API.md`, `docs/RAW_SOURCE_PROVIDER_EXPANSION_PLAN.md`, `docs/EXTERNAL_SOURCE_AUDIT.md`, README additions, and test fixtures under `tests/fixtures/manga_sources/` plus unit tests in `tests/test_manga_provider_base.py` and CLI smoke-tests in `scripts/test_manga_sources.py`.

### Testing

- New automated tests and smoke-test scripts were added, including `pytest -q tests/test_manga_provider_base.py`, `python scripts/test_manga_sources.py` (with `--stable-registry-only` and `--include-experimental` options), and `python scripts/audit_external_manga_sources.py` as developer tooling.
- Fixtures for parser unit tests were added under `tests/fixtures/manga_sources/` and `tests/test_manga_provider_base.py` exercises provider dataclasses, legacy dict conversions, registry lookups, and per-provider HTML parsing.
- No automated tests were executed as part of this rollout; CI/test execution should run the added `pytest` and script commands to validate provider parsing and registry behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bae9c9938832c9f57d7aa63033958)