### PR TITLE
Automation API & headless contract, secret/keyring migration, interchange formats, TM/QA, UI integrations and tests

### DIFF
--- a/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
+++ b/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Alternatives Feature Gap Implementation Plan
 
-Last updated: 2026-05-18
+Last updated: 2026-05-19
 
 This document is the safety baseline for closing gaps versus manga-image-translator, Koharu, ImageTrans, manga-translator-ui, and focused cleanup tools. The rule for every phase is: audit first, extend existing Pro systems, do not duplicate equivalent functionality, and do not remove existing Pro behavior.
 
@@ -32,18 +32,18 @@ Every implementation PR in this roadmap must verify:
 
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
-| Stable JSON scene operation API | Partially implemented | `utils/api_edit_ops.py`, `ui/mainwindow.py` `_api_apply_edit`, `tests/test_api_edit_ops*.py` | Extend edit-op dataclasses, stable block IDs, undo command integration | Medium; current UI edit path mutates blocks directly for some ops | Payload validation, stable IDs, undo/redo, invalid page/index errors |
+| Stable JSON scene operation API | Partially implemented | `utils/api_edit_ops.py`, `ui/mainwindow.py` `_api_apply_edit`, `tests/test_api_edit_ops*.py` | Extended dataclass validation with index-or-block_id targeting and detailed error payloads; next: full undo-command integration | Medium; current UI edit path mutates blocks directly for some ops | Payload validation, stable IDs, undo/redo, invalid page/index errors |
 | Job manager | Partially implemented | `ui/mainwindow.py` job routes; new contract helper normalizes task aliases | Extract/extend job lifecycle helpers without duplicating UI behavior | Medium; cancellation is cooperative | job_start/status/cancel/logs/result/list; SSE snapshot; warning propagation |
 | MCP-compatible command surface | Partially implemented | handlers include `open_project`, `project_status`, `list_pages`, `apply_edit`, `run_pipeline`, `render`, `export`, `undo`, `redo`; route discovery now marks MCP routes | `ui/mainwindow.py`, `utils/automation_api_contract.py`, docs | Low | Route discovery contract tests |
-| CLI/headless mode | Partially implemented | `launch.py --headless`, `scripts/batch_translate.py` | Add stable CLI contract and exit codes | Medium; must not break current GUI launch | Headless open/run/export smoke with mocked modules |
+| CLI/headless mode | Partially implemented | `launch.py --headless`, `scripts/batch_translate.py` | `scripts/batch_translate.py` now returns stable headless exit codes and optional summary JSON; next: open/run/export unified CLI stages | Medium; must not break current GUI launch | Headless open/run/export smoke with mocked modules |
 | Route discovery docs/tests | Partially implemented → improved | `docs/LOCAL_AUTOMATION_API.md`, tests | Same | Low | Authenticated and unauthenticated discovery; `/events` content type |
 
 ## Phase 2 — Secure provider/model setup wizard
 
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
-| OS keyring credential storage | Partially implemented | `utils/credential_store.py`, `tests/test_credential_store.py` | Config migration path, provider settings UI/API | High; must not silently overwrite config or leak keys | keyring mocks, fallback opt-in, no-secret serialization |
-| Provider setup wizard | Not implemented as full wizard | Provider modules/settings exist, but no unified onboarding wizard | `ui/configpanel.py`, provider utilities, local API | Medium | connection test mocks, endpoint preset serialization |
+| OS keyring credential storage | Partially implemented → advanced | `utils/credential_store.py`, `utils/secret_migration.py`, `tests/test_credential_store.py`, `tests/test_secret_migration.py` | Config migration path + layout-review secret read/write UI path | High; must not silently overwrite config or leak keys | keyring mocks, migration clear/scrub tests, no-secret serialization |
+| Provider setup wizard | Partially implemented → advanced | Layout-review provider onboarding now includes endpoint presets + test connection path; full multi-provider unified wizard still pending | `ui/mainwindow.py`, provider utilities, local API | Medium | connection-test mocks, endpoint preset serialization, keyring-backed credential checks |
 | Runtime profiles | Partially implemented | runtime/profile/data-path tests exist | config/runtime utilities, model manager UI | Medium | low VRAM/CPU fallback diagnostics |
 | Translation options/retry policy | Partially implemented | translator batch mode tests exist | base translator/provider settings | Medium | per-block/page mode, retry behavior |
 
@@ -52,21 +52,21 @@ Every implementation PR in this roadmap must verify:
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
 | Truthful editable PSD strategy | Partially implemented | `utils/layered_psd_export.py`, `tests/test_layered_psd_export.py` | PSD handoff docs/manifests; optional PSD text only behind flag if feasible | Medium/high due PSD compatibility claims | no silent raster-only PSD claims |
-| XLIFF/Excel/Word/LabelPlus/XML/HTML/searchable PDF/TXT/JSON | Partially implemented | structured OCR, SVG/PSD/proof exports exist | new interchange utils and export dialog/API | Medium | format snapshots and optional dependency skips |
-| Roundtrip imports | Not implemented broadly | project ops protocol can update text | import utilities/API/UI | High; geometry/block matching can corrupt projects | stable ID/source/page/geometry matching tests |
+| XLIFF/Excel/Word/LabelPlus/XML/HTML/searchable PDF/TXT/JSON | Partially implemented → advanced | Added XLIFF export/import paths (UI + API + tests) on top of existing structured OCR/SVG/PSD/proof exports | `utils/xliff_interchange.py`, `ui/mainwindow.py`, `ui/mainwindowbars.py` | Medium | roundtrip snapshots, mismatch reporting, optional dependency skips for other formats |
+| Roundtrip imports | Partially implemented → advanced | project ops protocol can update text; XLIFF + translation JSON + translation CSV roundtrip now available | `utils/xliff_interchange.py`, `utils/translation_json_interchange.py`, import utilities/API/UI | High; geometry/block matching can corrupt projects | stable ID/source/page/geometry matching tests |
 | Export manifests | Already/partially implemented | `utils/export_manifest.py` | add renderer/pro format warnings | Low/medium | fallback source, missing font, clipped text warnings |
 
 ## Phase 4 — CAT-tool features and translation QA
 
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
-| Translation memory | Not implemented as reusable TM | Some context/glossary docs exist | new TM storage utilities/UI/API | Medium | fuzzy match, import/export |
+| Translation memory | Partially implemented → advanced | Added project TM store + fuzzy query + import/export API paths/tests (JSON) | `utils/translation_memory.py`, `utils/proj_imgtrans.py`, `ui/mainwindow.py` | Medium | fuzzy match tests, TM import/export tests, save/load compatibility tests |
 | Termbase/glossary | Partially implemented | `modules/llm_quality.py` glossary enforcement | glossary store/dialog/API | Medium | hard/soft violations, no destructive replacement |
 | Corpus concordance | Not implemented | Search widgets exist but not CAT concordance | corpus index/search utilities | Low/medium | provenance search |
 | SFX dictionary | Not implemented | style/prompt concepts exist | SFX dictionary data/UI | Low | lookup/import/export |
 | Auto glossary extraction | Not implemented | LLM quality utilities can be extended | extraction utility + approval UI | Medium | candidate categories, approval persistence |
-| Post-translation QA/retry | Partially implemented | `modules/llm_quality.py`, translation review tests | QA report/API/UI | Medium | thresholds, retry behavior |
-| Prompt profiles | Partially implemented | prompt/profile docs and translator settings | prompt profile store | Low/medium | profile selection by block type |
+| Post-translation QA/retry | Partially implemented → advanced | Added profile-aware QA report + retry candidate API (`translation_qa_report`) | `utils/translation_qa_profiles.py`, `ui/mainwindow.py` | Medium | threshold/retry tests, profile behavior tests |
+| Prompt profiles | Partially implemented → advanced | Added prompt profile registry + API exposure (`translation_prompt_profiles`) with default config selection | `utils/translation_qa_profiles.py`, `utils/config.py`, `ui/mainwindow.py` | Low/medium | profile selection tests and fallback tests |
 
 ## Phase 5 — OCR, reading order, and editor UX
 
@@ -75,7 +75,7 @@ Every implementation PR in this roadmap must verify:
 | OCR crop inspector | Partially implemented | `ui/ocr_crop_inspector_widget.py` and pipeline button exist | inspector rerun hooks | Medium | crop extraction/rerun metadata |
 | Hybrid OCR workflow | Not implemented | multiple OCR engines exist | OCR compare utility/UI/API | Medium | primary/secondary compare |
 | Reading-order editor | Partially implemented | `ui/reading_order_editor_dialog.py` exists | persistence/export integration | Medium | reorder persistence, structured export order |
-| Batch find/replace | Partially implemented | regex profiles and global replace exist | preview/apply API and UI | Medium | regex preview/apply undo |
+| Batch find/replace | Partially implemented → advanced | Added preview/apply batch find-replace API + project UI action with confirmation | `utils/batch_find_replace.py`, `ui/mainwindow.py`, `ui/mainwindowbars.py` | Medium | regex preview/apply tests, undo-path tests |
 | Import translated image workflow | Not implemented | OCR/project utilities exist | alignment utility/UI/API | High | IoU/order matching tests |
 
 ## Phase 6 — Advanced renderer fidelity
@@ -111,3 +111,18 @@ Every implementation PR in this roadmap must verify:
 1. Finish Phase 1 API contract: stable IDs/errors for scene ops, deeper job cancellation checkpoints, and headless CLI exit-code contract.
 2. Start Phase 2 secret migration using `utils/credential_store.py` and explicit insecure fallback warnings.
 3. Expand Phase 3 interchange only after export/import schemas are documented and tests are in place.
+
+
+## Phase PR slicing plan (review-sized)
+
+To keep changes reviewable and reduce regression risk, implement each phase in multiple PR-sized slices with explicit rollback boundaries:
+
+1. **Phase 1A**: route contract hardening (`/routes`, `/health`, `/events`) + tests + docs.
+2. **Phase 1B**: stable scene edit IDs/errors + undo/redo invariants + API edit tests.
+3. **Phase 1C**: job lifecycle and cancellation checkpoints + status/log/result tests.
+4. **Phase 1D**: headless CLI contract and exit codes + batch smoke tests.
+5. **Phase 2A**: keyring migration and insecure fallback warnings + migration tests.
+6. **Phase 2B**: provider setup wizard and endpoint validation/test-connection flows.
+7. **Phase 3+**: export/interchange and CAT/OCR/renderer/cleanup/batch features, each split into doc/schema/test-first slices before UI surfacing.
+
+Each slice should include: (a) migration notes, (b) startup/model-picker impact statement, (c) README/README_zh_CN parity check when user-visible behavior changes.

--- a/docs/LOCAL_AUTOMATION_API.md
+++ b/docs/LOCAL_AUTOMATION_API.md
@@ -1,6 +1,6 @@
 # Local Automation API and MCP Command Surface
 
-Last updated: 2026-05-18
+Last updated: 2026-05-19
 
 BallonsTranslator-Pro exposes a localhost-only automation API when `automation_api_enabled` is enabled in config. The API is designed for headless helpers, MCP-style tools, and external workflow scripts while keeping existing UI progress behavior intact.
 
@@ -11,6 +11,18 @@ BallonsTranslator-Pro exposes a localhost-only automation API when `automation_a
 - `GET /events?job_id=<job_id>` returns a Server-Sent Events snapshot for a job. The current implementation sends a bounded status/log snapshot; future work can extend this to a live streaming loop without changing the endpoint.
 
 If `automation_api_key` is set, send it as `X-API-Key` for every request, including discovery and events.
+
+### Route discovery payload fields
+
+`GET /routes` and `GET /health` share the same discovery payload contract:
+
+- `routes`: sorted list of POST handler names.
+- `methods.GET`: sorted GET endpoints (`events`, `health`, `routes` by default).
+- `methods.POST`: same sorted list as `routes`.
+- `mcp_routes`: subset of `routes` that map to MCP-compatible commands.
+- `job_routes`: subset of `routes` for job lifecycle endpoints (`job_*`, `jobs_list`).
+- `event_stream`: stable SSE template path (`/events?job_id=<job_id>`).
+
 
 ## MCP-friendly commands
 
@@ -44,9 +56,11 @@ Job lifecycle routes:
 
 - `POST /job_status` with `{"job_id": "..."}`
 - `POST /job_cancel` with `{"job_id": "..."}`
-- `POST /job_logs` with `{"job_id": "..."}`
+- `POST /job_logs` with `{"job_id": "...", "offset": 0}` for incremental log polling
 - `POST /job_result` with `{"job_id": "..."}`
 - `POST /jobs_list` with optional `{"limit": 50}`
+
+The job status payload now includes `stage` and `progress` (`0.0..1.0`) for stable automation progress reporting.
 
 Cancellation is cooperative. A queued job can be cancelled immediately; a running job exposes `cancel_requested` so deeper pipeline stages can progressively add cancellation checkpoints.
 
@@ -68,3 +82,125 @@ curl http://127.0.0.1:39542/events?job_id=job_123
 - The event stream currently returns a status/log snapshot rather than an infinite stream.
 - Job cancellation is exposed through the API but still depends on individual task implementations to check cancellation during expensive work.
 - The API remains bound to `127.0.0.1` by design; do not expose it directly on untrusted networks.
+
+
+### Scene edit payload
+
+`POST /apply_edit` (alias: `/scene_edit`) accepts either one operation object or a batch payload:
+
+```json
+{
+  "strict": true,
+  "ops": [
+    {"op": "add_textbox", "page": "001.png", "text": "Hello"},
+    {"op": "update_textbox", "page": "001.png", "block_id": "tbx_...", "text": "Updated"},
+    {"op": "delete_textbox", "page": "001.png", "index": 3},
+    {"op": "undo"},
+    {"op": "redo"}
+  ]
+}
+```
+
+Notes:
+- `update_textbox` and `delete_textbox` require **either** `index` **or** `block_id`.
+- Responses include stable `block_id` values for successful add/update/delete operations.
+- When `strict=false`, the server continues batch execution and returns per-operation errors in `errors`.
+- When `strict=true` (default), the first operation failure returns an API error.
+
+
+## Headless batch CLI contract
+
+For non-GUI runs, `scripts/batch_translate.py` now returns stable non-zero exit codes:
+
+- `0`: success
+- `2`: config error (e.g. missing config file)
+- `3`: input error (no valid input dirs)
+- `4`: runtime error (all requested dirs failed)
+- `5`: partial failure (some dirs succeeded, some failed)
+
+Optional output:
+
+- `--summary-json <path>` writes a machine-readable run summary (`requested/processed/skipped/failed`, plus `exit_code`).
+
+
+## Credential migration note
+
+Phase 2A migration support is now active for sensitive API keys used by automation/layout-review/video-flow-fixer settings.
+
+- When OS keyring is available, existing plaintext secrets are migrated and (by default) scrubbed from future config saves.
+- `credential_use_plaintext_fallback=true` keeps plaintext values for environments where keyring integration is intentionally bypassed.
+- UI now shows credential backend status in layout-review provider config.
+
+
+## Provider connection checks
+
+Phase 2B setup now exposes a connection test path in the Layout Review provider settings dialog:
+
+- Endpoint presets auto-fill common providers (OpenAI, OpenRouter, Google-compatible, LM Studio, Ollama).
+- **Test connection** performs a lightweight model-list probe and shows success/failure detail.
+- Requests use runtime timeout settings (`runtime_http_timeout_sec`).
+
+
+## XLIFF interchange
+
+Phase 3 interchange now includes XLIFF 1.2 export/import hooks:
+
+- API export: `POST /export_xliff` (or `POST /export` with `{"kind":"xliff"}`)
+- API import: `POST /import_xliff` with `{"path":".../file.xliff"}`
+- UI: Tools → Export → Export XLIFF / Import XLIFF
+
+Current mapping is stable per page + block index (`page::index`) and returns match diagnostics for missing/unmatched pages.
+
+
+## Translation JSON interchange
+
+Added Phase 3 roundtrip translation JSON hooks for deterministic external editing:
+
+- API export: `POST /export_translation_json` (or `POST /export` with `{"kind":"translation_json"}`)
+- API import: `POST /import_translation_json` with `{"path":".../translation_export.json"}`
+- UI: Tools → Export → Export translation JSON / Import translation JSON
+
+Format includes stable `block_id` plus `index` fallback for resilient re-import.
+
+
+## Translation CSV interchange
+
+Added Phase 3 translation CSV roundtrip hooks:
+
+- API export: `POST /export_translation_csv` (or `POST /export` with `{"kind":"translation_csv"}`)
+- API import: `POST /import_translation_csv` with `{"path":".../translation_export.csv"}`
+- UI: Tools → Export → Export translation CSV / Import translation CSV
+
+Columns: `page,index,block_id,source,translation` with stable `block_id` matching and index fallback.
+
+
+## Translation memory (TM) API
+
+Phase 4 TM groundwork is now available via local automation routes:
+
+- `POST /tm_build_from_project` — build project TM from current source/translation pairs
+- `POST /tm_query` with `{"source":"...","min_score":0.65,"limit":5}`
+- `POST /tm_export` writes `translation_memory.json`
+- `POST /tm_import` imports TM JSON (`merge=true` by default)
+
+TM entries are persisted in project JSON as `translation_memory` and include `source`, `target`, `page`, and `block_id`.
+
+
+## Translation QA and prompt profiles API
+
+Phase 4 now exposes profile-aware translation QA endpoints:
+
+- `POST /translation_prompt_profiles` → available profile IDs + current default
+- `POST /translation_qa_report` with optional `page`, `profile`, `retry_issue_threshold`
+
+The QA report returns per-block issues and `retry_candidates` so automation can optionally re-run poor-quality blocks.
+
+
+## Batch find/replace API
+
+Phase 5 editor UX now includes previewable batch find/replace routes:
+
+- `POST /batch_find_replace_preview` with `pattern`, `replacement`, optional `pages`, `use_regex`, `case_sensitive`
+- `POST /batch_find_replace_apply` with either the same fields or a prior `preview` payload
+
+`preview` returns match samples without mutating the project; `apply` mutates translations and returns changed rows.

--- a/scripts/batch_translate.py
+++ b/scripts/batch_translate.py
@@ -19,6 +19,7 @@ import sys
 import os.path as osp
 from pathlib import Path
 from typing import List, Optional
+import json
 import logging
 
 # Run from project root
@@ -34,6 +35,7 @@ from utils.config import load_config, pcfg, RunStatus
 from utils.proj_imgtrans import ProjImgTrans
 from utils.textblock import examine_textblk, remove_contained_boxes, deduplicate_primary_boxes
 from utils.logger import logger as LOGGER
+from utils.headless_contract import HeadlessExitCode, HeadlessRunSummary
 from modules import (
     init_module_registries,
     TEXTDETECTORS,
@@ -185,7 +187,7 @@ def run_batch_pipeline(
     log.info("Batch finished: %s", proj.directory)
 
 
-def main() -> None:
+def main() -> int:
     parser = argparse.ArgumentParser(description="Batch detect/OCR/translate/inpaint on project folder(s).")
     parser.add_argument("dirs", nargs="*", help="Project directory (folder of images).")
     parser.add_argument("--dir", "-d", action="append", default=[], dest="dirs_opt", help="Add project directory.")
@@ -195,18 +197,20 @@ def main() -> None:
     parser.add_argument("--no-translate", action="store_true", help="Skip translation.")
     parser.add_argument("--no-inpaint", action="store_true", help="Skip inpainting.")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging.")
+    parser.add_argument("--summary-json", default="", help="Write headless run summary JSON to this path.")
     args = parser.parse_args()
 
     dirs = list(args.dirs) + list(args.dirs_opt or [])
     if not dirs:
-        parser.error("Provide at least one project directory (positional or --dir).")
+        print("error: Provide at least one project directory (positional or --dir).", file=sys.stderr)
+        return int(HeadlessExitCode.INPUT_ERROR)
 
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
 
     if not osp.exists(args.config):
         LOGGER.error("Config not found: %s", args.config)
-        sys.exit(1)
+        return int(HeadlessExitCode.CONFIG_ERROR)
 
     load_config(args.config)
     init_module_registries()
@@ -227,25 +231,48 @@ def main() -> None:
             if m and hasattr(m, "load_model"):
                 m.load_model()
 
+    processed, skipped, failed = [], [], []
     for d in dirs:
         d = osp.abspath(d)
         if not osp.isdir(d):
             LOGGER.warning("Not a directory: %s", d)
+            skipped.append(d)
             continue
         LOGGER.info("Processing project: %s", d)
-        proj = ProjImgTrans(d)
-        run_batch_pipeline(
-            proj,
-            detector=detector,
-            ocr=ocr,
-            translator=translator,
-            inpainter=inpainter,
-            enable_detect=enable_detect,
-            enable_ocr=enable_ocr,
-            enable_translate=enable_translate,
-            enable_inpaint=enable_inpaint,
-        )
+        try:
+            proj = ProjImgTrans(d)
+            run_batch_pipeline(
+                proj,
+                detector=detector,
+                ocr=ocr,
+                translator=translator,
+                inpainter=inpainter,
+                enable_detect=enable_detect,
+                enable_ocr=enable_ocr,
+                enable_translate=enable_translate,
+                enable_inpaint=enable_inpaint,
+            )
+            processed.append(d)
+        except Exception as e:
+            LOGGER.error("Project failed: %s (%s)", d, e, exc_info=True)
+            failed.append(d)
+
+    summary = HeadlessRunSummary(
+        requested_dirs=[osp.abspath(x) for x in dirs],
+        processed_dirs=processed,
+        skipped_dirs=skipped,
+        failed_dirs=failed,
+    )
+    payload = summary.to_payload()
+    payload["exit_code"] = summary.exit_code()
+    LOGGER.info("Headless summary: %s", payload)
+    if args.summary_json:
+        out_path = osp.abspath(args.summary_json)
+        os.makedirs(osp.dirname(out_path), exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+    return summary.exit_code()
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_api_edit_ops.py
+++ b/tests/test_api_edit_ops.py
@@ -1,6 +1,12 @@
 import pytest
 
-from utils.api_edit_ops import validate_textbox_operation, validate_batch_payload, EditValidationError
+from utils.api_edit_ops import (
+    validate_textbox_operation,
+    validate_batch_payload,
+    EditValidationError,
+    ensure_block_stable_id,
+    find_block_index_by_stable_id,
+)
 
 
 def test_validate_update_textbox_ok():
@@ -25,3 +31,29 @@ def test_validate_delete_requires_index():
     with pytest.raises(EditValidationError) as e:
         validate_textbox_operation({"op": "delete_textbox"})
     assert e.value.code == "missing_field"
+
+
+class _Blk:
+    pass
+
+
+def test_validate_update_accepts_block_id():
+    op = validate_textbox_operation({"op": "update_textbox", "block_id": "tbx_abc", "text": "hello"})
+    assert op.op == "update_textbox"
+    assert op.block_id == "tbx_abc"
+    assert op.index is None
+
+
+def test_stable_id_helpers_assign_and_lookup():
+    a = _Blk()
+    b = _Blk()
+    bid_a = ensure_block_stable_id(a)
+    bid_b = ensure_block_stable_id(b)
+    assert bid_a != bid_b
+    assert find_block_index_by_stable_id([a, b], bid_b) == 1
+
+
+def test_find_block_index_missing_raises_not_found():
+    with pytest.raises(EditValidationError) as e:
+        find_block_index_by_stable_id([_Blk()], "tbx_missing")
+    assert e.value.code == "not_found"

--- a/tests/test_automation_jobs.py
+++ b/tests/test_automation_jobs.py
@@ -1,0 +1,27 @@
+from utils.automation_jobs import new_job, checkpoint_or_cancel, set_status, status_payload, append_log
+
+
+def test_job_lifecycle_progress_and_status_payload():
+    job = new_job('job_1', 'run_pipeline')
+    set_status(job, 'running', stage='ocr', progress=0.35)
+    payload = status_payload(job)
+    assert payload['status'] == 'running'
+    assert payload['stage'] == 'ocr'
+    assert abs(payload['progress'] - 0.35) < 1e-9
+
+
+def test_checkpoint_cancels_when_requested():
+    job = new_job('job_2', 'export')
+    job['cancel_requested'] = True
+    cancelled = checkpoint_or_cancel(job, 'render', 0.6)
+    assert cancelled is True
+    assert job['status'] == 'cancelled'
+    assert 'cancelled at checkpoint' in '\n'.join(job['logs'])
+
+
+def test_append_log_respects_limit():
+    job = new_job('job_3', 'proof_pack')
+    for i in range(10):
+        append_log(job, f'line-{i}', limit=3)
+    assert len(job['logs']) == 3
+    assert job['logs'][0] == 'line-7'

--- a/tests/test_batch_find_replace.py
+++ b/tests/test_batch_find_replace.py
@@ -1,0 +1,30 @@
+from utils.batch_find_replace import preview_batch_find_replace, apply_batch_find_replace
+
+
+class B:
+    def __init__(self, t):
+        self.translation = t
+        self.text = t
+
+
+class P:
+    def __init__(self):
+        self.pages = {
+            'p1.png': [B('Hello Cat'), B('Cat cat')],
+            'p2.png': [B('No match')],
+        }
+
+
+def test_preview_regex_counts_hits():
+    proj = P()
+    rst = preview_batch_find_replace(proj, r'cat', 'dog', use_regex=True, case_sensitive=False)
+    assert rst['count'] == 2
+
+
+def test_apply_updates_translations_from_preview():
+    proj = P()
+    prev = preview_batch_find_replace(proj, r'cat', 'dog', use_regex=True, case_sensitive=False)
+    changed, applied = apply_batch_find_replace(proj, prev)
+    assert changed == 2
+    assert len(applied) == 2
+    assert proj.pages['p1.png'][0].translation == 'Hello dog'

--- a/tests/test_headless_contract.py
+++ b/tests/test_headless_contract.py
@@ -1,0 +1,20 @@
+from utils.headless_contract import HeadlessRunSummary, HeadlessExitCode
+
+
+def test_headless_summary_ok_exit_code():
+    s = HeadlessRunSummary(requested_dirs=['a'], processed_dirs=['a'], skipped_dirs=[], failed_dirs=[])
+    assert s.exit_code() == int(HeadlessExitCode.OK)
+
+
+def test_headless_summary_partial_failure_exit_code():
+    s = HeadlessRunSummary(requested_dirs=['a', 'b'], processed_dirs=['a'], skipped_dirs=[], failed_dirs=['b'])
+    assert s.exit_code() == int(HeadlessExitCode.PARTIAL_FAILURE)
+
+
+def test_headless_summary_payload_counts():
+    s = HeadlessRunSummary(requested_dirs=['a', 'b'], processed_dirs=[], skipped_dirs=['a'], failed_dirs=['b'])
+    payload = s.to_payload()
+    assert payload['requested'] == 2
+    assert payload['processed'] == 0
+    assert payload['skipped'] == 1
+    assert payload['failed'] == 1

--- a/tests/test_local_automation_api_routes_contract.py
+++ b/tests/test_local_automation_api_routes_contract.py
@@ -1,0 +1,29 @@
+import json
+import urllib.request
+
+from utils.local_automation_api import LocalAutomationApiServer
+
+
+def test_routes_and_health_include_contract_metadata():
+    handlers = {
+        'open_project': lambda body: {'ok': True},
+        'job_status': lambda body: {'status': 'idle'},
+        'jobs_list': lambda body: {'jobs': []},
+        'z_custom': lambda body: {},
+    }
+    server = LocalAutomationApiServer('127.0.0.1', 39605, handlers)
+    server.start()
+    try:
+        with urllib.request.urlopen('http://127.0.0.1:39605/routes', timeout=2) as resp:
+            routes = json.loads(resp.read().decode('utf-8'))
+        with urllib.request.urlopen('http://127.0.0.1:39605/health', timeout=2) as resp:
+            health = json.loads(resp.read().decode('utf-8'))
+    finally:
+        server.stop()
+
+    assert routes['mcp_routes'] == ['open_project']
+    assert routes['job_routes'] == ['job_status', 'jobs_list']
+    assert routes['event_stream'] == '/events?job_id=<job_id>'
+    assert health['status'] == 'ok'
+    assert health['mcp_routes'] == routes['mcp_routes']
+    assert health['job_routes'] == routes['job_routes']

--- a/tests/test_provider_setup.py
+++ b/tests/test_provider_setup.py
@@ -1,0 +1,21 @@
+from utils.provider_setup import check_provider_connection, provider_endpoint_preset
+
+
+def test_provider_endpoint_preset_for_ollama():
+    assert provider_endpoint_preset('Ollama').startswith('http://localhost:11434')
+
+
+def test_provider_connection_success_parses_model_count():
+    def fake_fetch(url, headers, timeout):
+        return 200, '{"data":[{"id":"a"},{"id":"b"}]}'
+    rst = check_provider_connection('OpenAI', 'https://api.openai.com/v1', api_key='sk-test', fetcher=fake_fetch)
+    assert rst.ok is True
+    assert '2 model' in rst.detail
+
+
+def test_provider_connection_failure_status():
+    def fake_fetch(url, headers, timeout):
+        return 401, '{}'
+    rst = check_provider_connection('OpenRouter', 'https://openrouter.ai/api/v1', api_key='bad', fetcher=fake_fetch)
+    assert rst.ok is False
+    assert rst.status_code == 401

--- a/tests/test_secret_migration.py
+++ b/tests/test_secret_migration.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+from utils.secret_migration import migrate_secrets_to_keyring_if_possible, scrub_plaintext_secrets_for_save
+
+
+class _FakeKeyring:
+    def __init__(self):
+        self.store = {}
+    def set_password(self, service, key, value):
+        self.store[(service, key)] = value
+    def get_password(self, service, key):
+        return self.store.get((service, key))
+
+
+def _pcfg():
+    return SimpleNamespace(
+        credential_migration_done=False,
+        credential_use_plaintext_fallback=False,
+        automation_api_key='autokey',
+        module=SimpleNamespace(
+            layout_review_api_key='sk-test',
+            video_translator_flow_fixer_openrouter_apikey='',
+            video_translator_flow_fixer_openai_apikey='sk-openai',
+        )
+    )
+
+
+def test_secret_migration_moves_plaintext_and_clears_when_secure():
+    fake = _FakeKeyring()
+    pcfg = _pcfg()
+    migrated = migrate_secrets_to_keyring_if_possible(
+        pcfg,
+        has_keyring=lambda: True,
+        set_secret=lambda k, v: (fake.set_password('ballonstranslator-pro', k, v) or True),
+    )
+    assert migrated is True
+    assert pcfg.credential_migration_done is True
+    assert pcfg.module.layout_review_api_key == ''
+    assert pcfg.module.video_translator_flow_fixer_openai_apikey == ''
+    assert fake.get_password('ballonstranslator-pro', 'layout_review_api_key') == 'sk-test'
+
+
+def test_scrub_plaintext_before_save_when_keyring_available():
+    pcfg = _pcfg()
+    scrub_plaintext_secrets_for_save(pcfg, has_keyring=lambda: True)
+    assert pcfg.module.layout_review_api_key == ''
+    assert pcfg.automation_api_key == ''

--- a/tests/test_translation_csv_interchange.py
+++ b/tests/test_translation_csv_interchange.py
@@ -1,0 +1,36 @@
+from utils.translation_csv_interchange import export_translation_csv_text, import_translation_csv_text
+
+
+class B:
+    def __init__(self, src, tr=''):
+        self._src = src
+        self.translation = tr
+        self.api_block_id = ''
+    def get_text(self):
+        return self._src
+
+
+class P:
+    def __init__(self):
+        self.pages = {'p1.png': [B('A', 'AA'), B('B', 'BB')]}
+
+
+def test_export_csv_has_header_and_block_id():
+    txt = export_translation_csv_text(P())
+    assert 'page,index,block_id,source,translation' in txt
+    assert 'tbx_' in txt
+
+
+def test_import_csv_uses_block_id_matching():
+    proj = P()
+    txt = export_translation_csv_text(proj)
+    lines = txt.strip().splitlines()
+    header = lines[0]
+    row1 = lines[1].split(',')
+    row2 = lines[2].split(',')
+    row2[4] = 'B_NEW'
+    swapped = '\n'.join([header, ','.join(row2), ','.join(row1)]) + '\n'
+    ok, rst = import_translation_csv_text(proj, swapped)
+    assert ok is True
+    assert proj.pages['p1.png'][1].translation == 'B_NEW'
+    assert 'p1.png' in rst['matched_pages']

--- a/tests/test_translation_json_interchange.py
+++ b/tests/test_translation_json_interchange.py
@@ -1,0 +1,35 @@
+from utils.translation_json_interchange import export_translation_json, import_translation_json
+
+
+class B:
+    def __init__(self, src, tr=''):
+        self._src = src
+        self.translation = tr
+        self.api_block_id = ''
+    def get_text(self):
+        return self._src
+
+
+class P:
+    def __init__(self):
+        self.pages = {'p1.png': [B('A', 'AA'), B('B', 'BB')]}
+
+
+def test_export_translation_json_has_schema_and_block_ids():
+    payload = export_translation_json(P())
+    assert payload['schema'] == 'ballonstranslator.translation_json.v1'
+    bid = payload['pages'][0]['blocks'][0]['block_id']
+    assert bid.startswith('tbx_')
+
+
+def test_import_translation_json_prefers_block_id():
+    proj = P()
+    payload = export_translation_json(proj)
+    # swap order but keep block ids
+    blocks = payload['pages'][0]['blocks']
+    blocks[0], blocks[1] = blocks[1], blocks[0]
+    blocks[0]['translation'] = 'B_NEW'
+    ok, rst = import_translation_json(proj, payload)
+    assert ok is True
+    assert proj.pages['p1.png'][1].translation == 'B_NEW'
+    assert 'p1.png' in rst['matched_pages']

--- a/tests/test_translation_memory.py
+++ b/tests/test_translation_memory.py
@@ -1,0 +1,30 @@
+from utils.translation_memory import build_tm_from_project, query_tm, export_tm_payload, import_tm_payload
+
+
+class B:
+    def __init__(self, src, tr):
+        self._src = src
+        self.translation = tr
+        self.api_block_id = ''
+    def get_text(self):
+        return self._src
+
+
+class P:
+    def __init__(self):
+        self.pages = {'p1.png': [B('hello world', '你好世界'), B('good morning', '早上好')]}
+
+
+def test_build_tm_from_project_and_query():
+    store = build_tm_from_project(P())
+    assert len(store) == 2
+    hits = query_tm(store, 'hello worlds', min_score=0.6, limit=3)
+    assert hits and hits[0]['target'] == '你好世界'
+
+
+def test_tm_export_import_roundtrip():
+    store = build_tm_from_project(P())
+    payload = export_tm_payload(store)
+    out = import_tm_payload(payload)
+    assert len(out) == len(store)
+    assert out[0]['source'] == store[0]['source']

--- a/tests/test_translation_qa_profiles.py
+++ b/tests/test_translation_qa_profiles.py
@@ -1,0 +1,24 @@
+from utils.translation_qa_profiles import build_translation_qa_report, resolve_prompt_profile
+
+
+class B:
+    def __init__(self, src, tr):
+        self.text = src
+        self.translation = tr
+
+
+def test_resolve_prompt_profile_defaults_to_dialogue():
+    assert resolve_prompt_profile('unknown')['max_len_ratio'] == resolve_prompt_profile('dialogue')['max_len_ratio']
+
+
+def test_qa_report_respects_sfx_profile_for_same_text():
+    blocks = [B('BAM', 'BAM'), B('Hello', 'Hello')]
+    report = build_translation_qa_report(blocks, glossary=[], profile='sfx', retry_issue_threshold=1)
+    # sfx allows carry-over
+    assert report['issue_blocks'] == 0
+
+
+def test_qa_report_retry_candidates_by_issue_count():
+    blocks = [B('alpha beta', 'alpha beta alpha beta alpha beta alpha beta')]
+    report = build_translation_qa_report(blocks, glossary=[{'source': 'alpha', 'target': '阿尔法'}], profile='dialogue', retry_issue_threshold=2)
+    assert report['retry_candidates'] == [0]

--- a/tests/test_xliff_interchange.py
+++ b/tests/test_xliff_interchange.py
@@ -1,0 +1,30 @@
+from utils.xliff_interchange import export_project_xliff, import_project_xliff
+
+
+class B:
+    def __init__(self, src, tr=''):
+        self._src = src
+        self.translation = tr
+    def get_text(self):
+        return self._src
+
+
+class P:
+    def __init__(self):
+        self.pages = {'p1.png': [B('A', 'AA'), B('B', 'BB')]}
+
+
+def test_export_xliff_contains_schema_and_units():
+    xml = export_project_xliff(P())
+    assert 'ballonstranslator.xliff.v1' in xml
+    assert 'trans-unit' in xml
+    assert 'p1.png::0' in xml
+
+
+def test_import_xliff_updates_translations():
+    proj = P()
+    xml = export_project_xliff(proj).replace('<target>AA</target>', '<target>ZZ</target>')
+    ok, rst = import_project_xliff(proj, xml)
+    assert ok is True
+    assert proj.pages['p1.png'][0].translation == 'ZZ'
+    assert 'p1.png' in rst['matched_pages']

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -16,7 +16,7 @@ from urllib import request as urlrequest
 from urllib import error as urlerror
 
 from tqdm import tqdm
-from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QProgressBar, QLabel, QWidget, QInputDialog, QFormLayout, QDialogButtonBox, QLineEdit, QDoubleSpinBox, QSpinBox, QCheckBox, QComboBox
+from qtpy.QtWidgets import QAction, QFileDialog, QMenu, QHBoxLayout, QVBoxLayout, QApplication, QStackedWidget, QSplitter, QListWidget, QShortcut, QListWidgetItem, QMessageBox, QTextEdit, QPlainTextEdit, QDialog, QProgressBar, QLabel, QWidget, QInputDialog, QFormLayout, QDialogButtonBox, QLineEdit, QDoubleSpinBox, QSpinBox, QCheckBox, QComboBox, QPushButton
 from qtpy.QtCore import Qt, QPoint, QSize, QEvent, Signal, QTimer
 from qtpy.QtGui import QContextMenuEvent, QTextCursor, QGuiApplication, QIcon, QCloseEvent, QKeySequence, QKeyEvent, QPainter, QClipboard, QImage, QShowEvent, QCursor, QPixmap, QBrush, QColor
 
@@ -25,6 +25,8 @@ from utils.text_processing import is_cjk, full_len, half_len
 from utils.detect_layout_flags import should_enable_auto_textlayout, should_run_post_detect_autofit
 from utils.text_layout import _merge_stub_lines_in_string
 from utils.textblock import TextBlock, TextAlignment, examine_textblk
+from utils.credential_store import get_secret, set_secret, has_keyring
+from utils.provider_setup import check_provider_connection, provider_endpoint_preset
 from utils.split_text_region import split_textblock
 from utils import shared
 from utils.message import create_error_dialog, create_info_dialog
@@ -73,12 +75,19 @@ from .lettering_workflow_dialog import LetteringWorkflowDialog
 from utils.fontformat import pt2px
 from utils.image_colorization import apply_colorization
 from utils.structured_ocr_export import build_structured_ocr_export
+from utils.xliff_interchange import export_project_xliff, import_project_xliff
+from utils.translation_json_interchange import export_translation_json, import_translation_json
+from utils.translation_csv_interchange import export_translation_csv_text, import_translation_csv_text
+from utils.translation_memory import query_tm, add_tm_entry, build_tm_from_project, export_tm_payload, import_tm_payload
+from utils.translation_qa_profiles import build_translation_qa_report, PROMPT_PROFILES
+from utils.batch_find_replace import preview_batch_find_replace, apply_batch_find_replace
 from utils.layered_psd_export import build_layered_psd_handoff
 from utils.svg_text_export import build_svg_text_handoff
 from utils.lettering_proof_export import build_lettering_proof_pack
 from utils.text_rendering import locale_aware_upper
 from utils.local_automation_api import LocalAutomationApiServer
 from utils.automation_api_contract import normalize_job_task
+from utils.automation_jobs import new_job, append_log, add_warning, set_status, checkpoint_or_cancel, status_payload
 from utils.workflow_presets import apply_workflow_preset, list_workflow_presets, workflow_stage_vector
 from utils.model_manager import get_available_module_keys
 from modules.llm_quality import enforce_glossary, back_translation_drift_score
@@ -894,6 +903,20 @@ class MainWindow(mainwindow_cls):
             'project_status': self._api_project_status,
             'pipeline_presets': self._api_pipeline_presets,
             'export_structured_ocr': self._api_export_structured_ocr,
+            'export_xliff': self._api_export_xliff,
+            'import_xliff': self._api_import_xliff,
+            'export_translation_json': self._api_export_translation_json,
+            'import_translation_json': self._api_import_translation_json,
+            'export_translation_csv': self._api_export_translation_csv,
+            'import_translation_csv': self._api_import_translation_csv,
+            'tm_query': self._api_tm_query,
+            'tm_build_from_project': self._api_tm_build_from_project,
+            'tm_export': self._api_tm_export,
+            'tm_import': self._api_tm_import,
+            'translation_qa_report': self._api_translation_qa_report,
+            'translation_prompt_profiles': self._api_translation_prompt_profiles,
+            'batch_find_replace_preview': self._api_batch_find_replace_preview,
+            'batch_find_replace_apply': self._api_batch_find_replace_apply,
             'render_current_page': self._api_render_current_page,
             'list_rendering_issues': self._api_list_rendering_issues,
             'apply_rendering_preset': self._api_apply_rendering_preset,
@@ -955,12 +978,7 @@ class MainWindow(mainwindow_cls):
         task = normalize_job_task(str((body or {}).get('task', '') or ''))
         payload = dict((body or {}).get('payload') or {})
         job_id = f"job_{int(time.time() * 1000)}_{threading.get_ident()}"
-        job = {
-            'job_id': job_id, 'task': task, 'status': 'queued',
-            'warnings': [], 'logs': [f'created task={task}'],
-            'created_at': time.time(), 'updated_at': time.time(),
-            'result': None, 'cancel_requested': False,
-        }
+        job = new_job(job_id, task)
         with self._api_jobs_lock:
             self._api_jobs[job_id] = job
             self._trim_api_jobs_locked()
@@ -971,14 +989,18 @@ class MainWindow(mainwindow_cls):
                 if j is None:
                     return
                 if j.get('cancel_requested'):
-                    j['status'] = 'cancelled'
-                    j['updated_at'] = time.time()
-                    self._append_api_job_log_locked(j, 'cancelled before start')
+                    set_status(j, 'cancelled', stage='cancelled:before_start', progress=0.0)
+                    append_log(j, 'cancelled before start')
                     return
-                j['status'] = 'running'
-                j['updated_at'] = time.time()
-                self._append_api_job_log_locked(j, 'started')
+                set_status(j, 'running', stage='starting', progress=0.02)
+                append_log(j, 'started')
             try:
+                with self._api_jobs_lock:
+                    j = self._api_jobs.get(job_id)
+                    if j is None:
+                        return
+                    if checkpoint_or_cancel(j, 'dispatch', 0.08):
+                        return
                 if task == 'run_pipeline':
                     rst = self._api_run_pipeline(payload)
                 elif task == 'render_page':
@@ -993,19 +1015,20 @@ class MainWindow(mainwindow_cls):
                     j = self._api_jobs.get(job_id)
                     if j is None:
                         return
-                    self._append_api_job_log_locked(j, 'finished')
+                    if j.get('cancel_requested'):
+                        set_status(j, 'cancelled', stage='cancelled:completed_with_cancel_request', progress=1.0)
+                    else:
+                        set_status(j, 'succeeded', stage='completed', progress=1.0)
+                    append_log(j, 'finished')
                     j['result'] = rst
-                    j['status'] = 'cancelled' if j.get('cancel_requested') else 'succeeded'
-                    j['updated_at'] = time.time()
             except Exception as e:
                 with self._api_jobs_lock:
                     j = self._api_jobs.get(job_id)
                     if j is None:
                         return
-                    j['status'] = 'failed'
-                    j['warnings'].append(str(e))
-                    j['updated_at'] = time.time()
-                    self._append_api_job_log_locked(j, f'failed: {e}')
+                    set_status(j, 'failed', stage='failed')
+                    add_warning(j, str(e))
+                    append_log(j, f'failed: {e}')
 
         threading.Thread(target=_runner, daemon=True).start()
         return {'ok': True, 'job_id': job_id, 'status': 'queued', 'task': task}
@@ -1018,16 +1041,7 @@ class MainWindow(mainwindow_cls):
             job = self._api_jobs.get(job_id)
             if job is None:
                 raise ValueError('unknown job_id')
-            return {
-                'job_id': job['job_id'],
-                'task': job['task'],
-                'status': job['status'],
-                'warnings': list(job.get('warnings', [])),
-                'cancel_requested': bool(job.get('cancel_requested', False)),
-                'created_at': float(job.get('created_at', 0.0)),
-                'updated_at': float(job.get('updated_at', 0.0)),
-                'has_result': job.get('result') is not None,
-            }
+            return status_payload(job)
 
     def _api_job_cancel(self, body: dict):
         job_id = str((body or {}).get('job_id', '') or '').strip()
@@ -1054,9 +1068,14 @@ class MainWindow(mainwindow_cls):
             job = self._api_jobs.get(job_id)
             if job is None:
                 raise ValueError('unknown job_id')
+            offset = int((body or {}).get('offset', 0) or 0)
+            logs = list(job.get('logs', []))
+            offset = max(0, min(offset, len(logs)))
             return {
                 'job_id': job_id,
-                'logs': list(job.get('logs', [])),
+                'offset': offset,
+                'next_offset': len(logs),
+                'logs': logs[offset:],
                 'warnings': list(job.get('warnings', [])),
             }
 
@@ -1088,11 +1107,8 @@ class MainWindow(mainwindow_cls):
             return {'jobs': out, 'count': len(out)}
 
     def _append_api_job_log_locked(self, job: dict, text: str):
-        logs = job.setdefault('logs', [])
-        logs.append(str(text))
         lim = int(getattr(pcfg, 'automation_api_job_log_limit', 200) or 200)
-        if lim > 0 and len(logs) > lim:
-            del logs[0:len(logs)-lim]
+        append_log(job, text, limit=lim)
 
     def _trim_api_jobs_locked(self):
         lim = int(getattr(pcfg, 'automation_api_job_history_limit', 200) or 200)
@@ -1154,48 +1170,76 @@ class MainWindow(mainwindow_cls):
         return self._api_call_ui(self._api_apply_edit_ui, body)
 
     def _api_apply_edit_ui(self, body: dict):
-        from utils.api_edit_ops import validate_batch_payload, EditValidationError
+        from utils.api_edit_ops import (
+            validate_batch_payload,
+            EditValidationError,
+            find_block_index_by_stable_id,
+            describe_block_ref,
+        )
         if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
             raise ValueError('open a project first')
+        raw_body = body if isinstance(body, dict) else {}
+        strict = bool(raw_body.get('strict', True))
         try:
-            ops = validate_batch_payload(body if isinstance(body, dict) and "ops" in body else {"ops": [body or {}]})
+            ops = validate_batch_payload(raw_body if "ops" in raw_body else {"ops": [body or {}]})
         except EditValidationError as e:
             raise ValueError(f'edit_validation_failed: {e.to_payload()}')
         applied = []
-        for op in ops:
-            if op.op == "undo":
-                self.on_undo()
-                applied.append({"op": "undo", "ok": True})
-                continue
-            if op.op == "redo":
-                self.on_redo()
-                applied.append({"op": "redo", "ok": True})
-                continue
-            page = op.page or self.imgtrans_proj.current_img
-            blks = self.imgtrans_proj.pages.get(page, []) if page else []
-            if op.op == "update_textbox":
-                idx = int(op.index if op.index is not None else -1)
-                if idx < 0 or idx >= len(blks):
-                    raise ValueError(f'invalid index {idx} for page {page}')
-                blks[idx].translation = str(op.text or "")
-                applied.append({"op": "update_textbox", "page": page, "index": idx})
-            elif op.op == "delete_textbox":
-                idx = int(op.index if op.index is not None else -1)
-                if idx < 0 or idx >= len(blks):
-                    raise ValueError(f'invalid index {idx} for page {page}')
-                del blks[idx]
-                applied.append({"op": "delete_textbox", "page": page, "index": idx})
-            elif op.op == "add_textbox":
-                self.imgtrans_proj.current_img = page
-                self.shortcutCreateTextbox()
-                new_index = len(self.imgtrans_proj.pages.get(page, []) or []) - 1
-                if new_index >= 0:
-                    nb = self.imgtrans_proj.pages[page][new_index]
-                    nb.translation = str(op.text or "")
-                applied.append({"op": "add_textbox", "page": page, "index": new_index})
+        errors = []
+        for op_index, op in enumerate(ops):
+            try:
+                if op.op == "undo":
+                    self.on_undo()
+                    applied.append({"op": "undo", "ok": True})
+                    continue
+                if op.op == "redo":
+                    self.on_redo()
+                    applied.append({"op": "redo", "ok": True})
+                    continue
+                page = op.page or self.imgtrans_proj.current_img
+                blks = self.imgtrans_proj.pages.get(page, []) if page else []
+                if op.op == "update_textbox":
+                    if op.block_id:
+                        idx = find_block_index_by_stable_id(blks, op.block_id)
+                    else:
+                        idx = int(op.index if op.index is not None else -1)
+                    if idx < 0 or idx >= len(blks):
+                        raise EditValidationError("index_out_of_range", "invalid textbox index", {"page": page, "index": idx, "count": len(blks)})
+                    blks[idx].translation = str(op.text or "")
+                    applied.append({"op": "update_textbox", **describe_block_ref(page, idx, blks[idx])})
+                elif op.op == "delete_textbox":
+                    if op.block_id:
+                        idx = find_block_index_by_stable_id(blks, op.block_id)
+                    else:
+                        idx = int(op.index if op.index is not None else -1)
+                    if idx < 0 or idx >= len(blks):
+                        raise EditValidationError("index_out_of_range", "invalid textbox index", {"page": page, "index": idx, "count": len(blks)})
+                    removed = blks[idx]
+                    ref = describe_block_ref(page, idx, removed)
+                    del blks[idx]
+                    applied.append({"op": "delete_textbox", **ref})
+                elif op.op == "add_textbox":
+                    self.imgtrans_proj.current_img = page
+                    self.shortcutCreateTextbox()
+                    new_index = len(self.imgtrans_proj.pages.get(page, []) or []) - 1
+                    if new_index >= 0:
+                        nb = self.imgtrans_proj.pages[page][new_index]
+                        nb.translation = str(op.text or "")
+                        applied.append({"op": "add_textbox", **describe_block_ref(page, new_index, nb)})
+                    else:
+                        raise EditValidationError("add_failed", "failed to create textbox", {"page": page})
+            except EditValidationError as e:
+                errors.append({"op_index": op_index, "op": op.op, "error": e.to_payload()})
+                if strict:
+                    raise ValueError(f'edit_apply_failed: {errors[-1]}')
+            except Exception as e:
+                errors.append({"op_index": op_index, "op": op.op, "error": {"code": "apply_exception", "message": str(e)}})
+                if strict:
+                    raise ValueError(f'edit_apply_failed: {errors[-1]}')
         self.canvas.updateTextBlkList()
-        self.canvas.setProjSaveState(True)
-        return {'ok': True, 'applied': applied, 'count': len(applied)}
+        if applied:
+            self.canvas.setProjSaveState(True)
+        return {'ok': len(errors) == 0, 'applied': applied, 'errors': errors, 'count': len(applied)}
 
     def _api_undo(self, body: dict):
         return self._api_call_ui(self._api_undo_ui, body)
@@ -1264,6 +1308,12 @@ class MainWindow(mainwindow_cls):
             return self._api_render_current_page_ui(body)
         if kind in {'structured_ocr', 'ocr_json'}:
             return self._api_export_structured_ocr_ui(body)
+        if kind in {'xliff', 'xlf'}:
+            return self._api_export_xliff_ui(body)
+        if kind in {'translation_json', 'trans_json'}:
+            return self._api_export_translation_json_ui(body)
+        if kind in {'translation_csv', 'trans_csv', 'csv'}:
+            return self._api_export_translation_csv_ui(body)
         if kind in {'svg_handoff', 'svg_text', 'editable_svg'}:
             if not self.imgtrans_proj.current_img:
                 raise ValueError('select a page first')
@@ -1782,6 +1832,216 @@ class MainWindow(mainwindow_cls):
             self.imgtrans_proj.save()
         self.pipelineInsightsPanel.add_event('API', self.tr('Applied rendering preset {0} to {1} text boxes').format(preset_id, applied))
         return {'ok': True, 'page': page, 'preset': preset_id, 'applied': applied}
+
+
+    def _api_export_xliff(self, body: dict):
+        return self._api_call_ui(self._api_export_xliff_ui, body)
+
+    def _api_export_xliff_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            out_path = osp.join(self.imgtrans_proj.directory, 'translation_export.xliff')
+        xml_text = export_project_xliff(self.imgtrans_proj)
+        with open(out_path, 'w', encoding='utf-8') as f:
+            f.write(xml_text)
+        return {'ok': True, 'path': out_path, 'format': 'xliff'}
+
+    def _api_import_xliff(self, body: dict):
+        return self._api_call_ui(self._api_import_xliff_ui, body)
+
+    def _api_import_xliff_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        path = str((body or {}).get('path', '') or '').strip()
+        if not path or not osp.exists(path):
+            raise ValueError('path is required and must exist')
+        with open(path, 'r', encoding='utf-8') as f:
+            xml_text = f.read()
+        all_matched, match_rst = import_project_xliff(self.imgtrans_proj, xml_text)
+        self.canvas.updateTextBlkList()
+        self.canvas.setProjSaveState(True)
+        return {'ok': all_matched, 'match': match_rst, 'path': path}
+
+
+    def _api_export_translation_json(self, body: dict):
+        return self._api_call_ui(self._api_export_translation_json_ui, body)
+
+    def _api_export_translation_json_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            out_path = osp.join(self.imgtrans_proj.directory, 'translation_export.json')
+        payload = export_translation_json(self.imgtrans_proj)
+        with open(out_path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        return {'ok': True, 'path': out_path, 'format': 'translation_json', 'pages': len(payload.get('pages', []))}
+
+    def _api_import_translation_json(self, body: dict):
+        return self._api_call_ui(self._api_import_translation_json_ui, body)
+
+    def _api_import_translation_json_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        path = str((body or {}).get('path', '') or '').strip()
+        if not path or not osp.exists(path):
+            raise ValueError('path is required and must exist')
+        with open(path, 'r', encoding='utf-8') as f:
+            payload = json.load(f)
+        all_matched, match_rst = import_translation_json(self.imgtrans_proj, payload if isinstance(payload, dict) else {})
+        self.canvas.updateTextBlkList()
+        self.canvas.setProjSaveState(True)
+        return {'ok': all_matched, 'path': path, 'match': match_rst}
+
+
+    def _api_export_translation_csv(self, body: dict):
+        return self._api_call_ui(self._api_export_translation_csv_ui, body)
+
+    def _api_export_translation_csv_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            out_path = osp.join(self.imgtrans_proj.directory, 'translation_export.csv')
+        csv_text = export_translation_csv_text(self.imgtrans_proj)
+        with open(out_path, 'w', encoding='utf-8', newline='') as f:
+            f.write(csv_text)
+        return {'ok': True, 'path': out_path, 'format': 'translation_csv'}
+
+    def _api_import_translation_csv(self, body: dict):
+        return self._api_call_ui(self._api_import_translation_csv_ui, body)
+
+    def _api_import_translation_csv_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        path = str((body or {}).get('path', '') or '').strip()
+        if not path or not osp.exists(path):
+            raise ValueError('path is required and must exist')
+        with open(path, 'r', encoding='utf-8') as f:
+            text = f.read()
+        all_matched, match_rst = import_translation_csv_text(self.imgtrans_proj, text)
+        self.canvas.updateTextBlkList()
+        self.canvas.setProjSaveState(True)
+        return {'ok': all_matched, 'path': path, 'match': match_rst}
+
+
+    def _api_tm_query(self, body: dict):
+        return self._api_call_ui(self._api_tm_query_ui, body)
+
+    def _api_tm_query_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        source = str((body or {}).get('source', '') or '')
+        min_score = float((body or {}).get('min_score', 0.65) or 0.65)
+        limit = int((body or {}).get('limit', 5) or 5)
+        store = list(getattr(self.imgtrans_proj, 'translation_memory', []) or [])
+        hits = query_tm(store, source, min_score=min_score, limit=limit)
+        return {'ok': True, 'hits': hits, 'count': len(hits)}
+
+    def _api_tm_build_from_project(self, body: dict):
+        return self._api_call_ui(self._api_tm_build_from_project_ui, body)
+
+    def _api_tm_build_from_project_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        self.imgtrans_proj.translation_memory = build_tm_from_project(self.imgtrans_proj)
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'entries': len(self.imgtrans_proj.translation_memory)}
+
+    def _api_tm_export(self, body: dict):
+        return self._api_call_ui(self._api_tm_export_ui, body)
+
+    def _api_tm_export_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            out_path = osp.join(self.imgtrans_proj.directory, 'translation_memory.json')
+        payload = export_tm_payload(list(getattr(self.imgtrans_proj, 'translation_memory', []) or []))
+        with open(out_path, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+        return {'ok': True, 'path': out_path, 'entries': len(payload.get('entries', []))}
+
+    def _api_tm_import(self, body: dict):
+        return self._api_call_ui(self._api_tm_import_ui, body)
+
+    def _api_tm_import_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        path = str((body or {}).get('path', '') or '').strip()
+        if not path or not osp.exists(path):
+            raise ValueError('path is required and must exist')
+        with open(path, 'r', encoding='utf-8') as f:
+            payload = json.load(f)
+        imported = import_tm_payload(payload if isinstance(payload, dict) else {})
+        merge = bool((body or {}).get('merge', True))
+        if merge:
+            store = list(getattr(self.imgtrans_proj, 'translation_memory', []) or [])
+            for row in imported:
+                add_tm_entry(store, row.get('source', ''), row.get('target', ''), page=row.get('page', ''), block_id=row.get('block_id', ''))
+            self.imgtrans_proj.translation_memory = store
+        else:
+            self.imgtrans_proj.translation_memory = imported
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'entries': len(self.imgtrans_proj.translation_memory)}
+
+
+    def _api_translation_prompt_profiles(self, body: dict):
+        return {'ok': True, 'profiles': sorted(PROMPT_PROFILES.keys()), 'default': getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue')}
+
+    def _api_translation_qa_report(self, body: dict):
+        return self._api_call_ui(self._api_translation_qa_report_ui, body)
+
+    def _api_translation_qa_report_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        page = str((body or {}).get('page', '') or self.imgtrans_proj.current_img or '')
+        if not page:
+            raise ValueError('page is required')
+        blocks = list((self.imgtrans_proj.pages or {}).get(page, []) or [])
+        profile = str((body or {}).get('profile', '') or getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue') or 'dialogue')
+        retry_threshold = int((body or {}).get('retry_issue_threshold', getattr(pcfg.module, 'translation_qa_retry_issue_threshold', 2)) or 2)
+        glossary = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
+        report = build_translation_qa_report(blocks, glossary, profile=profile, retry_issue_threshold=retry_threshold)
+        report['page'] = page
+        return {'ok': True, 'report': report}
+
+
+    def _api_batch_find_replace_preview(self, body: dict):
+        return self._api_call_ui(self._api_batch_find_replace_preview_ui, body)
+
+    def _api_batch_find_replace_preview_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        pattern = str((body or {}).get('pattern', '') or '')
+        replacement = str((body or {}).get('replacement', '') or '')
+        use_regex = bool((body or {}).get('use_regex', True))
+        case_sensitive = bool((body or {}).get('case_sensitive', False))
+        pages = (body or {}).get('pages') or None
+        preview = preview_batch_find_replace(
+            self.imgtrans_proj, pattern, replacement,
+            use_regex=use_regex, case_sensitive=case_sensitive, target='translation', pages=pages
+        )
+        preview['pattern'] = pattern
+        preview['replacement'] = replacement
+        return {'ok': True, **preview}
+
+    def _api_batch_find_replace_apply(self, body: dict):
+        return self._api_call_ui(self._api_batch_find_replace_apply_ui, body)
+
+    def _api_batch_find_replace_apply_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        preview = (body or {}).get('preview')
+        if not isinstance(preview, dict):
+            preview = self._api_batch_find_replace_preview_ui(body)
+        changed, applied = apply_batch_find_replace(self.imgtrans_proj, preview)
+        if changed > 0:
+            self.canvas.updateTextBlkList()
+            self.canvas.setProjSaveState(True)
+        return {'ok': True, 'changed': changed, 'applied': applied, 'count': len(applied)}
 
     def _api_export_structured_ocr(self, body: dict):
         return self._api_call_ui(self._api_export_structured_ocr_ui, body)
@@ -2597,6 +2857,18 @@ class MainWindow(mainwindow_cls):
         self.titleBar.batch_export_as_trigger.connect(self.on_batch_export_as)
         self.titleBar.export_lptxt_trigger.connect(self.on_export_lptxt)
         self.titleBar.export_structured_ocr_trigger.connect(self.on_export_structured_ocr_json)
+        if hasattr(self.titleBar, "export_xliff_trigger"):
+            self.titleBar.export_xliff_trigger.connect(self.on_export_xliff)
+        if hasattr(self.titleBar, "import_xliff_trigger"):
+            self.titleBar.import_xliff_trigger.connect(self.on_import_xliff)
+        if hasattr(self.titleBar, "export_translation_json_trigger"):
+            self.titleBar.export_translation_json_trigger.connect(self.on_export_translation_json)
+        if hasattr(self.titleBar, "import_translation_json_trigger"):
+            self.titleBar.import_translation_json_trigger.connect(self.on_import_translation_json)
+        if hasattr(self.titleBar, "export_translation_csv_trigger"):
+            self.titleBar.export_translation_csv_trigger.connect(self.on_export_translation_csv)
+        if hasattr(self.titleBar, "import_translation_csv_trigger"):
+            self.titleBar.import_translation_csv_trigger.connect(self.on_import_translation_csv)
         if hasattr(self.titleBar, "export_layered_psd_handoff_trigger"):
             self.titleBar.export_layered_psd_handoff_trigger.connect(self.on_export_layered_psd_handoff)
         if hasattr(self.titleBar, "export_svg_text_handoff_trigger"):
@@ -2610,6 +2882,8 @@ class MainWindow(mainwindow_cls):
         self.titleBar.retry_models_trigger.connect(self.on_retry_model_downloads)
         self.titleBar.environment_doctor_trigger.connect(self.on_environment_doctor)
         self.titleBar.translation_qa_report_trigger.connect(self.on_translation_qa_report_current_page)
+        if hasattr(self.titleBar, "batch_find_replace_trigger"):
+            self.titleBar.batch_find_replace_trigger.connect(self.on_batch_find_replace_current_project)
         self.titleBar.ocr_triage_trigger.connect(self.on_open_ocr_triage_current_page)
         self.titleBar.auto_extract_glossary_trigger.connect(self.on_auto_extract_glossary_current_page)
         self.titleBar.save_run_profile_trigger.connect(self.on_save_run_profile_snapshot)
@@ -3356,7 +3630,19 @@ class MainWindow(mainwindow_cls):
         api_provider.addItems(["OpenAI", "Google", "Grok", "OpenRouter", "LLM Studio", "Ollama"])
         api_provider.setCurrentText(getattr(pcfg.module, "layout_review_api_provider", "OpenAI"))
 
-        api_key = QLineEdit(getattr(pcfg.module, "layout_review_api_key", ""), dlg)
+        endpoint_preset = QComboBox(dlg)
+        endpoint_preset.addItems([
+            self.tr("Auto (provider default)"),
+            self.tr("OpenAI Cloud"),
+            self.tr("OpenRouter"),
+            self.tr("Google Gemini (OpenAI-compatible)"),
+            self.tr("LM Studio (local)"),
+            self.tr("Ollama (local)"),
+        ])
+
+        _api_key_fallback = getattr(pcfg.module, "layout_review_api_key", "")
+        _api_key_loaded = get_secret("layout_review_api_key") or _api_key_fallback
+        api_key = QLineEdit(_api_key_loaded, dlg)
         api_key.setEchoMode(QLineEdit.EchoMode.Password)
 
         endpoint = QLineEdit(getattr(pcfg.module, "layout_review_api_endpoint", ""), dlg)
@@ -3407,6 +3693,8 @@ class MainWindow(mainwindow_cls):
         form.addRow("", use_translator)
         form.addRow(self.tr("API provider"), api_provider)
         form.addRow(self.tr("API key"), api_key)
+        cred_label = QLabel(self.tr("Credential backend: OS keyring") if has_keyring() else self.tr("Credential backend: config fallback"), dlg)
+        form.addRow("", cred_label)
         form.addRow(self.tr("Endpoint"), endpoint)
         form.addRow(self.tr("Override model"), override_model)
         form.addRow(self.tr("Model"), model_name)
@@ -3417,6 +3705,42 @@ class MainWindow(mainwindow_cls):
         form.addRow(self.tr("Screenshot max side"), screenshot_max_side)
         form.addRow(self.tr("Prompt"), prompt)
         form.addRow(self.tr("Extra params JSON"), extra_params)
+        form.addRow(self.tr("Endpoint preset"), endpoint_preset)
+        form.addRow("", btn_test_conn)
+        form.addRow("", conn_status)
+
+        conn_status = QLabel(self.tr("Connection: not tested"), dlg)
+        btn_test_conn = QPushButton(self.tr("Test connection"), dlg)
+
+        def _apply_endpoint_preset(label: str):
+            label = (label or "").strip()
+            provider_map = {
+                self.tr("OpenAI Cloud"): "OpenAI",
+                self.tr("OpenRouter"): "OpenRouter",
+                self.tr("Google Gemini (OpenAI-compatible)"): "Google",
+                self.tr("LM Studio (local)"): "LLM Studio",
+                self.tr("Ollama (local)"): "Ollama",
+            }
+            provider_name = provider_map.get(label, api_provider.currentText())
+            if provider_name and label != self.tr("Auto (provider default)"):
+                api_provider.setCurrentText(provider_name)
+                endpoint.setText(provider_endpoint_preset(provider_name) or endpoint.text())
+
+        endpoint_preset.currentTextChanged.connect(_apply_endpoint_preset)
+
+        def _test_conn():
+            rst = check_provider_connection(
+                provider=api_provider.currentText(),
+                endpoint=endpoint.text().strip(),
+                api_key=api_key.text().strip(),
+                timeout_sec=max(2.0, float(getattr(pcfg, "runtime_http_timeout_sec", 60.0))),
+            )
+            if rst.ok:
+                conn_status.setText(self.tr("Connection: OK ({0})").format(rst.detail or "ok"))
+            else:
+                conn_status.setText(self.tr("Connection: failed ({0})").format(rst.detail or str(rst.status_code)))
+
+        btn_test_conn.clicked.connect(_test_conn)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
@@ -3458,7 +3782,12 @@ class MainWindow(mainwindow_cls):
         pcfg.module.layout_review_provider = provider.currentText()
         pcfg.module.layout_review_use_translator_settings = use_translator.isChecked()
         pcfg.module.layout_review_api_provider = api_provider.currentText()
-        pcfg.module.layout_review_api_key = api_key.text().strip()
+        _layout_key = api_key.text().strip()
+        _saved_layout = set_secret("layout_review_api_key", _layout_key) if _layout_key else False
+        if _saved_layout and not bool(getattr(pcfg, "credential_use_plaintext_fallback", False)):
+            pcfg.module.layout_review_api_key = ""
+        else:
+            pcfg.module.layout_review_api_key = _layout_key
         pcfg.module.layout_review_api_endpoint = endpoint.text().strip()
         pcfg.module.layout_review_override_model = override_model.text().strip()
         pcfg.module.layout_review_model_name = model_name.text().strip()
@@ -3549,7 +3878,7 @@ class MainWindow(mainwindow_cls):
             extra.update(
                 {
                     "api_provider": getattr(pcfg.module, "layout_review_api_provider", "OpenAI"),
-                    "api_key": getattr(pcfg.module, "layout_review_api_key", ""),
+                    "api_key": (get_secret("layout_review_api_key") or getattr(pcfg.module, "layout_review_api_key", "")),
                     "api_base_url": getattr(pcfg.module, "layout_review_api_endpoint", ""),
                     "api_path": "/v1/chat/completions",
                     "override_model": getattr(pcfg.module, "layout_review_override_model", ""),
@@ -5868,6 +6197,146 @@ class MainWindow(mainwindow_cls):
             LOGGER.exception(e)
             create_error_dialog(e, self.tr('Layered PSD handoff export failed'))
 
+
+    def on_export_xliff(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Export'), self.tr('Open a project first.'))
+            return
+        default_path = osp.join(self.imgtrans_proj.directory, 'translation_export.xliff')
+        savep = QFileDialog.getSaveFileName(self, self.tr('Export XLIFF'), default_path, self.tr('XLIFF (*.xliff *.xlf)'))
+        if not isinstance(savep, str):
+            savep = savep[0]
+        if not savep:
+            return
+        try:
+            with open(savep, 'w', encoding='utf-8') as f:
+                f.write(export_project_xliff(self.imgtrans_proj))
+            create_info_dialog(self.tr('XLIFF exported to: ') + savep)
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to export XLIFF'))
+
+    def on_import_xliff(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Import'), self.tr('Open a project first.'))
+            return
+        dialog = QFileDialog()
+        selected_file = str(dialog.getOpenFileUrl(self.parent(), self.tr('Import XLIFF'), filter='*.xliff *.xlf')[0].toLocalFile())
+        if not osp.exists(selected_file):
+            return
+        try:
+            with open(selected_file, 'r', encoding='utf-8') as f:
+                xml_text = f.read()
+            all_matched, match_rst = import_project_xliff(self.imgtrans_proj, xml_text)
+            if self.imgtrans_proj.current_img in (match_rst.get('matched_pages') or set()):
+                self.canvas.clear_undostack(update_saved_step=True)
+                self.st_manager.updateSceneTextitems()
+            create_info_dialog(self.tr('XLIFF import done. Matched: {0}, Unmatched: {1}, Missing: {2}').format(len(match_rst.get('matched_pages') or []), len(match_rst.get('unmatched_pages') or []), len(match_rst.get('missing_pages') or [])))
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to import XLIFF'))
+
+
+    def on_export_translation_json(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Export'), self.tr('Open a project first.'))
+            return
+        default_path = osp.join(self.imgtrans_proj.directory, 'translation_export.json')
+        savep = QFileDialog.getSaveFileName(self, self.tr('Export translation JSON'), default_path, self.tr('JSON (*.json)'))
+        if not isinstance(savep, str):
+            savep = savep[0]
+        if not savep:
+            return
+        try:
+            payload = export_translation_json(self.imgtrans_proj)
+            with open(savep, 'w', encoding='utf-8') as f:
+                json.dump(payload, f, ensure_ascii=False, indent=2)
+            create_info_dialog(self.tr('Translation JSON exported to: ') + savep)
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to export translation JSON'))
+
+    def on_import_translation_json(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Import'), self.tr('Open a project first.'))
+            return
+        dialog = QFileDialog()
+        selected_file = str(dialog.getOpenFileUrl(self.parent(), self.tr('Import translation JSON'), filter='*.json')[0].toLocalFile())
+        if not osp.exists(selected_file):
+            return
+        try:
+            with open(selected_file, 'r', encoding='utf-8') as f:
+                payload = json.load(f)
+            all_matched, match_rst = import_translation_json(self.imgtrans_proj, payload if isinstance(payload, dict) else {})
+            if self.imgtrans_proj.current_img in (match_rst.get('matched_pages') or set()):
+                self.canvas.clear_undostack(update_saved_step=True)
+                self.st_manager.updateSceneTextitems()
+            create_info_dialog(self.tr('Translation JSON import done. Matched: {0}, Unmatched: {1}, Missing: {2}').format(len(match_rst.get('matched_pages') or []), len(match_rst.get('unmatched_pages') or []), len(match_rst.get('missing_pages') or [])))
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to import translation JSON'))
+
+
+    def on_export_translation_csv(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Export'), self.tr('Open a project first.'))
+            return
+        default_path = osp.join(self.imgtrans_proj.directory, 'translation_export.csv')
+        savep = QFileDialog.getSaveFileName(self, self.tr('Export translation CSV'), default_path, self.tr('CSV (*.csv)'))
+        if not isinstance(savep, str):
+            savep = savep[0]
+        if not savep:
+            return
+        try:
+            with open(savep, 'w', encoding='utf-8', newline='') as f:
+                f.write(export_translation_csv_text(self.imgtrans_proj))
+            create_info_dialog(self.tr('Translation CSV exported to: ') + savep)
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to export translation CSV'))
+
+    def on_import_translation_csv(self):
+        if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Import'), self.tr('Open a project first.'))
+            return
+        dialog = QFileDialog()
+        selected_file = str(dialog.getOpenFileUrl(self.parent(), self.tr('Import translation CSV'), filter='*.csv')[0].toLocalFile())
+        if not osp.exists(selected_file):
+            return
+        try:
+            with open(selected_file, 'r', encoding='utf-8') as f:
+                text = f.read()
+            all_matched, match_rst = import_translation_csv_text(self.imgtrans_proj, text)
+            if self.imgtrans_proj.current_img in (match_rst.get('matched_pages') or set()):
+                self.canvas.clear_undostack(update_saved_step=True)
+                self.st_manager.updateSceneTextitems()
+            create_info_dialog(self.tr('Translation CSV import done. Matched: {0}, Unmatched: {1}, Missing: {2}').format(len(match_rst.get('matched_pages') or []), len(match_rst.get('unmatched_pages') or []), len(match_rst.get('missing_pages') or [])))
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to import translation CSV'))
+
+
+    def on_batch_find_replace_current_project(self):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            create_info_dialog({'title': self.tr('No project loaded'), 'text': self.tr('Open a project first.')})
+            return
+        pattern, ok = QInputDialog.getText(self, self.tr('Batch find/replace'), self.tr('Find (regex supported):'))
+        if not ok or not str(pattern).strip():
+            return
+        replacement, ok2 = QInputDialog.getText(self, self.tr('Batch find/replace'), self.tr('Replace with:'))
+        if not ok2:
+            return
+        preview = preview_batch_find_replace(self.imgtrans_proj, str(pattern), str(replacement), use_regex=True, case_sensitive=False, target='translation')
+        if preview.get('count', 0) <= 0:
+            create_info_dialog({'title': self.tr('Batch find/replace'), 'text': self.tr('No matches found.')})
+            return
+        sample = []
+        for hit in preview.get('hits', [])[:12]:
+            sample.append(f"{hit['page']}#{hit['index']+1}: {hit['before'][:36]} -> {hit['after'][:36]}")
+        msg = self.tr('Preview matches: {0}\nApply replacements?').format(preview.get('count', 0)) + '\n\n' + '\n'.join(sample)
+        yn = QMessageBox.question(self, self.tr('Batch find/replace preview'), msg, QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if yn != QMessageBox.StandardButton.Yes:
+            return
+        changed, _applied = apply_batch_find_replace(self.imgtrans_proj, preview)
+        if changed > 0:
+            self.canvas.updateTextBlkList()
+            self.canvas.setProjSaveState(True)
+        create_info_dialog({'title': self.tr('Batch find/replace'), 'text': self.tr('Applied changes: {0}').format(changed)})
+
     def on_export_structured_ocr_json(self):
         if not self.imgtrans_proj or self.imgtrans_proj.is_empty:
             QMessageBox.information(self, self.tr('Export'), self.tr('Open a project first.'))
@@ -6778,22 +7247,22 @@ class MainWindow(mainwindow_cls):
         if self.imgtrans_proj is None or not getattr(self.imgtrans_proj, 'current_img', None):
             create_info_dialog({'title': self.tr('No page loaded'), 'text': self.tr('Open a project/page first.')})
             return
-        from utils.translation_review import extract_glossary_candidates, check_translation_guardrails
         page = self.imgtrans_proj.current_img
-        blks = self.imgtrans_proj.pages.get(page, []) or []
-        src_texts = [getattr(b, 'text', '') or '' for b in blks]
-        trans_texts = [getattr(b, 'translation', '') or '' for b in blks]
+        blocks = self.imgtrans_proj.pages.get(page, []) or []
         glossary = getattr(self.imgtrans_proj, 'translation_glossary', None) or []
-        issues = []
-        for i, b in enumerate(blks):
-            for issue in check_translation_guardrails(getattr(b, 'text', ''), getattr(b, 'translation', ''), glossary=glossary):
-                issues.append(f"#{i+1}: {issue}")
+        profile = getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue')
+        retry_threshold = int(getattr(pcfg.module, 'translation_qa_retry_issue_threshold', 2) or 2)
+        report = build_translation_qa_report(blocks, glossary, profile=profile, retry_issue_threshold=retry_threshold)
+        from utils.translation_review import extract_glossary_candidates
+        src_texts = [getattr(b, 'text', '') or '' for b in blocks]
+        trans_texts = [getattr(b, 'translation', '') or '' for b in blocks]
         candidates = extract_glossary_candidates(src_texts, trans_texts, min_freq=2)[:20]
-        empty_ocr = [str(i+1) for i,b in enumerate(blks) if not (getattr(b, 'text', '') or '').strip()]
-        lines = [self.tr('Page: ') + str(page), self.tr('Blocks: ') + str(len(blks))]
-        lines.append(self.tr('Likely OCR triage (empty source): ') + (', '.join(empty_ocr) if empty_ocr else self.tr('none')))
-        lines.append(self.tr('Guardrail issues: ') + str(len(issues)))
-        lines.extend(issues[:50])
+        lines = [self.tr('Page: ') + str(page), self.tr('Profile: ') + str(profile), self.tr('Blocks: ') + str(report['total_blocks'])]
+        lines.append(self.tr('Issue blocks: ') + str(report['issue_blocks']))
+        lines.append(self.tr('Retry candidates (>= issue threshold): ') + ', '.join(str(i+1) for i in report.get('retry_candidates', [])) if report.get('retry_candidates') else self.tr('none'))
+        for row in report.get('rows', [])[:80]:
+            for issue in row.get('issues', []):
+                lines.append(f"#{row['index']+1}: {issue}")
         if candidates:
             lines.append(self.tr('Glossary candidates (source -> target):'))
             lines.extend([f"- {c.get('source','')} -> {c.get('target','')}" for c in candidates])

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -794,6 +794,10 @@ class TitleBar(Widget):
         projectMenu.addAction(translationQaAction)
         projectMenu.addAction(ocrTriageAction)
         projectMenu.addAction(autoExtractGlossaryAction)
+        batchFindReplaceAction = QAction(self.tr('Batch find/replace translations...'), self)
+        batchFindReplaceAction.setToolTip(self.tr('Preview regex find/replace across project translations before applying.'))
+        self.batch_find_replace_trigger = batchFindReplaceAction.triggered
+        projectMenu.addAction(batchFindReplaceAction)
         exportMenuTools = QMenu(self.tr('Export'), self)
         exportMenuTools.addAction(batchExportAction)
         exportMenuTools.addAction(batchExportAsAction)
@@ -809,6 +813,30 @@ class TitleBar(Widget):
         svgTextHandoffAction.setToolTip(self.tr('Export current page as an SVG with editable translated text elements for vector editors.'))
         self.export_svg_text_handoff_trigger = svgTextHandoffAction.triggered
         exportMenuTools.addAction(svgTextHandoffAction)
+        exportTransCsvAction = QAction(self.tr('Export translation CSV...'), self)
+        exportTransCsvAction.setToolTip(self.tr('Export source/translation rows as CSV for spreadsheet and CAT workflows.'))
+        self.export_translation_csv_trigger = exportTransCsvAction.triggered
+        exportMenuTools.addAction(exportTransCsvAction)
+        importTransCsvAction = QAction(self.tr('Import translation CSV...'), self)
+        importTransCsvAction.setToolTip(self.tr('Import translation CSV by page + stable block ID with index fallback.'))
+        self.import_translation_csv_trigger = importTransCsvAction.triggered
+        exportMenuTools.addAction(importTransCsvAction)
+        exportTransJsonAction = QAction(self.tr('Export translation JSON...'), self)
+        exportTransJsonAction.setToolTip(self.tr('Export source/translation with stable block IDs for external translation workflows.'))
+        self.export_translation_json_trigger = exportTransJsonAction.triggered
+        exportMenuTools.addAction(exportTransJsonAction)
+        importTransJsonAction = QAction(self.tr('Import translation JSON...'), self)
+        importTransJsonAction.setToolTip(self.tr('Import translation JSON back by page and stable block ID (with index fallback).'))
+        self.import_translation_json_trigger = importTransJsonAction.triggered
+        exportMenuTools.addAction(importTransJsonAction)
+        exportXliffAction = QAction(self.tr('Export XLIFF...'), self)
+        exportXliffAction.setToolTip(self.tr('Export source/translation blocks in XLIFF 1.2 for CAT-tool workflows.'))
+        self.export_xliff_trigger = exportXliffAction.triggered
+        exportMenuTools.addAction(exportXliffAction)
+        importXliffAction = QAction(self.tr('Import XLIFF...'), self)
+        importXliffAction.setToolTip(self.tr('Import translated XLIFF back into current project by page and block index.'))
+        self.import_xliff_trigger = importXliffAction.triggered
+        exportMenuTools.addAction(importXliffAction)
         structuredOcrExportAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'structured_ocr_export.svg')), self.tr('Export structured OCR JSON...'), self)
         structuredOcrExportAction.setToolTip(self.tr('Export page/block geometry, OCR text, translations, completion state, and font hints as JSON for LLM/tooling workflows.'))
         self.export_structured_ocr_trigger = structuredOcrExportAction.triggered

--- a/utils/api_edit_ops.py
+++ b/utils/api_edit_ops.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Mapping
+import uuid
 
 
 @dataclass
@@ -19,6 +20,7 @@ class TextboxOperation:
     text: Optional[str] = None
     rect: Optional[List[float]] = None
     page: Optional[str] = None
+    block_id: Optional[str] = None
 
 
 def _as_int(value: Any, field_name: str) -> int:
@@ -36,9 +38,12 @@ def validate_textbox_operation(raw: Dict[str, Any]) -> TextboxOperation:
         raise EditValidationError("unsupported_operation", "unsupported operation", {"op": op})
     item = TextboxOperation(op=op, page=str(raw.get("page", "") or "").strip() or None)
     if op in {"update_textbox", "delete_textbox"}:
-        if "index" not in raw:
-            raise EditValidationError("missing_field", "index is required", {"field": "index", "op": op})
-        item.index = _as_int(raw.get("index"), "index")
+        if "index" in raw:
+            item.index = _as_int(raw.get("index"), "index")
+        elif "block_id" in raw and str(raw.get("block_id","")).strip():
+            item.block_id = str(raw.get("block_id", "")).strip()
+        else:
+            raise EditValidationError("missing_field", "index or block_id is required", {"field": "index|block_id", "op": op})
     if op == "update_textbox":
         if "text" not in raw:
             raise EditValidationError("missing_field", "text is required for update_textbox", {"field": "text"})
@@ -66,3 +71,43 @@ def validate_batch_payload(body: Dict[str, Any]) -> List[TextboxOperation]:
         except EditValidationError as e:
             raise EditValidationError(e.code, e.message, {**e.details, "op_index": i}) from e
     return out
+
+
+
+def ensure_block_stable_id(block: Any) -> str:
+    """Return a stable automation id for one textbox block.
+
+    IDs are persisted on the block object when possible so subsequent API calls
+    can target the same textbox even if list indexes move.
+    """
+    for key in ("api_block_id", "block_id", "id"):
+        try:
+            value = getattr(block, key, None)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    new_id = f"tbx_{uuid.uuid4().hex[:16]}"
+    try:
+        setattr(block, "api_block_id", new_id)
+    except Exception:
+        pass
+    return new_id
+
+
+def find_block_index_by_stable_id(blocks: List[Any], block_id: str) -> int:
+    target = str(block_id or "").strip()
+    if not target:
+        raise EditValidationError("missing_field", "block_id is required", {"field": "block_id"})
+    for idx, block in enumerate(blocks or []):
+        if ensure_block_stable_id(block) == target:
+            return idx
+    raise EditValidationError("not_found", "textbox not found", {"block_id": target})
+
+
+def describe_block_ref(page: str, index: int, block: Any) -> Dict[str, Any]:
+    return {
+        "page": str(page or ""),
+        "index": int(index),
+        "block_id": ensure_block_stable_id(block),
+    }

--- a/utils/automation_jobs.py
+++ b/utils/automation_jobs.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import time
+from typing import Any, Dict, List
+
+FINAL_STATES = {"succeeded", "failed", "cancelled"}
+
+
+@dataclass
+class AutomationJob:
+    job_id: str
+    task: str
+    status: str = "queued"
+    warnings: List[str] = field(default_factory=list)
+    logs: List[str] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
+    updated_at: float = field(default_factory=time.time)
+    result: Any = None
+    cancel_requested: bool = False
+    progress: float = 0.0
+    stage: str = "queued"
+
+
+def new_job(job_id: str, task: str) -> Dict[str, Any]:
+    j = AutomationJob(job_id=job_id, task=task)
+    j.logs.append(f"created task={task}")
+    return j.__dict__.copy()
+
+
+def append_log(job: Dict[str, Any], text: str, *, limit: int = 200) -> None:
+    logs = job.setdefault("logs", [])
+    logs.append(str(text))
+    if limit > 0 and len(logs) > limit:
+        del logs[0: len(logs) - limit]
+    job["updated_at"] = time.time()
+
+
+def add_warning(job: Dict[str, Any], text: str) -> None:
+    warns = job.setdefault("warnings", [])
+    msg = str(text)
+    warns.append(msg)
+    append_log(job, f"warning: {msg}")
+
+
+def set_status(job: Dict[str, Any], status: str, *, stage: str | None = None, progress: float | None = None) -> None:
+    job["status"] = str(status)
+    if stage is not None:
+        job["stage"] = str(stage)
+    if progress is not None:
+        job["progress"] = max(0.0, min(1.0, float(progress)))
+    job["updated_at"] = time.time()
+
+
+def checkpoint_or_cancel(job: Dict[str, Any], stage: str, progress: float) -> bool:
+    set_status(job, job.get("status") or "running", stage=stage, progress=progress)
+    if job.get("cancel_requested"):
+        set_status(job, "cancelled", stage=f"cancelled:{stage}")
+        append_log(job, f"cancelled at checkpoint: {stage}")
+        return True
+    return False
+
+
+def status_payload(job: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "job_id": job.get("job_id", ""),
+        "task": job.get("task", ""),
+        "status": job.get("status", ""),
+        "stage": job.get("stage", ""),
+        "progress": float(job.get("progress", 0.0) or 0.0),
+        "warnings": list(job.get("warnings", [])),
+        "cancel_requested": bool(job.get("cancel_requested", False)),
+        "created_at": float(job.get("created_at", 0.0)),
+        "updated_at": float(job.get("updated_at", 0.0)),
+        "has_result": job.get("result") is not None,
+    }

--- a/utils/batch_find_replace.py
+++ b/utils/batch_find_replace.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+
+@dataclass
+class ReplaceHit:
+    page: str
+    index: int
+    field: str
+    before: str
+    after: str
+    count: int
+
+
+def _compile(pattern: str, use_regex: bool, case_sensitive: bool):
+    flags = 0 if case_sensitive else re.IGNORECASE
+    if use_regex:
+        return re.compile(pattern, flags)
+    return re.compile(re.escape(pattern), flags)
+
+
+def preview_batch_find_replace(project, pattern: str, replacement: str, *, use_regex: bool = True, case_sensitive: bool = False, target: str = "translation", pages: List[str] | None = None) -> Dict[str, Any]:
+    if not pattern:
+        return {"hits": [], "count": 0}
+    rx = _compile(pattern, use_regex, case_sensitive)
+    hits: List[Dict[str, Any]] = []
+    page_list = pages or list((getattr(project, "pages", {}) or {}).keys())
+    for page in page_list:
+        blks = (getattr(project, "pages", {}) or {}).get(page, []) or []
+        for idx, blk in enumerate(blks):
+            before = (getattr(blk, "translation", "") if target == "translation" else getattr(blk, "get_text", lambda: "")()) or ""
+            after, n = rx.subn(replacement, before)
+            if n > 0 and after != before:
+                hits.append({"page": page, "index": idx, "field": target, "before": before, "after": after, "count": n})
+    return {"hits": hits, "count": len(hits)}
+
+
+def apply_batch_find_replace(project, preview_payload: Dict[str, Any]) -> Tuple[int, List[Dict[str, Any]]]:
+    changed = 0
+    applied: List[Dict[str, Any]] = []
+    for hit in preview_payload.get("hits", []) or []:
+        page = str(hit.get("page", "") or "")
+        idx = int(hit.get("index", -1))
+        field = str(hit.get("field", "translation") or "translation")
+        after = str(hit.get("after", "") or "")
+        blks = (getattr(project, "pages", {}) or {}).get(page, []) or []
+        if idx < 0 or idx >= len(blks):
+            continue
+        blk = blks[idx]
+        if field == "translation":
+            if (getattr(blk, "translation", "") or "") != after:
+                blk.translation = after
+                changed += 1
+                applied.append({"page": page, "index": idx, "field": field})
+    return changed, applied

--- a/utils/config.py
+++ b/utils/config.py
@@ -9,6 +9,8 @@ from . import shared
 from .fontformat import FontFormat
 from .structures import List, Dict, Config, field, nested_dataclass
 from .logger import logger as LOGGER
+from utils.credential_store import has_keyring, set_secret
+from utils.secret_migration import migrate_secrets_to_keyring_if_possible, scrub_plaintext_secrets_for_save
 from .io_utils import json_dump_nested_obj, np, serialize_np
 
 class RunStatus:
@@ -341,6 +343,8 @@ class ModuleConfig(Config):
     automation_api_enabled: bool = False
     automation_api_port: int = 39542
     automation_api_key: str = ""
+    credential_use_plaintext_fallback: bool = False
+    credential_migration_done: bool = False
     automation_api_job_history_limit: int = 200
     automation_api_job_log_limit: int = 200
     user_replace_profiles: Dict = field(default_factory=dict)
@@ -723,9 +727,9 @@ CONFIG_KEY_ORDER = (
     "darkmode", "bubbly_ui", "accent_color_hex", "app_font_family", "app_font_size", "use_custom_cursor", "custom_cursor_path", "textselect_mini_menu", "fold_textarea", "show_source_text", "show_trans_text",
     "saladict_shortcut", "search_url", "ocr_sublist", "restore_ocr_empty", "pre_mt_sublist", "mt_sublist",
     "display_lang", "imgsave_quality", "imgsave_webp_lossless", "imgsave_ext", "intermediate_imgsave_ext",
-    "enable_glossary_enforcement", "llm_glossary_map", "enable_back_translation_qa", "back_translation_drift_threshold", "llm_token_budget",
+    "enable_glossary_enforcement", "llm_glossary_map", "enable_back_translation_qa", "back_translation_drift_threshold", "translation_prompt_profile_default", "translation_qa_retry_issue_threshold", "llm_token_budget",
     "enable_text_normalization", "text_normalization_profile",
-    "runtime_http_timeout_sec", "runtime_http_retries", "data_path_override", "automation_api_enabled", "automation_api_port", "automation_api_key", "automation_api_job_history_limit", "automation_api_job_log_limit",
+    "runtime_http_timeout_sec", "runtime_http_retries", "data_path_override", "automation_api_enabled", "automation_api_port", "automation_api_key", "credential_use_plaintext_fallback", "credential_migration_done", "automation_api_job_history_limit", "automation_api_job_log_limit",
     "user_replace_profiles",
     "vertical_cjk_rotate_latin", "vertical_cjk_punctuation_hang",
     "pipeline_retry_detect", "pipeline_retry_ocr", "pipeline_retry_translate", "pipeline_retry_inpaint",
@@ -851,6 +855,7 @@ def load_config(config_path: str = shared.CONFIG_PATH):
                 op['nemotron_parse'] = op.pop('nemotron_ocr')
             else:
                 op.pop('nemotron_ocr', None)
+    migrate_secrets_to_keyring_if_possible(pcfg, has_keyring=has_keyring, set_secret=set_secret)
     # Section 9: clamp numeric settings
     try:
         from utils.validation import clamp_settings
@@ -999,6 +1004,8 @@ def flush_config_save() -> bool:
     if pending:
         return bool(save_config(force=True))
     return False
+
+
 
 
 def save_config(force: bool = False):

--- a/utils/headless_contract.py
+++ b/utils/headless_contract.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Dict, List
+
+
+class HeadlessExitCode(IntEnum):
+    OK = 0
+    CONFIG_ERROR = 2
+    INPUT_ERROR = 3
+    RUNTIME_ERROR = 4
+    PARTIAL_FAILURE = 5
+
+
+@dataclass
+class HeadlessRunSummary:
+    requested_dirs: List[str]
+    processed_dirs: List[str]
+    skipped_dirs: List[str]
+    failed_dirs: List[str]
+
+    def to_payload(self) -> Dict[str, object]:
+        return {
+            "requested": len(self.requested_dirs),
+            "processed": len(self.processed_dirs),
+            "skipped": len(self.skipped_dirs),
+            "failed": len(self.failed_dirs),
+            "processed_dirs": list(self.processed_dirs),
+            "skipped_dirs": list(self.skipped_dirs),
+            "failed_dirs": list(self.failed_dirs),
+        }
+
+    def exit_code(self) -> int:
+        if not self.requested_dirs:
+            return int(HeadlessExitCode.INPUT_ERROR)
+        if self.failed_dirs:
+            return int(HeadlessExitCode.PARTIAL_FAILURE if self.processed_dirs else HeadlessExitCode.RUNTIME_ERROR)
+        if not self.processed_dirs:
+            return int(HeadlessExitCode.INPUT_ERROR)
+        return int(HeadlessExitCode.OK)

--- a/utils/proj_imgtrans.py
+++ b/utils/proj_imgtrans.py
@@ -109,6 +109,7 @@ class ProjImgTrans:
         self.mask_array: np.ndarray = None
         self.inpainted_array: np.ndarray = None
         self.translation_glossary: List[Dict[str, str]] = []  # [{"source": "...", "target": "..."}]
+        self.translation_memory: List[Dict[str, str]] = []  # [{source,target,page,block_id}]
         self.series_context_path: str = ""  # Folder or ID for cross-chapter consistency (e.g. urban_immortal_cultivator)
         self.run_profiles: Dict[str, Dict] = {}  # project-local snapshots of selected run/module settings
         if directory is not None:
@@ -188,6 +189,7 @@ class ProjImgTrans:
             self._image_info = {}
 
         self.translation_glossary = proj_dict.get('translation_glossary') or []
+        self.translation_memory = proj_dict.get('translation_memory') or []
 
         self.series_context_path = (proj_dict.get('series_context_path') or "").strip()
         self.run_profiles = proj_dict.get('run_profiles') or {}
@@ -411,6 +413,8 @@ class ProjImgTrans:
         }
         if getattr(self, 'translation_glossary', None):
             out['translation_glossary'] = self.translation_glossary
+        if getattr(self, 'translation_memory', None):
+            out['translation_memory'] = self.translation_memory
         if getattr(self, 'series_context_path', None):
             out['series_context_path'] = self.series_context_path
         if getattr(self, 'run_profiles', None):

--- a/utils/provider_setup.py
+++ b/utils/provider_setup.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+from urllib.parse import urljoin
+import json
+import urllib.request
+
+from utils.llm_provider import default_endpoint_for_provider
+
+
+@dataclass
+class ProviderCheckResult:
+    ok: bool
+    provider: str
+    endpoint: str
+    status_code: int
+    detail: str = ""
+
+
+def provider_endpoint_preset(provider: str) -> str:
+    return (default_endpoint_for_provider(provider) or "").strip()
+
+
+def _default_fetch(url: str, headers: Optional[Dict[str, str]] = None, timeout: float = 8.0) -> Tuple[int, str]:
+    req = urllib.request.Request(url, headers=headers or {}, method="GET")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return int(getattr(resp, "status", 200) or 200), resp.read().decode("utf-8", errors="replace")
+
+
+def check_provider_connection(
+    provider: str,
+    endpoint: str,
+    api_key: str = "",
+    timeout_sec: float = 8.0,
+    fetcher: Optional[Callable[[str, Optional[Dict[str, str]], float], Tuple[int, str]]] = None,
+) -> ProviderCheckResult:
+    provider = (provider or "").strip()
+    endpoint = (endpoint or provider_endpoint_preset(provider) or "").strip().rstrip("/")
+    if not endpoint:
+        return ProviderCheckResult(False, provider, endpoint, 0, "missing endpoint")
+    fetch = fetcher or _default_fetch
+    headers: Dict[str, str] = {"Accept": "application/json"}
+    if api_key.strip() and provider not in {"Ollama", "LLM Studio"}:
+        headers["Authorization"] = f"Bearer {api_key.strip()}"
+
+    # Lightweight provider-specific probes.
+    path = "/v1/models"
+    if provider == "Ollama":
+        path = "/api/tags"
+    elif provider == "LLM Studio":
+        path = "/v1/models"
+
+    url = urljoin(endpoint + "/", path.lstrip("/"))
+    try:
+        status, body = fetch(url, headers, float(timeout_sec))
+        if status < 200 or status >= 300:
+            return ProviderCheckResult(False, provider, endpoint, status, f"HTTP {status}")
+        # best-effort JSON parse for human detail
+        detail = "ok"
+        try:
+            payload = json.loads(body or "{}")
+            if isinstance(payload, dict) and isinstance(payload.get("data"), list):
+                detail = f"ok ({len(payload['data'])} model(s))"
+            elif isinstance(payload, dict) and isinstance(payload.get("models"), list):
+                detail = f"ok ({len(payload['models'])} model(s))"
+        except Exception:
+            pass
+        return ProviderCheckResult(True, provider, endpoint, status, detail)
+    except Exception as e:
+        return ProviderCheckResult(False, provider, endpoint, 0, str(e))

--- a/utils/secret_migration.py
+++ b/utils/secret_migration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+SECRET_FIELD_SPECS: List[Tuple[str | None, str, str]] = [
+    ("module", "layout_review_api_key", "layout_review_api_key"),
+    ("module", "video_translator_flow_fixer_openrouter_apikey", "video_flow_fixer_openrouter_apikey"),
+    ("module", "video_translator_flow_fixer_openai_apikey", "video_flow_fixer_openai_apikey"),
+    (None, "automation_api_key", "automation_api_key"),
+]
+
+
+def migrate_secrets_to_keyring_if_possible(pcfg: Any, *, has_keyring, set_secret) -> bool:
+    if not has_keyring() or bool(getattr(pcfg, "credential_migration_done", False)):
+        return False
+    allow_plain = bool(getattr(pcfg, "credential_use_plaintext_fallback", False))
+    migrated = False
+    for owner, field_name, secret_key in SECRET_FIELD_SPECS:
+        target = getattr(pcfg, owner) if owner else pcfg
+        value = str(getattr(target, field_name, "") or "").strip()
+        if not value:
+            continue
+        if set_secret(secret_key, value):
+            migrated = True
+            if not allow_plain:
+                setattr(target, field_name, "")
+    if migrated:
+        setattr(pcfg, "credential_migration_done", True)
+    return migrated
+
+
+def scrub_plaintext_secrets_for_save(pcfg: Any, *, has_keyring) -> None:
+    if bool(getattr(pcfg, "credential_use_plaintext_fallback", False)):
+        return
+    if not has_keyring():
+        return
+    for owner, field_name, _ in SECRET_FIELD_SPECS:
+        target = getattr(pcfg, owner) if owner else pcfg
+        if getattr(target, field_name, ""):
+            setattr(target, field_name, "")

--- a/utils/translation_csv_interchange.py
+++ b/utils/translation_csv_interchange.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from typing import Any, Dict, List, Tuple
+
+from utils.api_edit_ops import ensure_block_stable_id
+
+SCHEMA = "ballonstranslator.translation_csv.v1"
+FIELDS = ["page", "index", "block_id", "source", "translation"]
+
+
+def export_translation_csv_text(project) -> str:
+    bio = StringIO()
+    w = csv.DictWriter(bio, fieldnames=FIELDS)
+    w.writeheader()
+    for page, blks in (getattr(project, "pages", {}) or {}).items():
+        for idx, blk in enumerate(blks or []):
+            w.writerow({
+                "page": str(page),
+                "index": int(idx),
+                "block_id": ensure_block_stable_id(blk),
+                "source": (getattr(blk, "get_text", lambda: "")() or ""),
+                "translation": (getattr(blk, "translation", "") or ""),
+            })
+    return bio.getvalue()
+
+
+def import_translation_csv_text(project, text: str) -> Tuple[bool, Dict[str, Any]]:
+    rows = list(csv.DictReader(StringIO(text or "")))
+    pages = getattr(project, "pages", {}) or {}
+    matched_pages, missing_pages, unmatched_pages = set(), [], []
+
+    by_page: Dict[str, List[Dict[str, str]]] = {}
+    for row in rows:
+        page = str((row or {}).get("page", "") or "")
+        by_page.setdefault(page, []).append(row)
+
+    for page, page_rows in by_page.items():
+        if page not in pages:
+            missing_pages.append(page)
+            continue
+        matched_pages.add(page)
+        dst_blocks = pages.get(page, []) or []
+        id_to_idx = {ensure_block_stable_id(b): i for i, b in enumerate(dst_blocks)}
+        touched = 0
+        for row in page_rows:
+            idx = None
+            bid = str((row or {}).get("block_id", "") or "").strip()
+            if bid and bid in id_to_idx:
+                idx = id_to_idx[bid]
+            else:
+                try:
+                    idx = int((row or {}).get("index", ""))
+                except Exception:
+                    idx = None
+            if idx is None or idx < 0 or idx >= len(dst_blocks):
+                continue
+            dst_blocks[idx].translation = str((row or {}).get("translation", "") or "")
+            touched += 1
+        if touched != len(dst_blocks):
+            unmatched_pages.append(page)
+
+    ok = not missing_pages and not unmatched_pages
+    return ok, {
+        "schema": SCHEMA,
+        "matched_pages": matched_pages,
+        "missing_pages": missing_pages,
+        "unmatched_pages": unmatched_pages,
+        "unexpected_pages": [],
+    }

--- a/utils/translation_json_interchange.py
+++ b/utils/translation_json_interchange.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+from utils.api_edit_ops import ensure_block_stable_id
+
+SCHEMA = "ballonstranslator.translation_json.v1"
+
+
+def export_translation_json(project) -> Dict[str, Any]:
+    pages_payload: List[Dict[str, Any]] = []
+    for page_name, blks in (getattr(project, "pages", {}) or {}).items():
+        rows = []
+        for idx, blk in enumerate(blks or []):
+            rows.append({
+                "index": idx,
+                "block_id": ensure_block_stable_id(blk),
+                "source": (getattr(blk, "get_text", lambda: "")() or ""),
+                "translation": (getattr(blk, "translation", "") or ""),
+            })
+        pages_payload.append({"page": str(page_name), "blocks": rows})
+    return {"schema": SCHEMA, "pages": pages_payload}
+
+
+def import_translation_json(project, payload: Dict[str, Any]) -> Tuple[bool, Dict[str, Any]]:
+    pages = getattr(project, "pages", {}) or {}
+    matched_pages, missing_pages, unmatched_pages = set(), [], []
+    for page_rec in (payload.get("pages") or []):
+        page = str((page_rec or {}).get("page", "") or "")
+        if page not in pages:
+            missing_pages.append(page)
+            continue
+        matched_pages.add(page)
+        src_blocks = list((page_rec or {}).get("blocks") or [])
+        dst_blocks = pages.get(page, []) or []
+        if len(src_blocks) != len(dst_blocks):
+            unmatched_pages.append(page)
+        id_to_idx = {ensure_block_stable_id(b): i for i, b in enumerate(dst_blocks)}
+        for i, rec in enumerate(src_blocks):
+            target_idx = None
+            bid = str((rec or {}).get("block_id", "") or "").strip()
+            if bid and bid in id_to_idx:
+                target_idx = id_to_idx[bid]
+            elif i < len(dst_blocks):
+                target_idx = i
+            if target_idx is None:
+                continue
+            dst_blocks[target_idx].translation = str((rec or {}).get("translation", "") or "")
+    ok = not missing_pages and not unmatched_pages
+    return ok, {
+        "matched_pages": matched_pages,
+        "missing_pages": missing_pages,
+        "unmatched_pages": unmatched_pages,
+        "unexpected_pages": [],
+    }

--- a/utils/translation_memory.py
+++ b/utils/translation_memory.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+from typing import Any, Dict, List
+
+SCHEMA = "ballonstranslator.tm.v1"
+
+
+def normalize_text(s: str) -> str:
+    return " ".join((s or "").strip().lower().split())
+
+
+def add_tm_entry(store: List[Dict[str, str]], source: str, target: str, *, page: str = "", block_id: str = "") -> None:
+    src = (source or "").strip()
+    tgt = (target or "").strip()
+    if not src or not tgt:
+        return
+    for row in store:
+        if normalize_text(row.get("source", "")) == normalize_text(src) and normalize_text(row.get("target", "")) == normalize_text(tgt):
+            return
+    store.append({"source": src, "target": tgt, "page": page or "", "block_id": block_id or ""})
+
+
+def build_tm_from_project(project) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for page, blks in (getattr(project, "pages", {}) or {}).items():
+        for blk in blks or []:
+            source = (getattr(blk, "get_text", lambda: "")() or "")
+            target = (getattr(blk, "translation", "") or "")
+            add_tm_entry(rows, source, target, page=str(page), block_id=str(getattr(blk, "api_block_id", "") or ""))
+    return rows
+
+
+def query_tm(store: List[Dict[str, str]], source: str, *, min_score: float = 0.65, limit: int = 5) -> List[Dict[str, Any]]:
+    needle = normalize_text(source)
+    if not needle:
+        return []
+    out: List[Dict[str, Any]] = []
+    for row in store or []:
+        cand = normalize_text(row.get("source", ""))
+        if not cand:
+            continue
+        score = SequenceMatcher(None, needle, cand).ratio()
+        if score >= float(min_score):
+            out.append({**row, "score": round(score, 4)})
+    out.sort(key=lambda r: r.get("score", 0.0), reverse=True)
+    return out[: max(1, int(limit))]
+
+
+def export_tm_payload(store: List[Dict[str, str]]) -> Dict[str, Any]:
+    return {"schema": SCHEMA, "entries": list(store or [])}
+
+
+def import_tm_payload(payload: Dict[str, Any]) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    for row in (payload.get("entries") or []):
+        add_tm_entry(out, str((row or {}).get("source", "") or ""), str((row or {}).get("target", "") or ""), page=str((row or {}).get("page", "") or ""), block_id=str((row or {}).get("block_id", "") or ""))
+    return out

--- a/utils/translation_qa_profiles.py
+++ b/utils/translation_qa_profiles.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from utils.translation_review import check_translation_guardrails
+
+PROMPT_PROFILES: Dict[str, Dict[str, Any]] = {
+    "dialogue": {"max_len_ratio": 1.7, "allow_same_text": False},
+    "narration": {"max_len_ratio": 2.2, "allow_same_text": False},
+    "sfx": {"max_len_ratio": 1.3, "allow_same_text": True},
+    "signboard": {"max_len_ratio": 1.9, "allow_same_text": True},
+    "system": {"max_len_ratio": 2.0, "allow_same_text": False},
+}
+
+
+def resolve_prompt_profile(name: str) -> Dict[str, Any]:
+    key = (name or "dialogue").strip().lower()
+    return PROMPT_PROFILES.get(key, PROMPT_PROFILES["dialogue"])
+
+
+def build_translation_qa_report(
+    blocks: List[Any],
+    glossary: List[Dict[str, str]] | None,
+    *,
+    profile: str = "dialogue",
+    retry_issue_threshold: int = 2,
+) -> Dict[str, Any]:
+    cfg = resolve_prompt_profile(profile)
+    rows: List[Dict[str, Any]] = []
+    retry_candidates: List[int] = []
+    for idx, b in enumerate(blocks or []):
+        src = (getattr(b, "text", "") or getattr(b, "get_text", lambda: "")() or "").strip()
+        tgt = (getattr(b, "translation", "") or "").strip()
+        issues = check_translation_guardrails(src, tgt, glossary=glossary or [], max_len_ratio=float(cfg["max_len_ratio"]))
+        if cfg.get("allow_same_text", False):
+            issues = [x for x in issues if "Untranslated source carry-over" not in x]
+        if len(issues) >= int(retry_issue_threshold):
+            retry_candidates.append(idx)
+        rows.append({"index": idx, "source": src, "translation": tgt, "issues": issues, "issue_count": len(issues)})
+    return {
+        "profile": profile,
+        "rows": rows,
+        "total_blocks": len(rows),
+        "issue_blocks": sum(1 for r in rows if r["issue_count"] > 0),
+        "retry_candidates": retry_candidates,
+    }

--- a/utils/xliff_interchange.py
+++ b/utils/xliff_interchange.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Dict, Any, List, Tuple
+import xml.etree.ElementTree as ET
+
+
+SCHEMA = "ballonstranslator.xliff.v1"
+
+
+def export_project_xliff(project) -> str:
+    root = ET.Element("xliff", {"version": "1.2", "bt_schema": SCHEMA})
+    for page_name, blks in (getattr(project, "pages", {}) or {}).items():
+        file_el = ET.SubElement(root, "file", {"original": str(page_name), "source-language": "auto", "target-language": "auto", "datatype": "plaintext"})
+        body = ET.SubElement(file_el, "body")
+        for idx, blk in enumerate(blks or []):
+            trans_id = f"{page_name}::{idx}"
+            unit = ET.SubElement(body, "trans-unit", {"id": trans_id, "resname": str(idx)})
+            ET.SubElement(unit, "source").text = (getattr(blk, "get_text", lambda: "")() or "")
+            ET.SubElement(unit, "target").text = (getattr(blk, "translation", "") or "")
+    return ET.tostring(root, encoding="unicode")
+
+
+def import_project_xliff(project, xml_text: str) -> Tuple[bool, Dict[str, Any]]:
+    root = ET.fromstring(xml_text)
+    pages = getattr(project, "pages", {}) or {}
+    matched_pages: List[str] = []
+    missing_pages: List[str] = []
+    unmatched_pages: List[str] = []
+
+    for file_el in root.findall("file"):
+        page = str(file_el.attrib.get("original", "") or "")
+        if page not in pages:
+            missing_pages.append(page)
+            continue
+        matched_pages.append(page)
+        units = file_el.findall("./body/trans-unit")
+        blk_list = pages.get(page, []) or []
+        if len(units) != len(blk_list):
+            unmatched_pages.append(page)
+        for i, unit in enumerate(units[: len(blk_list)]):
+            tgt = unit.findtext("target", default="") or ""
+            blk_list[i].translation = str(tgt)
+
+    all_matched = not missing_pages and not unmatched_pages
+    return all_matched, {
+        "matched_pages": set(matched_pages),
+        "missing_pages": missing_pages,
+        "unmatched_pages": unmatched_pages,
+        "unexpected_pages": [],
+    }


### PR DESCRIPTION
### Motivation

- Harden the local automation API contract and MCP-friendly surface to enable stable headless and external workflows. 
- Provide a deterministic headless CLI contract (exit codes and optional summary JSON) and better job lifecycle/status reporting for automation. 
- Add import/export interchange (XLIFF/JSON/CSV), translation memory, QA profiles, batch find/replace, and provider/keyring onboarding to support CAT-tool and secure provider workflows. 

### Description

- Documentation: updated `docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md` and `docs/LOCAL_AUTOMATION_API.md` with route discovery payload, job/status semantics, scene-edit payloads, headless exit codes, credential migration notes, provider connection checks, and interchange/TM/QA endpoints. 
- Headless & CLI: added `utils/headless_contract.py`, updated `scripts/batch_translate.py` to return stable exit codes and optional `--summary-json` output. 
- Automation/job & API: new `utils/automation_jobs.py` for canonical job objects and status payloads, integrated into `ui/mainwindow.py` job start/status/logs/result handlers and `/job_logs` offset support. 
- Scene edits: extended `utils/api_edit_ops.py` to accept `block_id` stable targeting, added stable-id helpers and block-description helpers; `ui/mainwindow.py` now supports index-or-block_id edits with detailed per-op error payloads and strict/lenient batch behavior. 
- Interchange & TM: new utils `xliff_interchange.py`, `translation_json_interchange.py`, `translation_csv_interchange.py`, `translation_memory.py`, and `translation_qa_profiles.py` with UI and API hooks added to `ui/mainwindow.py` and menu triggers in `ui/mainwindowbars.py`; `ProjImgTrans` now persists `translation_memory`. 
- Batch find/replace: new `utils/batch_find_replace.py` plus UI action and API preview/apply routes. 
- Provider/keyring: new `utils/provider_setup.py` and `utils/secret_migration.py`, integrated keyring-aware credential handling into `utils/config.py` and the layout-review provider dialog in `ui/mainwindow.py` with test-connection button and endpoint presets, and `utils/credential_store` usage for secret read/write. 
- Misc: multiple UI wiring changes to expose the new API endpoints and export/import dialogs, and minor rework of export routing to accept `kind` values for new formats. 

### Testing

- Added and ran unit tests under `tests/` covering new features: `test_api_edit_ops.py`, `test_automation_jobs.py`, `test_batch_find_replace.py`, `test_headless_contract.py`, `test_local_automation_api_routes_contract.py`, `test_provider_setup.py`, `test_secret_migration.py`, `test_translation_csv_interchange.py`, `test_translation_json_interchange.py`, `test_translation_memory.py`, `test_translation_qa_profiles.py`, and `test_xliff_interchange.py`. 
- Executed the test suite with `pytest` against the modified modules and all new tests passed. 
- Manual smoke checks: invoked headless `scripts/batch_translate.py` to verify exit-code behavior and summary JSON emission and exercised basic API routes via the updated `/routes`, `/health`, and job endpoints (no regressions observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0bb6ce6750832c82c0466eddc8e9d8)