### PR TITLE
Add automation API/server-mode, headless batch stages, concordance/glossary, cleanup-only workflow, and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ python --version
 - LLM-aided review chain for quality/consistency
 - Strong defaults for fast onboarding
 - Local automation/API documentation for headless and MCP-style workflows (see [Local Automation API](docs/LOCAL_AUTOMATION_API.md))
+- Docker/server-mode quickstart plus sample curl/Python client snippets are included in the same document.
 
 ---
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -93,6 +93,7 @@ python --version
 - 基于 LLM 的审校链（质量/一致性）
 - 默认配置更友好，上手更快
 - 提供本地自动化/API 文档，便于无头模式与 MCP 风格工作流（见 [Local Automation API](docs/LOCAL_AUTOMATION_API.md)）
+- Docker/服务器模式快速说明与示例 curl/Python 客户端也在同一文档中。
 
 ---
 

--- a/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
+++ b/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Alternatives Feature Gap Implementation Plan
 
-Last updated: 2026-05-19
+Last updated: 2026-05-19 (Phase 0 baseline audit pass 2)
 
 This document is the safety baseline for closing gaps versus manga-image-translator, Koharu, ImageTrans, manga-translator-ui, and focused cleanup tools. The rule for every phase is: audit first, extend existing Pro systems, do not duplicate equivalent functionality, and do not remove existing Pro behavior.
 
@@ -27,6 +27,19 @@ Every implementation PR in this roadmap must verify:
 | Project save-state behavior | Partially implemented | `ui/mainwindow.py` API edit path marks save state; project tests exist | `utils/proj_imgtrans.py`, `ui/mainwindow.py` | Medium; project JSON compatibility is critical | Save/load with new fields absent/present; undoable API edits |
 | Startup entrypoints | Already implemented; untouched in this PR | `launch.py`, Windows batch files | Same | High if touched | Compile/argument smoke, Windows script snapshot |
 | First-run model picker | Already implemented; untouched in this PR | model picker tests and startup translations | `ui/model_manager_dialog.py`, `launch.py`, `translate/startup_model_ui.*.json` | High if touched | Existing model package selector/defaulting tests |
+
+
+## Phase 0 verification run (this pass)
+
+Commands executed for baseline verification:
+
+- `pytest -q tests/test_local_automation_api.py tests/test_local_automation_api_routes_contract.py tests/test_lettering_proof_export.py tests/test_export_manifest.py tests/test_project_ops_protocol.py tests/test_model_package_selector_dialog.py`
+
+Observed results:
+
+- Route discovery, proof-pack/export manifest, and project-ops protocol tests pass.
+- Model picker dialog tests currently fail in this environment because the qtpy widget stub used by the tests does not expose `QComboBox` during import (`ui/model_package_selector_dialog.py`).
+- No startup scripts or first-run behavior code was changed in this pass; failures are documented for follow-up in the next Phase 0/1 slice.
 
 ## Phase 1 — Automation, headless, and MCP parity
 
@@ -61,8 +74,8 @@ Every implementation PR in this roadmap must verify:
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
 | Translation memory | Partially implemented → advanced | Added project TM store + fuzzy query + import/export API paths/tests (JSON) | `utils/translation_memory.py`, `utils/proj_imgtrans.py`, `ui/mainwindow.py` | Medium | fuzzy match tests, TM import/export tests, save/load compatibility tests |
-| Termbase/glossary | Partially implemented | `modules/llm_quality.py` glossary enforcement | glossary store/dialog/API | Medium | hard/soft violations, no destructive replacement |
-| Corpus concordance | Not implemented | Search widgets exist but not CAT concordance | corpus index/search utilities | Low/medium | provenance search |
+| Termbase/glossary | Partially implemented → advanced | Added glossary CSV import/export helpers and API endpoints with merge/replace mode | `utils/glossary_io.py`, `ui/mainwindow.py` | Medium | CSV roundtrip tests, merge/replace behavior tests |
+| Corpus concordance | Partially implemented → advanced | Added project concordance query utility + API/UI surface with page provenance output | `utils/translation_concordance.py`, `ui/mainwindow.py`, `ui/mainwindowbars.py` | Low/medium | provenance query tests + API tests |
 | SFX dictionary | Not implemented | style/prompt concepts exist | SFX dictionary data/UI | Low | lookup/import/export |
 | Auto glossary extraction | Not implemented | LLM quality utilities can be extended | extraction utility + approval UI | Medium | candidate categories, approval persistence |
 | Post-translation QA/retry | Partially implemented → advanced | Added profile-aware QA report + retry candidate API (`translation_qa_report`) | `utils/translation_qa_profiles.py`, `ui/mainwindow.py` | Medium | threshold/retry tests, profile behavior tests |
@@ -72,11 +85,11 @@ Every implementation PR in this roadmap must verify:
 
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
-| OCR crop inspector | Partially implemented | `ui/ocr_crop_inspector_widget.py` and pipeline button exist | inspector rerun hooks | Medium | crop extraction/rerun metadata |
-| Hybrid OCR workflow | Not implemented | multiple OCR engines exist | OCR compare utility/UI/API | Medium | primary/secondary compare |
+| OCR crop inspector | Partially implemented → advanced | Added per-block crop inspector rerun flow (engine selectable) in UI + API (`ocr_rerun_block`) | `ui/ocr_crop_inspector_widget.py`, `ui/mainwindow.py` | Medium | rerun metadata + index validation tests |
+| Hybrid OCR workflow | Partially implemented → advanced | Added per-block OCR compare + apply flow (primary/secondary engine) in inspector UI and automation API | `ui/ocr_crop_inspector_widget.py`, `ui/mainwindow.py` | Medium | compare/apply API tests + persistence checks |
 | Reading-order editor | Partially implemented | `ui/reading_order_editor_dialog.py` exists | persistence/export integration | Medium | reorder persistence, structured export order |
 | Batch find/replace | Partially implemented → advanced | Added preview/apply batch find-replace API + project UI action with confirmation | `utils/batch_find_replace.py`, `ui/mainwindow.py`, `ui/mainwindowbars.py` | Medium | regex preview/apply tests, undo-path tests |
-| Import translated image workflow | Not implemented | OCR/project utilities exist | alignment utility/UI/API | High | IoU/order matching tests |
+| Import translated image workflow | Partially implemented → advanced | Added translated-image IoU alignment utility and local API route (`import_translated_image_align`) to map OCR text back to raw blocks | `utils/translated_image_alignment.py`, `ui/mainwindow.py` | High | IoU alignment unit tests + API integration tests |
 
 ## Phase 6 — Advanced renderer fidelity
 
@@ -85,7 +98,7 @@ Every implementation PR in this roadmap must verify:
 | Renderer stack audit | Partially implemented | rendering docs/tests exist | text rendering docs and diagnostics | Low | doc + fixture review |
 | Optional shaping backend | Not implemented fully | Qt rendering and text rendering utilities exist | optional uharfbuzz/freetype path | High; packaging/Windows risk | optional dependency skip tests |
 | Keep Qt default | Already required | current renderer is Qt-based | config/render settings | Low | default config compatibility |
-| Diagnostics | Partially implemented | rendering QA tests exist | renderer diagnostics/export manifests | Medium | missing glyph/clipping/shaping fallback |
+| Diagnostics | Partially implemented → advanced | Added renderer capability diagnostics route + export manifest renderer metadata | `utils/renderer_diagnostics.py`, `ui/mainwindow.py`, `utils/export_manifest.py` | Medium | diagnostics shape tests + manifest renderer metadata tests |
 | Visual regression tests | Partially implemented | text rendering tests exist | deterministic fixtures | Medium | image snapshots/tolerances |
 
 ## Phase 7 — Cleanup, segmentation, and mask quality
@@ -95,16 +108,16 @@ Every implementation PR in this roadmap must verify:
 | Bubble-aware mask expansion | Partially implemented | mask diagnostics/textbox masking tests | mask generation utilities | Medium | inside/outside dilation fixtures |
 | Edge-halo detector | Partially implemented | `tests/test_mask_diagnostics.py` | diagnostics utility/UI/API | Medium | halo fixtures |
 | Mask-aware text flow | Partially implemented | auto layout/mask-safe diagnostics | text layout/rendering utilities | High | irregular flow fallback tests |
-| Cleanup-only workflow | Partially implemented | inpaint/export modules; no stable CLI/API contract yet | API/headless/export | Medium | cleanup-only CLI/API path |
+| Cleanup-only workflow | Partially implemented → advanced | Added stable cleanup-only API route (`cleanup_only`) that runs detect+inpaint and optional clean export directory output | `utils/cleanup_only_workflow.py`, `ui/mainwindow.py` | Medium | cleanup-only workflow tests + route validation |
 
 ## Phase 8 — Batch, archive, and packaging parity
 
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
-| Parent/child CBZ/folder processing | Partially implemented | `utils/zip_batch.py`, batch queue UI, headless dirs | batch queue/headless API | Medium | parent/child queue, resume state |
+| Parent/child CBZ/folder processing | Partially implemented → advanced | Added parent-batch enumerate/save-state API for nested dirs + CBZ/ZIP child discovery and resumable status JSON | `utils/batch_parent_queue.py`, `ui/mainwindow.py` | Medium | parent/child enumerate + state persistence tests + status update/next-pending tests |
 | Streaming ZIP/CBZ export | Partially implemented | API archive export exists; manifests exist | export utilities/job progress | Medium | progress/cancel/manifest |
-| Docker/web/API mode docs | Not implemented fully | local API exists | docs, sample client | Low | docs smoke snippets |
-| Data path manager | Partially implemented | `tests/test_data_path_manager.py` | config/UI migration helper | Medium | free-space and migration tests |
+| Docker/web/API mode docs | Partially implemented → advanced | Added `server_mode_info` API route and docs quickstart with curl/Python snippets and mount hints | `utils/server_mode_info.py`, `ui/mainwindow.py`, `docs/LOCAL_AUTOMATION_API.md`, `README.md`, `README_zh_CN.md` | Low | server-mode info shape tests + docs smoke snippets |
+| Data path manager | Partially implemented → advanced | Added automation API routes for path status/free-space checks and dry-run/apply migration helper | `utils/data_path_manager.py`, `ui/mainwindow.py` | Medium | migration dry-run/apply tests + status threshold tests |
 
 ## Immediate implementation order
 

--- a/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
+++ b/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
@@ -106,7 +106,7 @@ Observed results:
 | Required feature | Status | Existing evidence | Target files | Migration risk | Tests to add/keep |
 |---|---|---|---|---|---|
 | Bubble-aware mask expansion | Partially implemented | mask diagnostics/textbox masking tests | mask generation utilities | Medium | inside/outside dilation fixtures |
-| Edge-halo detector | Partially implemented | `tests/test_mask_diagnostics.py` | diagnostics utility/UI/API | Medium | halo fixtures |
+| Edge-halo detector | Partially implemented → advanced | Cleanup-only workflow now computes mask edge-halo ratio, applies adaptive mask expansion/merge policy, and flags risky pages via API warnings/metadata | `modules/mask_diagnostics.py`, `utils/cleanup_only_workflow.py`, `ui/mainwindow.py` | Medium | halo-threshold cleanup workflow tests |
 | Mask-aware text flow | Partially implemented | auto layout/mask-safe diagnostics | text layout/rendering utilities | High | irregular flow fallback tests |
 | Cleanup-only workflow | Partially implemented → advanced | Added stable cleanup-only API route (`cleanup_only`) that runs detect+inpaint and optional clean export directory output | `utils/cleanup_only_workflow.py`, `ui/mainwindow.py` | Medium | cleanup-only workflow tests + route validation |
 

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -1,6 +1,6 @@
 # Feature Parity Matrix (Working Draft)
 
-Last updated: 2026-05-18
+Last updated: 2026-05-19
 
 This matrix tracks BallonsTranslator-Pro parity progress against major alternatives.
 
@@ -9,6 +9,7 @@ This matrix tracks BallonsTranslator-Pro parity progress against major alternati
 - **Phase 0 (Audit & safety baseline):** ✅ **in progress / mostly done baseline**
   - Audit plan documented in `docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md`.
   - Route discovery and export/proof/save-state tests are in place and being expanded.
+  - Baseline verification rerun on 2026-05-19; route/export/save-state suites passed, with a known model-picker test import stub failure documented for follow-up.
 - **Phase 1 (Automation/headless/MCP):** 🟨 **actively in progress**
   - Added typed edit-op validation and batch scene-edit surface.
   - Added job lifecycle routes (`job_start/status/cancel/logs/result/list`).

--- a/docs/LOCAL_AUTOMATION_API.md
+++ b/docs/LOCAL_AUTOMATION_API.md
@@ -8,7 +8,7 @@ BallonsTranslator-Pro exposes a localhost-only automation API when `automation_a
 
 - `GET /health` returns service status plus the same route catalog as `/routes`.
 - `GET /routes` returns stable sorted POST routes, GET routes, MCP-compatible command routes, job routes, and the SSE event-stream template.
-- `GET /events?job_id=<job_id>` returns a Server-Sent Events snapshot for a job. The current implementation sends a bounded status/log snapshot; future work can extend this to a live streaming loop without changing the endpoint.
+- `GET /events?job_id=<job_id>` returns a Server-Sent Events snapshot for a job. Events now include SSE `id` (job `updated_at`) and `event` (current job status such as `running` / `succeeded` / `failed` / `cancelled`) plus a bounded status/log snapshot payload; this keeps clients forward-compatible with future live streaming loops.
 
 If `automation_api_key` is set, send it as `X-API-Key` for every request, including discovery and events.
 
@@ -110,6 +110,20 @@ Notes:
 
 ## Headless batch CLI contract
 
+The `scripts/batch_translate.py` runner now exposes an explicit stage selector for automation callers:
+
+- `--stages detect,ocr,translate,inpaint` to run only a stable subset of stages.
+- `--save-text-json <path|dir>` exports translation JSON after processing.
+- `--load-text-json <path>` imports translation JSON before processing each project.
+- Empty `--stages` keeps default behavior (all enabled pipeline stages from config, subject to `--no-*` flags).
+- Invalid stage names fail fast with `HeadlessExitCode.INPUT_ERROR`.
+
+Summary JSON payloads include:
+
+- `stages`: normalized sorted stage list requested by the caller.
+- `warnings`: non-fatal contract warnings (for example, when no stages remain enabled after config + flag filtering).
+
+
 For non-GUI runs, `scripts/batch_translate.py` now returns stable non-zero exit codes:
 
 - `0`: success
@@ -204,3 +218,65 @@ Phase 5 editor UX now includes previewable batch find/replace routes:
 - `POST /batch_find_replace_apply` with either the same fields or a prior `preview` payload
 
 `preview` returns match samples without mutating the project; `apply` mutates translations and returns changed rows.
+
+
+## Concordance and glossary API
+
+- `POST /concordance_query` with `{query, in_target=true, limit=50}` returns project-wide source/target matches with `page`, `index`, and `block_id` provenance.
+- `POST /glossary_export` with optional `{format: "json"|"csv", path}` exports project glossary.
+- `POST /glossary_import_preview` with `{path, mode: "merge"|"replace"}` returns non-destructive preview counts (`added/skipped/result`).
+- `POST /glossary_import` with `{path, mode: "merge"|"replace"}` imports glossary entries from JSON or CSV.
+
+
+## OCR crop inspector API
+
+- `POST /ocr_rerun_block` with `{page?, index, engine?}` reruns OCR on one textbox only and returns updated OCR text, confidence, and selected engine.
+
+- `POST /ocr_compare_block` with `{page?, index, secondary_engine}` compares current OCR text against a secondary OCR engine for one block (non-destructive).
+- `POST /ocr_apply_compare_choice` with `{page?, index, text, engine?}` applies a chosen OCR text to one block.
+
+- `POST /renderer_diagnostics` returns renderer backend capability diagnostics (Qt default renderer, optional shaping modules, warnings).
+
+
+## Cleanup-only workflow API
+
+- `POST /cleanup_only` with optional `{pages, out_dir}` runs detect + inpaint only (no OCR/translation) and optionally exports clean images.
+
+
+## Parent/child batch planning API
+
+- `POST /batch_parent_enumerate` with `{parent_path}` discovers child projects from nested image folders and `.cbz`/`.zip` archives.
+- `POST /batch_parent_save_state` with `{parent_path, state_path, statuses?}` writes resumable parent-batch state JSON (`pending/done/failed/...`).
+- `POST /batch_parent_load_state` with `{state_path}` loads saved parent-batch state payload.
+- `POST /batch_parent_update_status` with `{state_path, input_path, status}` updates one child status.
+- `POST /batch_parent_next_pending` with `{state_path}` returns next pending child item.
+
+
+## Data path manager API
+
+- `POST /data_path_status` with optional `{path, min_free_gb}` returns resolved path, existence, free space, and threshold check.
+- `POST /data_path_migrate` with `{source, dest, dry_run=true}` previews or performs data-path migration for top-level entries.
+
+
+## Docker / server mode quickstart
+
+For headless/API usage, run Pro with automation API enabled and query the helper route:
+
+- `POST /server_mode_info` returns health/routes URLs, path hints, Docker mount hints, and ready-to-run curl/Python snippets.
+
+Example curl:
+
+```bash
+curl -X POST http://127.0.0.1:39542/server_mode_info -H 'Content-Type: application/json' -d '{}'
+```
+
+Typical container mount hints from the payload:
+
+- `/app/data/models` for model/cache volume
+- `/app/projects` for project input/output volume
+- `/app/config/config.json` for persisted configuration
+
+
+## Import translated image alignment API
+
+- `POST /import_translated_image_align` with `{page, translated_image, min_iou?}` detects/OCRs the translated image and maps translations back to raw blocks by IoU.

--- a/scripts/batch_translate.py
+++ b/scripts/batch_translate.py
@@ -36,6 +36,7 @@ from utils.proj_imgtrans import ProjImgTrans
 from utils.textblock import examine_textblk, remove_contained_boxes, deduplicate_primary_boxes
 from utils.logger import logger as LOGGER
 from utils.headless_contract import HeadlessExitCode, HeadlessRunSummary
+from utils.headless_batch_contract import parse_stage_set
 from modules import (
     init_module_registries,
     TEXTDETECTORS,
@@ -49,6 +50,7 @@ from modules import (
 )
 from modules.base import GPUINTENSIVE_SET, soft_empty_cache
 from modules.inpaint.base import build_mask_with_resolved_overlaps
+from utils.translation_json_interchange import export_translation_json, import_translation_json
 
 try:
     from utils.image_upscale import apply_initial_upscale, downscale_to_size
@@ -56,6 +58,8 @@ except ImportError:
     apply_initial_upscale = None
     def downscale_to_size(img, w, h):
         return img
+
+
 
 def _get_module(module_type: str, name: str):
     if module_type == "textdetector":
@@ -198,6 +202,9 @@ def main() -> int:
     parser.add_argument("--no-inpaint", action="store_true", help="Skip inpainting.")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose logging.")
     parser.add_argument("--summary-json", default="", help="Write headless run summary JSON to this path.")
+    parser.add_argument("--save-text-json", default="", help="Export translation JSON after run. Path or directory.")
+    parser.add_argument("--load-text-json", default="", help="Import translation JSON before run.")
+    parser.add_argument("--stages", default="", help="Comma-separated stages to run: detect,ocr,translate,inpaint. Empty=all enabled by config.")
     args = parser.parse_args()
 
     dirs = list(args.dirs) + list(args.dirs_opt or [])
@@ -215,11 +222,17 @@ def main() -> int:
     load_config(args.config)
     init_module_registries()
 
+    try:
+        selected_stages = parse_stage_set(args.stages)
+    except ValueError as e:
+        LOGGER.error(str(e))
+        return int(HeadlessExitCode.INPUT_ERROR)
+
     cfg = pcfg.module
-    enable_detect = cfg.enable_detect and not args.no_detect
-    enable_ocr = cfg.enable_ocr and not args.no_ocr
-    enable_translate = cfg.enable_translate and not args.no_translate
-    enable_inpaint = cfg.enable_inpaint and not args.no_inpaint
+    enable_detect = cfg.enable_detect and not args.no_detect and "detect" in selected_stages
+    enable_ocr = cfg.enable_ocr and not args.no_ocr and "ocr" in selected_stages
+    enable_translate = cfg.enable_translate and not args.no_translate and "translate" in selected_stages
+    enable_inpaint = cfg.enable_inpaint and not args.no_inpaint and "inpaint" in selected_stages
 
     detector = _get_module("textdetector", cfg.textdetector) if enable_detect else None
     ocr = _get_module("ocr", cfg.ocr) if enable_ocr else None
@@ -241,6 +254,11 @@ def main() -> int:
         LOGGER.info("Processing project: %s", d)
         try:
             proj = ProjImgTrans(d)
+            if args.load_text_json:
+                with open(osp.abspath(args.load_text_json), "r", encoding="utf-8") as f:
+                    payload = json.load(f)
+                import_translation_json(proj, payload if isinstance(payload, dict) else {})
+                proj.save()
             run_batch_pipeline(
                 proj,
                 detector=detector,
@@ -252,18 +270,37 @@ def main() -> int:
                 enable_translate=enable_translate,
                 enable_inpaint=enable_inpaint,
             )
+            if args.save_text_json:
+                out_target = osp.abspath(args.save_text_json)
+                if osp.isdir(out_target) or out_target.endswith(osp.sep):
+                    os.makedirs(out_target, exist_ok=True)
+                    out_path = osp.join(out_target, f"{osp.basename(d.rstrip(osp.sep))}.translation.json")
+                elif len(dirs) > 1 and out_target.lower().endswith(".json"):
+                    os.makedirs(osp.dirname(out_target) or ".", exist_ok=True)
+                    stem = osp.splitext(osp.basename(out_target))[0]
+                    out_path = osp.join(osp.dirname(out_target), f"{stem}.{osp.basename(d.rstrip(osp.sep))}.json")
+                else:
+                    os.makedirs(osp.dirname(out_target) or ".", exist_ok=True)
+                    out_path = out_target
+                with open(out_path, "w", encoding="utf-8") as f:
+                    json.dump(export_translation_json(proj), f, ensure_ascii=False, indent=2)
             processed.append(d)
         except Exception as e:
             LOGGER.error("Project failed: %s (%s)", d, e, exc_info=True)
             failed.append(d)
 
+    warnings = []
+    if not any((enable_detect, enable_ocr, enable_translate, enable_inpaint)):
+        warnings.append("No stages enabled after config/flags filtering.")
     summary = HeadlessRunSummary(
         requested_dirs=[osp.abspath(x) for x in dirs],
         processed_dirs=processed,
         skipped_dirs=skipped,
         failed_dirs=failed,
+        warnings=warnings,
     )
     payload = summary.to_payload()
+    payload["stages"] = sorted(selected_stages)
     payload["exit_code"] = summary.exit_code()
     LOGGER.info("Headless summary: %s", payload)
     if args.summary_json:

--- a/tests/test_automation_jobs.py
+++ b/tests/test_automation_jobs.py
@@ -1,4 +1,4 @@
-from utils.automation_jobs import new_job, checkpoint_or_cancel, set_status, status_payload, append_log
+from utils.automation_jobs import new_job, checkpoint_or_cancel, set_status, status_payload, append_log, update_from_task_result
 
 
 def test_job_lifecycle_progress_and_status_payload():
@@ -25,3 +25,11 @@ def test_append_log_respects_limit():
         append_log(job, f'line-{i}', limit=3)
     assert len(job['logs']) == 3
     assert job['logs'][0] == 'line-7'
+
+
+def test_update_from_task_result_captures_warnings_and_progress():
+    job = new_job('job_4', 'export')
+    update_from_task_result(job, {'warnings': ['missing font'], 'stage': 'exporting', 'progress': 0.7})
+    assert job['warnings'] == ['missing font']
+    assert job['stage'] == 'exporting'
+    assert abs(job['progress'] - 0.7) < 1e-9

--- a/tests/test_batch_parent_queue.py
+++ b/tests/test_batch_parent_queue.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child
+
+
+def test_enumerate_child_projects_collects_dirs_and_archives(tmp_path: Path):
+    root = tmp_path / 'root'
+    (root / 'ch1').mkdir(parents=True)
+    (root / 'ch1' / '001.png').write_bytes(b'x')
+    (root / 'pack.cbz').write_bytes(b'zip')
+    children = enumerate_child_projects(str(root))
+    kinds = sorted([c.kind for c in children])
+    assert 'dir' in kinds
+    assert 'cbz' in kinds
+
+
+def test_save_parent_batch_state_writes_statuses(tmp_path: Path):
+    root = tmp_path / 'root'
+    root.mkdir()
+    child = enumerate_child_projects(str(root))
+    if not child:
+        from utils.batch_parent_queue import BatchChildProject
+        child = [BatchChildProject(kind='dir', input_path=str(root), display_name='.')]
+    state = save_parent_batch_state(str(tmp_path / 'state.json'), str(root), child, statuses={child[0].input_path: 'done'})
+    assert state['children'][0]['status'] == 'done'
+
+
+def test_parent_state_load_update_and_next_pending(tmp_path: Path):
+    root = tmp_path / 'root'
+    (root / 'ch1').mkdir(parents=True)
+    (root / 'ch1' / '001.png').write_bytes(b'x')
+    children = enumerate_child_projects(str(root))
+    state_path = tmp_path / 'state.json'
+    save_parent_batch_state(str(state_path), str(root), children)
+    loaded = load_parent_batch_state(str(state_path))
+    assert loaded['format'].endswith('v1')
+    first = loaded['children'][0]['input_path']
+    update_parent_batch_status(str(state_path), first, 'done')
+    loaded2 = load_parent_batch_state(str(state_path))
+    nxt = next_pending_child(loaded2)
+    if len(loaded2['children']) == 1:
+        assert nxt is None
+    else:
+        assert nxt is not None

--- a/tests/test_cleanup_only_workflow.py
+++ b/tests/test_cleanup_only_workflow.py
@@ -32,7 +32,13 @@ class P:
 
 def test_cleanup_only_exports_clean_images(tmp_path):
     proj = P(tmp_path)
-    rst = run_cleanup_only_pages(proj, D(), I(), ['001.png'], out_dir=str(tmp_path / 'out'))
+    rst = run_cleanup_only_pages(proj, D(), I(), ['001.png'], out_dir=str(tmp_path / 'out'), inside_radius=1, outside_radius=2, detector_confidence=0.9)
     assert rst['processed'] == 1
     assert rst['failed'] == 0
     assert (tmp_path / 'out' / '001_clean.png').exists()
+
+
+def test_cleanup_only_returns_mask_policy(tmp_path):
+    proj = P(tmp_path)
+    rst = run_cleanup_only_pages(proj, D(), I(), ['001.png'], out_dir=str(tmp_path / 'out2'))
+    assert rst['mask_policy']['outside_radius'] >= rst['mask_policy']['inside_radius']

--- a/tests/test_cleanup_only_workflow.py
+++ b/tests/test_cleanup_only_workflow.py
@@ -1,0 +1,38 @@
+import numpy as np
+from pathlib import Path
+
+from utils.cleanup_only_workflow import run_cleanup_only_pages
+
+
+class B:
+    def __init__(self):
+        self.xyxy = [1, 1, 4, 4]
+
+
+class D:
+    def detect(self, img, proj):
+        return None, [B()]
+
+
+class I:
+    def inpaint(self, img, mask):
+        out = img.copy()
+        out[1:4, 1:4] = 255
+        return out
+
+
+class P:
+    def __init__(self, tmp):
+        self.tmp = Path(tmp)
+    def read_img(self, page):
+        return np.zeros((8, 8, 3), dtype=np.uint8)
+    def save_inpainted(self, page, img):
+        return None
+
+
+def test_cleanup_only_exports_clean_images(tmp_path):
+    proj = P(tmp_path)
+    rst = run_cleanup_only_pages(proj, D(), I(), ['001.png'], out_dir=str(tmp_path / 'out'))
+    assert rst['processed'] == 1
+    assert rst['failed'] == 0
+    assert (tmp_path / 'out' / '001_clean.png').exists()

--- a/tests/test_data_path_manager.py
+++ b/tests/test_data_path_manager.py
@@ -1,4 +1,6 @@
-from utils.data_path_manager import resolve_data_path, free_space_gb
+from pathlib import Path
+
+from utils.data_path_manager import resolve_data_path, free_space_gb, describe_data_path, migrate_data_path
 
 
 def test_resolve_data_path_defaults_to_data():
@@ -8,3 +10,22 @@ def test_resolve_data_path_defaults_to_data():
 
 def test_free_space_gb_nonnegative(tmp_path):
     assert free_space_gb(str(tmp_path)) >= 0.0
+
+
+def test_describe_data_path_has_space_fields(tmp_path):
+    d = describe_data_path(str(tmp_path))
+    assert d['exists'] is True
+    assert d['free_gb'] >= 0.0
+
+
+def test_migrate_data_path_dry_run_and_apply(tmp_path: Path):
+    src = tmp_path / 'src'
+    dst = tmp_path / 'dst'
+    src.mkdir()
+    (src / 'a.txt').write_text('x', encoding='utf-8')
+    dry = migrate_data_path(str(src), str(dst), dry_run=True)
+    assert dry['ok'] is True
+    assert (src / 'a.txt').exists()
+    run = migrate_data_path(str(src), str(dst), dry_run=False)
+    assert run['ok'] is True
+    assert (dst / 'a.txt').exists()

--- a/tests/test_export_manifest.py
+++ b/tests/test_export_manifest.py
@@ -58,3 +58,13 @@ def test_export_manifest_records_unrendered_fallback_sources(tmp_path):
     assert manifest["pages"][0]["source_kind"] == "original_fallback"
     assert manifest["pages"][0]["used_fallback_source"] is True
     assert "fallback" in manifest["warnings"][0]
+
+
+def test_export_manifest_includes_renderer_info(tmp_path):
+    out = tmp_path / "out"
+    page = out / "001.png"
+    out.mkdir()
+    page.write_bytes(b"x")
+    project = Project()
+    manifest = write_export_manifest(project, str(out), [("p1.png", str(page))], [], options={"renderer": {"default_renderer": "qt", "advanced_backend_available": False}})
+    assert manifest["renderer"]["default_renderer"] == "qt"

--- a/tests/test_glossary_io.py
+++ b/tests/test_glossary_io.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from utils.glossary_io import export_glossary_csv, import_glossary_csv, preview_glossary_merge
+
+
+def test_glossary_csv_roundtrip(tmp_path: Path):
+    entries = [{'source': '宗门', 'target': 'Sect'}, {'source': '灵石', 'target': 'Spirit Stone'}]
+    out = tmp_path / 'glossary.csv'
+    count = export_glossary_csv(entries, str(out))
+    loaded = import_glossary_csv(str(out))
+    assert count == 2
+    assert loaded[0]['source'] == '宗门'
+    assert loaded[1]['target'] == 'Spirit Stone'
+
+
+def test_preview_glossary_merge_reports_add_and_skip():
+    existing = [{'source': '宗门', 'target': 'Sect'}]
+    incoming = [{'source': '宗门', 'target': 'SectX'}, {'source': '灵石', 'target': 'Spirit Stone'}]
+    p = preview_glossary_merge(existing, incoming, mode='merge')
+    assert p['added_count'] == 1
+    assert p['skipped_count'] == 1
+    assert p['result_count'] == 2

--- a/tests/test_headless_batch_contract.py
+++ b/tests/test_headless_batch_contract.py
@@ -1,0 +1,13 @@
+from utils.headless_batch_contract import parse_stage_set
+
+
+def test_parse_stage_set_defaults_all():
+    assert parse_stage_set("") == {"detect", "ocr", "translate", "inpaint"}
+
+
+def test_parse_stage_set_rejects_invalid_entries():
+    try:
+        parse_stage_set("detect,foo")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "invalid stage" in str(e)

--- a/tests/test_headless_contract.py
+++ b/tests/test_headless_contract.py
@@ -18,3 +18,9 @@ def test_headless_summary_payload_counts():
     assert payload['processed'] == 0
     assert payload['skipped'] == 1
     assert payload['failed'] == 1
+
+
+def test_headless_summary_payload_includes_warnings():
+    s = HeadlessRunSummary(requested_dirs=['a'], processed_dirs=['a'], skipped_dirs=[], failed_dirs=[], warnings=['w1'])
+    payload = s.to_payload()
+    assert payload['warnings'] == ['w1']

--- a/tests/test_local_automation_api.py
+++ b/tests/test_local_automation_api.py
@@ -103,6 +103,7 @@ def test_local_automation_api_event_stream_job_snapshot():
         content_type = resp.headers.get('Content-Type')
     server.stop()
     assert content_type == 'text/event-stream'
-    assert body.startswith('event: job\n')
+    assert 'event: running' in body
+    assert 'id: ' in body
     assert '"status": "running"' in body
     assert 'started' in body

--- a/tests/test_mask_cleanup_quality.py
+++ b/tests/test_mask_cleanup_quality.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from utils.mask_cleanup_quality import adaptive_mask_expand, merge_masks_with_confidence
+
+
+def test_adaptive_mask_expand_increases_coverage():
+    m = np.zeros((16, 16), dtype=np.uint8)
+    m[6:10, 6:10] = 255
+    out = adaptive_mask_expand(m, inside_radius=1, outside_radius=2)
+    assert out.sum() >= m.sum()
+
+
+def test_merge_masks_with_confidence_gates_secondary():
+    a = np.zeros((8, 8), dtype=np.uint8)
+    b = np.zeros((8, 8), dtype=np.uint8)
+    a[2:4, 2:4] = 255
+    b[4:6, 4:6] = 255
+    low = merge_masks_with_confidence(a, b, confidence=0.1)
+    high = merge_masks_with_confidence(a, b, confidence=0.9)
+    assert high.sum() > low.sum()

--- a/tests/test_renderer_diagnostics.py
+++ b/tests/test_renderer_diagnostics.py
@@ -1,0 +1,8 @@
+from utils.renderer_diagnostics import collect_renderer_diagnostics
+
+
+def test_renderer_diagnostics_shape():
+    d = collect_renderer_diagnostics()
+    assert d['default_renderer'] == 'qt'
+    assert 'optional_modules' in d
+    assert 'warnings' in d

--- a/tests/test_server_mode_info.py
+++ b/tests/test_server_mode_info.py
@@ -1,0 +1,8 @@
+from utils.server_mode_info import build_server_mode_info
+
+
+def test_server_mode_info_has_urls_and_paths():
+    d = build_server_mode_info(host='127.0.0.1', port=39542)
+    assert d['health_url'].endswith('/health')
+    assert d['routes_url'].endswith('/routes')
+    assert 'docker_mount_hints' in d

--- a/tests/test_translated_image_alignment.py
+++ b/tests/test_translated_image_alignment.py
@@ -1,0 +1,19 @@
+from utils.translated_image_alignment import align_translations_by_iou
+
+
+class B:
+    def __init__(self, xyxy, txt='', tr=''):
+        self.xyxy = xyxy
+        self._txt = txt
+        self.translation = tr
+    def get_text(self):
+        return self._txt
+
+
+def test_align_translations_by_iou_applies_best_match():
+    raw = [B([0,0,10,10], tr=''), B([20,20,30,30], tr='x')]
+    trn = [B([1,1,9,9], txt='hello'), B([21,21,29,29], txt='world')]
+    out = align_translations_by_iou(raw, trn, min_iou=0.2)
+    assert out['matched'] == 2
+    assert raw[0].translation == 'hello'
+    assert raw[1].translation == 'world'

--- a/tests/test_translation_concordance.py
+++ b/tests/test_translation_concordance.py
@@ -1,0 +1,28 @@
+from utils.translation_concordance import build_concordance_from_project, query_concordance
+
+
+class B:
+    def __init__(self, src, tgt, bid=''):
+        self._src = src
+        self.translation = tgt
+        self.api_block_id = bid
+    def get_text(self):
+        return self._src
+
+
+class P:
+    def __init__(self):
+        self.pages = {'001.png': [B('hello hero', '你好勇者', 'a1'), B('bye', '再见', 'a2')]}
+
+
+def test_build_concordance_rows_include_page_and_block_id():
+    rows = build_concordance_from_project(P())
+    assert len(rows) == 2
+    assert rows[0]['page'] == '001.png'
+    assert rows[0]['block_id'] == 'a1'
+
+
+def test_query_concordance_matches_source_and_target():
+    rows = build_concordance_from_project(P())
+    assert query_concordance(rows, 'hero')
+    assert query_concordance(rows, '勇者')

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -80,6 +80,14 @@ from utils.translation_json_interchange import export_translation_json, import_t
 from utils.translation_csv_interchange import export_translation_csv_text, import_translation_csv_text
 from utils.translation_memory import query_tm, add_tm_entry, build_tm_from_project, export_tm_payload, import_tm_payload
 from utils.translation_qa_profiles import build_translation_qa_report, PROMPT_PROFILES
+from utils.translation_concordance import build_concordance_from_project, query_concordance
+from utils.renderer_diagnostics import collect_renderer_diagnostics
+from utils.cleanup_only_workflow import run_cleanup_only_pages
+from utils.data_path_manager import describe_data_path, migrate_data_path
+from utils.server_mode_info import build_server_mode_info
+from utils.translated_image_alignment import align_translations_by_iou
+from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child
+from utils.glossary_io import export_glossary_csv, import_glossary_csv, preview_glossary_merge
 from utils.batch_find_replace import preview_batch_find_replace, apply_batch_find_replace
 from utils.layered_psd_export import build_layered_psd_handoff
 from utils.svg_text_export import build_svg_text_handoff
@@ -915,6 +923,24 @@ class MainWindow(mainwindow_cls):
             'tm_import': self._api_tm_import,
             'translation_qa_report': self._api_translation_qa_report,
             'translation_prompt_profiles': self._api_translation_prompt_profiles,
+            'concordance_query': self._api_concordance_query,
+            'glossary_export': self._api_glossary_export,
+            'glossary_import': self._api_glossary_import,
+            'glossary_import_preview': self._api_glossary_import_preview,
+            'ocr_rerun_block': self._api_ocr_rerun_block,
+            'ocr_compare_block': self._api_ocr_compare_block,
+            'ocr_apply_compare_choice': self._api_ocr_apply_compare_choice,
+            'renderer_diagnostics': self._api_renderer_diagnostics,
+            'cleanup_only': self._api_cleanup_only,
+            'batch_parent_enumerate': self._api_batch_parent_enumerate,
+            'batch_parent_save_state': self._api_batch_parent_save_state,
+            'batch_parent_load_state': self._api_batch_parent_load_state,
+            'batch_parent_update_status': self._api_batch_parent_update_status,
+            'batch_parent_next_pending': self._api_batch_parent_next_pending,
+            'data_path_status': self._api_data_path_status,
+            'data_path_migrate': self._api_data_path_migrate,
+            'server_mode_info': self._api_server_mode_info,
+            'import_translated_image_align': self._api_import_translated_image_align,
             'batch_find_replace_preview': self._api_batch_find_replace_preview,
             'batch_find_replace_apply': self._api_batch_find_replace_apply,
             'render_current_page': self._api_render_current_page,
@@ -992,8 +1018,7 @@ class MainWindow(mainwindow_cls):
                     set_status(j, 'cancelled', stage='cancelled:before_start', progress=0.0)
                     append_log(j, 'cancelled before start')
                     return
-                set_status(j, 'running', stage='starting', progress=0.02)
-                append_log(j, 'started')
+                mark_started(j, task)
             try:
                 with self._api_jobs_lock:
                     j = self._api_jobs.get(job_id)
@@ -1001,25 +1026,32 @@ class MainWindow(mainwindow_cls):
                         return
                     if checkpoint_or_cancel(j, 'dispatch', 0.08):
                         return
+                if checkpoint_or_cancel(j, 'task_dispatch', 0.12):
+                    return
                 if task == 'run_pipeline':
+                    set_status(j, 'running', stage='pipeline', progress=0.2)
                     rst = self._api_run_pipeline(payload)
                 elif task == 'render_page':
+                    set_status(j, 'running', stage='render_page', progress=0.35)
                     rst = self._api_render_current_page(payload)
                 elif task == 'export':
+                    set_status(j, 'running', stage='export', progress=0.45)
                     rst = self._api_export(payload)
                 elif task == 'batch_export':
+                    set_status(j, 'running', stage='batch_export', progress=0.45)
                     rst = self._api_batch_export(payload)
                 else:
+                    set_status(j, 'running', stage='proof_pack', progress=0.45)
                     rst = self._api_export_lettering_proof(payload)
                 with self._api_jobs_lock:
                     j = self._api_jobs.get(job_id)
                     if j is None:
                         return
+                    update_from_task_result(j, rst)
                     if j.get('cancel_requested'):
-                        set_status(j, 'cancelled', stage='cancelled:completed_with_cancel_request', progress=1.0)
+                        mark_finished(j, task, cancelled=True)
                     else:
-                        set_status(j, 'succeeded', stage='completed', progress=1.0)
-                    append_log(j, 'finished')
+                        mark_finished(j, task, cancelled=False)
                     j['result'] = rst
             except Exception as e:
                 with self._api_jobs_lock:
@@ -1136,6 +1168,160 @@ class MainWindow(mainwindow_cls):
             })
         return {'recent_projects': entries, 'count': len(entries)}
 
+
+    def _api_renderer_diagnostics(self, body: dict):
+        return self._api_call_ui(self._api_renderer_diagnostics_ui, body)
+
+    def _api_renderer_diagnostics_ui(self, body: dict):
+        return {'ok': True, **collect_renderer_diagnostics()}
+
+    def _api_cleanup_only(self, body: dict):
+        return self._api_call_ui(self._api_cleanup_only_ui, body)
+
+    def _api_cleanup_only_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        pages = list((body or {}).get('pages') or [])
+        if not pages:
+            pages = list(getattr(self.imgtrans_proj, 'pages', {}).keys())
+        out_dir = str((body or {}).get('out_dir', '') or '').strip()
+        detector = getattr(self.module_manager, 'textdetector', None)
+        inpainter = getattr(self.module_manager, 'inpainter', None)
+        if detector is None or inpainter is None:
+            raise ValueError('detector and inpainter must be loaded')
+        rst = run_cleanup_only_pages(self.imgtrans_proj, detector, inpainter, pages, out_dir=out_dir)
+        if rst.get('processed'):
+            self.canvas.setProjSaveState(True)
+        return {'ok': True, **rst}
+
+    def _api_batch_parent_enumerate(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_enumerate_ui, body)
+
+    def _api_batch_parent_enumerate_ui(self, body: dict):
+        parent_path = str((body or {}).get('parent_path', '') or '').strip()
+        if not parent_path:
+            raise ValueError('parent_path is required')
+        children = enumerate_child_projects(parent_path)
+        return {
+            'ok': True,
+            'parent_path': parent_path,
+            'count': len(children),
+            'children': [
+                {'kind': c.kind, 'input_path': c.input_path, 'display_name': c.display_name}
+                for c in children
+            ],
+        }
+
+    def _api_batch_parent_save_state(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_save_state_ui, body)
+
+    def _api_batch_parent_save_state_ui(self, body: dict):
+        parent_path = str((body or {}).get('parent_path', '') or '').strip()
+        state_path = str((body or {}).get('state_path', '') or '').strip()
+        if not parent_path or not state_path:
+            raise ValueError('parent_path and state_path are required')
+        children = enumerate_child_projects(parent_path)
+        statuses = dict((body or {}).get('statuses') or {})
+        payload = save_parent_batch_state(state_path, parent_path, children, statuses=statuses)
+        return {'ok': True, 'state_path': state_path, 'count': len(payload.get('children', [])), 'format': payload.get('format', '')}
+
+    def _api_data_path_status(self, body: dict):
+        return self._api_call_ui(self._api_data_path_status_ui, body)
+
+    def _api_data_path_status_ui(self, body: dict):
+        override_path = str((body or {}).get('path', '') or '')
+        min_free_gb = float((body or {}).get('min_free_gb', 0.0) or 0.0)
+        info = describe_data_path(override_path)
+        info['ok'] = True
+        info['enough_space'] = float(info.get('free_gb', 0.0)) >= min_free_gb
+        info['min_free_gb'] = min_free_gb
+        return info
+
+    def _api_data_path_migrate(self, body: dict):
+        return self._api_call_ui(self._api_data_path_migrate_ui, body)
+
+    def _api_data_path_migrate_ui(self, body: dict):
+        src = str((body or {}).get('source', '') or '')
+        dst = str((body or {}).get('dest', '') or '')
+        dry_run = bool((body or {}).get('dry_run', True))
+        if not src or not dst:
+            raise ValueError('source and dest are required')
+        rst = migrate_data_path(src, dst, dry_run=dry_run)
+        if not rst.get('ok'):
+            raise ValueError(str(rst.get('error', 'migrate_failed')))
+        rst['ok'] = True
+        return rst
+
+    def _api_batch_parent_load_state(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_load_state_ui, body)
+
+    def _api_batch_parent_load_state_ui(self, body: dict):
+        state_path = str((body or {}).get('state_path', '') or '').strip()
+        if not state_path:
+            raise ValueError('state_path is required')
+        payload = load_parent_batch_state(state_path)
+        return {'ok': True, 'state_path': state_path, 'state': payload}
+
+    def _api_batch_parent_update_status(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_update_status_ui, body)
+
+    def _api_batch_parent_update_status_ui(self, body: dict):
+        state_path = str((body or {}).get('state_path', '') or '').strip()
+        input_path = str((body or {}).get('input_path', '') or '').strip()
+        status = str((body or {}).get('status', '') or '').strip()
+        if not state_path or not input_path or not status:
+            raise ValueError('state_path, input_path, status are required')
+        payload = update_parent_batch_status(state_path, input_path, status)
+        return {'ok': True, 'state_path': state_path, 'updated': input_path, 'status': status, 'count': len(payload.get('children', []))}
+
+    def _api_batch_parent_next_pending(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_next_pending_ui, body)
+
+    def _api_batch_parent_next_pending_ui(self, body: dict):
+        state_path = str((body or {}).get('state_path', '') or '').strip()
+        if not state_path:
+            raise ValueError('state_path is required')
+        payload = load_parent_batch_state(state_path)
+        nxt = next_pending_child(payload)
+        return {'ok': True, 'state_path': state_path, 'next_pending': nxt, 'has_pending': nxt is not None}
+
+    def _api_server_mode_info(self, body: dict):
+        return self._api_call_ui(self._api_server_mode_info_ui, body)
+
+    def _api_server_mode_info_ui(self, body: dict):
+        host = '127.0.0.1'
+        port = int(getattr(pcfg, 'automation_api_port', 39542) or 39542)
+        return {'ok': True, **build_server_mode_info(host=host, port=port)}
+
+    def _api_import_translated_image_align(self, body: dict):
+        return self._api_call_ui(self._api_import_translated_image_align_ui, body)
+
+    def _api_import_translated_image_align_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        page = str((body or {}).get('page', '') or '').strip() or str(getattr(self.imgtrans_proj, 'current_img', '') or '')
+        translated_image = str((body or {}).get('translated_image', '') or '').strip()
+        min_iou = float((body or {}).get('min_iou', 0.2) or 0.2)
+        if not page or not translated_image:
+            raise ValueError('page and translated_image are required')
+        raw_blocks = self.imgtrans_proj.pages.get(page, []) or []
+        if not raw_blocks:
+            raise ValueError('no raw blocks for page')
+        if not osp.isfile(translated_image):
+            raise ValueError('translated image not found')
+        img_trans = imread(translated_image)
+        if img_trans is None:
+            raise ValueError('failed to read translated image')
+        detector = getattr(self.module_manager, 'textdetector', None)
+        ocr_runner = getattr(self.module_manager, 'ocr', None)
+        if detector is None or ocr_runner is None:
+            raise ValueError('detector and ocr must be loaded')
+        _mask, tr_blocks = detector.detect(img_trans, self.imgtrans_proj)
+        ocr_runner.run_ocr(img_trans, tr_blocks)
+        rst = align_translations_by_iou(raw_blocks, tr_blocks or [], min_iou=min_iou)
+        self.imgtrans_proj.pages[page] = raw_blocks
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'page': page, 'translated_image': translated_image, **rst}
 
     def _api_project_status(self, body: dict):
         return self._api_call_ui(self._api_project_status_ui, body)
@@ -1988,6 +2174,98 @@ class MainWindow(mainwindow_cls):
         return {'ok': True, 'entries': len(self.imgtrans_proj.translation_memory)}
 
 
+    def _api_concordance_query(self, body: dict):
+        return self._api_call_ui(self._api_concordance_query_ui, body)
+
+    def _api_concordance_query_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        query = str((body or {}).get('query', '') or '').strip()
+        if not query:
+            raise ValueError('query is required')
+        limit = int((body or {}).get('limit', 50) or 50)
+        in_target = bool((body or {}).get('in_target', True))
+        rows = build_concordance_from_project(self.imgtrans_proj)
+        hits = query_concordance(rows, query, in_target=in_target, limit=limit)
+        return {'ok': True, 'query': query, 'hits': hits, 'count': len(hits)}
+
+    def _api_glossary_export(self, body: dict):
+        return self._api_call_ui(self._api_glossary_export_ui, body)
+
+    def _api_glossary_export_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        fmt = str((body or {}).get('format', 'json') or 'json').strip().lower()
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            base = self.imgtrans_proj.directory
+            out_path = osp.join(base, 'translation_glossary.csv' if fmt == 'csv' else 'translation_glossary.json')
+        entries = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
+        if fmt == 'csv':
+            count = export_glossary_csv(entries, out_path)
+        else:
+            import json
+            with open(out_path, 'w', encoding='utf-8') as f:
+                json.dump({'entries': entries}, f, ensure_ascii=False, indent=2)
+            count = len(entries)
+        return {'ok': True, 'path': out_path, 'format': fmt, 'entries': count}
+
+    def _api_glossary_import_preview(self, body: dict):
+        return self._api_call_ui(self._api_glossary_import_preview_ui, body)
+
+    def _api_glossary_import_preview_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        import_mode = str((body or {}).get('mode', 'merge') or 'merge').strip().lower()
+        in_path = str((body or {}).get('path', '') or '').strip()
+        if not in_path:
+            raise ValueError('path is required')
+        if in_path.lower().endswith('.csv'):
+            entries = import_glossary_csv(in_path)
+        else:
+            import json
+            with open(in_path, 'r', encoding='utf-8') as f:
+                payload = json.load(f)
+            entries = list((payload or {}).get('entries', []) or [])
+        store = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
+        preview = preview_glossary_merge(store, entries, mode=import_mode)
+        return {'ok': True, **preview}
+
+    def _api_glossary_import(self, body: dict):
+        return self._api_call_ui(self._api_glossary_import_ui, body)
+
+    def _api_glossary_import_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        import_mode = str((body or {}).get('mode', 'merge') or 'merge').strip().lower()
+        in_path = str((body or {}).get('path', '') or '').strip()
+        if not in_path:
+            raise ValueError('path is required')
+        entries = []
+        if in_path.lower().endswith('.csv'):
+            entries = import_glossary_csv(in_path)
+        else:
+            import json
+            with open(in_path, 'r', encoding='utf-8') as f:
+                payload = json.load(f)
+            entries = list((payload or {}).get('entries', []) or [])
+        store = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
+        if import_mode == 'replace':
+            store = []
+        seen = {str((r or {}).get('source', '') or '').strip() for r in store}
+        added = 0
+        for row in entries:
+            src = str((row or {}).get('source', '') or '').strip()
+            tgt = str((row or {}).get('target', '') or '').strip()
+            if not src or src in seen:
+                continue
+            store.append({'source': src, 'target': tgt})
+            seen.add(src)
+            added += 1
+        self.imgtrans_proj.translation_glossary = store
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'mode': import_mode, 'added': added, 'entries': len(store)}
+
     def _api_translation_prompt_profiles(self, body: dict):
         return {'ok': True, 'profiles': sorted(PROMPT_PROFILES.keys()), 'default': getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue')}
 
@@ -2153,8 +2431,128 @@ class MainWindow(mainwindow_cls):
         if img is None or not blks:
             self.pipelineInsightsPanel.add_warning('OCR_INSPECT', self.tr('Missing image or OCR blocks on current page.'))
             return
-        self.ocrCropInspectorPanel.set_page(img, blks)
+        ocr_engines = sorted(list(getattr(OCR, 'module_dict', {}).keys()))
+        current_engine = str(getattr(pcfg.module, 'ocr', '') or '')
+        self.ocrCropInspectorPanel.set_page(
+            img,
+            blks,
+            ocr_engines=ocr_engines,
+            current_engine=current_engine,
+            on_rerun=self._on_ocr_crop_inspector_rerun,
+            on_compare=self._on_ocr_crop_inspector_compare,
+        )
         self.rightComicTransStackPanel.setCurrentWidget(self.ocrCropInspectorPanel)
+
+
+    def _on_ocr_crop_inspector_rerun(self, block_index: int, engine_name: str):
+        try:
+            rst = self._api_ocr_rerun_block_ui({'index': int(block_index), 'engine': str(engine_name or '')})
+            self.canvas.updateTextBlkList()
+            page = str((rst or {}).get('page', '') or '')
+            idx = int((rst or {}).get('index', -1) or -1)
+            txt = str((rst or {}).get('text', '') or '')
+            conf = (rst or {}).get('confidence', None)
+            self.pipelineInsightsPanel.add_event('OCR_INSPECT', self.tr('Re-ran OCR on {0} block #{1}.').format(page, idx + 1))
+            if hasattr(self.ocrCropInspectorPanel, 'text_lbl') and idx >= 0:
+                self.ocrCropInspectorPanel.text_lbl.setText(f"OCR: {txt}\nConfidence: {conf if conf is not None else '-'}")
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to rerun OCR for selected block'))
+
+    def _api_ocr_rerun_block(self, body: dict):
+        return self._api_call_ui(self._api_ocr_rerun_block_ui, body)
+
+    def _api_ocr_rerun_block_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        page = str((body or {}).get('page', '') or '').strip() or str(getattr(self.imgtrans_proj, 'current_img', '') or '')
+        if not page:
+            raise ValueError('page is required')
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        index = int((body or {}).get('index', -1) or -1)
+        if index < 0 or index >= len(blks):
+            raise ValueError('invalid index')
+        engine = str((body or {}).get('engine', '') or '').strip()
+        if engine:
+            self.module_manager.setOCR(engine)
+        img = self.imgtrans_proj.read_img(page)
+        self.module_manager.ocr_thread.run_ocr(img, [blks[index]])
+        self.canvas.setProjSaveState(True)
+        return {
+            'ok': True,
+            'page': page,
+            'index': index,
+            'engine': str(getattr(pcfg.module, 'ocr', '') or ''),
+            'text': str(getattr(blks[index], 'text', '') or ''),
+            'translation': str(getattr(blks[index], 'translation', '') or ''),
+            'confidence': getattr(blks[index], 'confidence', None),
+        }
+
+
+    def _on_ocr_crop_inspector_compare(self, block_index: int, engine_name: str):
+        try:
+            rst = self._api_ocr_compare_block_ui({'index': int(block_index), 'secondary_engine': str(engine_name or '')})
+            primary = str((rst or {}).get('primary_text', '') or '')
+            secondary = str((rst or {}).get('secondary_text', '') or '')
+            chosen = QMessageBox.question(
+                self,
+                self.tr('OCR compare result'),
+                self.tr('Primary ({0}):\n{1}\n\nSecondary ({2}):\n{3}\n\nApply secondary text?').format(
+                    rst.get('primary_engine', ''), primary, rst.get('secondary_engine', ''), secondary,
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if chosen == QMessageBox.StandardButton.Yes:
+                self._api_ocr_apply_compare_choice_ui({'page': rst.get('page'), 'index': rst.get('index'), 'text': secondary, 'engine': rst.get('secondary_engine')})
+                self.canvas.updateTextBlkList()
+                self.pipelineInsightsPanel.add_event('OCR_INSPECT', self.tr('Applied secondary OCR text to selected block.'))
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to compare OCR engines'))
+
+    def _api_ocr_compare_block(self, body: dict):
+        return self._api_call_ui(self._api_ocr_compare_block_ui, body)
+
+    def _api_ocr_compare_block_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        page = str((body or {}).get('page', '') or '').strip() or str(getattr(self.imgtrans_proj, 'current_img', '') or '')
+        index = int((body or {}).get('index', -1) or -1)
+        secondary = str((body or {}).get('secondary_engine', '') or '').strip()
+        if not page or index < 0:
+            raise ValueError('page and valid index are required')
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        if index >= len(blks):
+            raise ValueError('invalid index')
+        primary_engine = str(getattr(pcfg.module, 'ocr', '') or '')
+        img = self.imgtrans_proj.read_img(page)
+        blk = blks[index]
+        primary_text = str(getattr(blk, 'text', '') or '')
+        if secondary:
+            self.module_manager.setOCR(secondary)
+            self.module_manager.ocr_thread.run_ocr(img, [blk])
+            secondary_text = str(getattr(blk, 'text', '') or '')
+            self.module_manager.setOCR(primary_engine)
+            # restore primary result
+            blk.text = primary_text
+        else:
+            secondary_text = primary_text
+        return {'ok': True, 'page': page, 'index': index, 'primary_engine': primary_engine, 'secondary_engine': secondary or primary_engine, 'primary_text': primary_text, 'secondary_text': secondary_text}
+
+    def _api_ocr_apply_compare_choice(self, body: dict):
+        return self._api_call_ui(self._api_ocr_apply_compare_choice_ui, body)
+
+    def _api_ocr_apply_compare_choice_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        page = str((body or {}).get('page', '') or '').strip() or str(getattr(self.imgtrans_proj, 'current_img', '') or '')
+        index = int((body or {}).get('index', -1) or -1)
+        text = str((body or {}).get('text', '') or '')
+        blks = self.imgtrans_proj.pages.get(page, []) or []
+        if index < 0 or index >= len(blks):
+            raise ValueError('invalid index')
+        blks[index].text = text
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'page': page, 'index': index, 'text': text, 'engine': str((body or {}).get('engine', '') or '')}
 
     def on_open_reading_order_editor_requested(self):
         page = self.imgtrans_proj.current_img
@@ -2886,6 +3284,10 @@ class MainWindow(mainwindow_cls):
             self.titleBar.batch_find_replace_trigger.connect(self.on_batch_find_replace_current_project)
         self.titleBar.ocr_triage_trigger.connect(self.on_open_ocr_triage_current_page)
         self.titleBar.auto_extract_glossary_trigger.connect(self.on_auto_extract_glossary_current_page)
+        if hasattr(self.titleBar, 'concordance_search_trigger'):
+            self.titleBar.concordance_search_trigger.connect(self.on_concordance_search_current_project)
+        if hasattr(self.titleBar, 'import_glossary_preview_trigger'):
+            self.titleBar.import_glossary_preview_trigger.connect(self.on_import_glossary_with_preview)
         self.titleBar.save_run_profile_trigger.connect(self.on_save_run_profile_snapshot)
         self.titleBar.apply_run_profile_trigger.connect(self.on_apply_run_profile_snapshot)
         self.titleBar.layout_review_selected_trigger.connect(self.shortcutLayoutReviewSelected)
@@ -4994,7 +5396,7 @@ class MainWindow(mainwindow_cls):
                 exported_paths,
                 missing,
                 export_kind='rendered_images',
-                options={'ext': ext or '', 'also_pdf': bool(also_pdf), 'clean_after_export': bool(clean_after_export), 'include_intermediate': bool(include_intermediate), 'include_unrendered': bool(include_unrendered), 'filename_template': filename_template or getattr(pcfg, 'export_filename_template', '{index:03d}'), 'helper_paths': helper_paths, 'fallback_paths': fallback_paths, 'export_sources': export_sources},
+                options={'ext': ext or '', 'also_pdf': bool(also_pdf), 'clean_after_export': bool(clean_after_export), 'include_intermediate': bool(include_intermediate), 'include_unrendered': bool(include_unrendered), 'filename_template': filename_template or getattr(pcfg, 'export_filename_template', '{index:03d}'), 'helper_paths': helper_paths, 'fallback_paths': fallback_paths, 'export_sources': export_sources, 'renderer': collect_renderer_diagnostics()},
             )
             msg += '\n' + self.tr('Export manifest: {0}').format(manifest.get('manifest_path', ''))
             if marked_exported:
@@ -7476,3 +7878,51 @@ class MainWindow(mainwindow_cls):
             self.textPanel.formatpanel.showGlobalFontFormatBtn.setVisible(True)
         if cfg_name == 'text_advanced_format_panel' and hasattr(self, 'textPanel'):
             self.textPanel.formatpanel.showAdvancedFontFormatBtn.setVisible(True)
+
+
+    def on_concordance_search_current_project(self):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            create_info_dialog({'title': self.tr('Concordance search'), 'text': self.tr('Open a project first.')})
+            return
+        text, ok = QInputDialog.getText(self, self.tr('Concordance search'), self.tr('Find in source/target:'))
+        if not ok or not str(text).strip():
+            return
+        rows = build_concordance_from_project(self.imgtrans_proj)
+        hits = query_concordance(rows, text, in_target=True, limit=200)
+        if not hits:
+            create_info_dialog({'title': self.tr('Concordance search'), 'text': self.tr('No matches found.')})
+            return
+        lines = [self.tr('Matches: {0}').format(len(hits))]
+        for h in hits[:50]:
+            lines.append(f"[{h.get('page','')}] {h.get('source','')} -> {h.get('target','')}")
+        if len(hits) > 50:
+            lines.append(self.tr('...and {0} more').format(len(hits)-50))
+        create_info_dialog({'title': self.tr('Concordance search'), 'text': '\n'.join(lines)})
+
+
+    def on_import_glossary_with_preview(self):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            QMessageBox.information(self, self.tr('Import'), self.tr('Open a project first.'))
+            return
+        in_path, _ = QFileDialog.getOpenFileName(self, self.tr('Import glossary'), self.imgtrans_proj.directory, self.tr('Glossary (*.json *.csv)'))
+        if not in_path:
+            return
+        mode, ok = QInputDialog.getItem(self, self.tr('Import mode'), self.tr('Mode'), [self.tr('merge'), self.tr('replace')], 0, False)
+        if not ok:
+            return
+        mode_v = 'replace' if str(mode).lower().startswith('replace') else 'merge'
+        try:
+            preview = self._api_glossary_import_preview_ui({'path': in_path, 'mode': mode_v})
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to preview glossary import'))
+            return
+        text = self.tr('Incoming: {0}\nWill add: {1}\nSkipped: {2}\nResult total: {3}').format(preview.get('incoming_count', 0), preview.get('added_count', 0), preview.get('skipped_count', 0), preview.get('result_count', 0))
+        yn = QMessageBox.question(self, self.tr('Glossary import preview'), text + '\n\n' + self.tr('Apply now?'), QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No, QMessageBox.StandardButton.No)
+        if yn != QMessageBox.StandardButton.Yes:
+            return
+        try:
+            rst = self._api_glossary_import_ui({'path': in_path, 'mode': mode_v})
+            create_info_dialog({'title': self.tr('Glossary import'), 'text': self.tr('Added entries: {0} (total: {1})').format(rst.get('added', 0), rst.get('entries', 0))})
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to import glossary'))
+

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -1185,11 +1185,15 @@ class MainWindow(mainwindow_cls):
         if not pages:
             pages = list(getattr(self.imgtrans_proj, 'pages', {}).keys())
         out_dir = str((body or {}).get('out_dir', '') or '').strip()
+        halo_threshold = float((body or {}).get('halo_threshold', 0.18) or 0.18)
+        inside_radius = int((body or {}).get('inside_radius', 1) or 1)
+        outside_radius = int((body or {}).get('outside_radius', 2) or 2)
+        detector_confidence = float((body or {}).get('detector_confidence', 1.0) or 1.0)
         detector = getattr(self.module_manager, 'textdetector', None)
         inpainter = getattr(self.module_manager, 'inpainter', None)
         if detector is None or inpainter is None:
             raise ValueError('detector and inpainter must be loaded')
-        rst = run_cleanup_only_pages(self.imgtrans_proj, detector, inpainter, pages, out_dir=out_dir)
+        rst = run_cleanup_only_pages(self.imgtrans_proj, detector, inpainter, pages, out_dir=out_dir, halo_threshold=halo_threshold, inside_radius=inside_radius, outside_radius=outside_radius, detector_confidence=detector_confidence)
         if rst.get('processed'):
             self.canvas.setProjSaveState(True)
         return {'ok': True, **rst}

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -738,6 +738,10 @@ class TitleBar(Widget):
         translationQaAction.setToolTip(self.tr('Run glossary candidate extraction and guardrail checks on current page.'))
         self.translation_qa_report_trigger = translationQaAction.triggered
 
+        concordanceSearchAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'search.svg')), self.tr('Concordance search (project)...'), self)
+        concordanceSearchAction.setToolTip(self.tr('Search previous source/target lines with page provenance.'))
+        self.concordance_search_trigger = concordanceSearchAction.triggered
+
         saveRunProfileAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'save_activate.svg')), self.tr('Save run profile snapshot...'), self)
         saveRunProfileAction.setToolTip(self.tr('Save current module selections as a project-local run profile.'))
         self.save_run_profile_trigger = saveRunProfileAction.triggered
@@ -794,6 +798,7 @@ class TitleBar(Widget):
         projectMenu.addAction(translationQaAction)
         projectMenu.addAction(ocrTriageAction)
         projectMenu.addAction(autoExtractGlossaryAction)
+        projectMenu.addAction(concordanceSearchAction)
         batchFindReplaceAction = QAction(self.tr('Batch find/replace translations...'), self)
         batchFindReplaceAction.setToolTip(self.tr('Preview regex find/replace across project translations before applying.'))
         self.batch_find_replace_trigger = batchFindReplaceAction.triggered
@@ -813,6 +818,9 @@ class TitleBar(Widget):
         svgTextHandoffAction.setToolTip(self.tr('Export current page as an SVG with editable translated text elements for vector editors.'))
         self.export_svg_text_handoff_trigger = svgTextHandoffAction.triggered
         exportMenuTools.addAction(svgTextHandoffAction)
+        importGlossaryPreviewAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'openbtn.svg')), self.tr('Import glossary with preview...'), self)
+        importGlossaryPreviewAction.setToolTip(self.tr('Preview merge/replace impact before importing glossary entries.'))
+        self.import_glossary_preview_trigger = importGlossaryPreviewAction.triggered
         exportTransCsvAction = QAction(self.tr('Export translation CSV...'), self)
         exportTransCsvAction.setToolTip(self.tr('Export source/translation rows as CSV for spreadsheet and CAT workflows.'))
         self.export_translation_csv_trigger = exportTransCsvAction.triggered
@@ -821,6 +829,7 @@ class TitleBar(Widget):
         importTransCsvAction.setToolTip(self.tr('Import translation CSV by page + stable block ID with index fallback.'))
         self.import_translation_csv_trigger = importTransCsvAction.triggered
         exportMenuTools.addAction(importTransCsvAction)
+        exportMenuTools.addAction(importGlossaryPreviewAction)
         exportTransJsonAction = QAction(self.tr('Export translation JSON...'), self)
         exportTransJsonAction.setToolTip(self.tr('Export source/translation with stable block IDs for external translation workflows.'))
         self.export_translation_json_trigger = exportTransJsonAction.triggered

--- a/ui/model_package_selector_dialog.py
+++ b/ui/model_package_selector_dialog.py
@@ -15,15 +15,35 @@ from qtpy.QtWidgets import (
     QGroupBox,
     QFrame,
     QMessageBox,
-    QComboBox,
 )
+try:
+    from qtpy.QtWidgets import QComboBox
+except ImportError:
+    class QComboBox:  # headless/test fallback
+        def __init__(self, *_, **__):
+            self._items = []
+            self._current = ""
+            self.currentTextChanged = type("_Signal", (), {"connect": staticmethod(lambda *a, **k: None)})()
+
+        def addItems(self, items):
+            self._items.extend(list(items or []))
+
+        def setCurrentText(self, text):
+            self._current = str(text or "")
 try:
     from qtpy.QtWidgets import QRadioButton
 except ImportError:
     QRadioButton = QCheckBox
 
 import utils.model_packages as _model_packages
-from utils.config import pcfg, save_config
+try:
+    from utils.config import pcfg, save_config
+except Exception:
+    class _CfgFallback:
+        display_lang = "English"
+    pcfg = _CfgFallback()
+    def save_config():
+        return None
 from utils.shared import DISPLAY_LANGUAGE_MAP
 MODEL_PACKAGES = _model_packages.MODEL_PACKAGES
 PACKAGE_LABELS = _model_packages.PACKAGE_LABELS
@@ -67,7 +87,8 @@ class ModelPackageSelectorDialog(QDialog):
         self._result = ["core"]
         self._result_preset_ids = []
         self._build_ui()
-        self.setStyleSheet(_dark_first_launch_stylesheet())
+        if hasattr(self, "setStyleSheet"):
+            self.setStyleSheet(_dark_first_launch_stylesheet())
 
     def _build_ui(self):
         layout = QVBoxLayout(self)
@@ -79,7 +100,10 @@ class ModelPackageSelectorDialog(QDialog):
         self._lang_combo.setCurrentText(self._display_lang_to_label(getattr(pcfg, "display_lang", "English")))
         self._lang_combo.currentTextChanged.connect(self._on_display_lang_changed)
         lang_row.addWidget(lang_label)
-        lang_row.addWidget(self._lang_combo, 1)
+        try:
+            lang_row.addWidget(self._lang_combo, 1)
+        except TypeError:
+            lang_row.addWidget(self._lang_combo)
         layout.addLayout(lang_row)
 
         intro = QLabel(

--- a/ui/ocr_crop_inspector_widget.py
+++ b/ui/ocr_crop_inspector_widget.py
@@ -1,5 +1,5 @@
 from qtpy.QtCore import Qt, QPropertyAnimation, QEasingCurve
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QHBoxLayout, QGraphicsOpacityEffect
+from qtpy.QtWidgets import QWidget, QVBoxLayout, QLabel, QListWidget, QListWidgetItem, QHBoxLayout, QGraphicsOpacityEffect, QPushButton, QComboBox
 import numpy as np
 
 from .misc import ndarray2pixmap
@@ -22,9 +22,24 @@ class OcrCropInspectorWidget(QWidget):
         self.text_lbl = QLabel(self)
         self.text_lbl.setWordWrap(True)
         lay.addWidget(self.text_lbl)
+
+        ctl = QHBoxLayout()
+        self.engine_combo = QComboBox(self)
+        self.rerun_btn = QPushButton(self.tr("Rerun OCR for selected block"), self)
+        self.rerun_btn.setToolTip(self.tr("Run OCR again only for the selected block using the selected OCR engine."))
+        self.compare_btn = QPushButton(self.tr("Compare OCR engines"), self)
+        self.compare_btn.setToolTip(self.tr("Compare current OCR output with selected secondary OCR engine for this block."))
+        ctl.addWidget(self.engine_combo, 1)
+        ctl.addWidget(self.rerun_btn)
+        ctl.addWidget(self.compare_btn)
+        lay.addLayout(ctl)
         self._img = None
         self._blks = []
+        self._on_rerun = None
+        self._on_compare = None
         self.listw.currentRowChanged.connect(self._on_row)
+        self.rerun_btn.clicked.connect(self._on_rerun_clicked)
+        self.compare_btn.clicked.connect(self._on_compare_clicked)
 
         self._opacity = QGraphicsOpacityEffect(self)
         self.setGraphicsEffect(self._opacity)
@@ -34,9 +49,18 @@ class OcrCropInspectorWidget(QWidget):
         self._anim.setEndValue(1.0)
         self._anim.setEasingCurve(QEasingCurve.OutCubic)
 
-    def set_page(self, img: np.ndarray, blocks: list):
+    def set_page(self, img: np.ndarray, blocks: list, *, ocr_engines: list | None = None, current_engine: str = "", on_rerun=None, on_compare=None):
         self._img = img
         self._blks = blocks or []
+        self._on_rerun = on_rerun
+        self._on_compare = on_compare
+        self.engine_combo.clear()
+        for name in (ocr_engines or []):
+            self.engine_combo.addItem(str(name))
+        if current_engine:
+            idx = self.engine_combo.findText(str(current_engine))
+            if idx >= 0:
+                self.engine_combo.setCurrentIndex(idx)
         self.listw.clear()
         for i, b in enumerate(self._blks):
             conf = getattr(b, 'confidence', None)
@@ -58,3 +82,11 @@ class OcrCropInspectorWidget(QWidget):
         crop = self._img[y1:y2, x1:x2]
         self.preview.setPixmap(ndarray2pixmap(crop).scaledToWidth(320, Qt.TransformationMode.SmoothTransformation))
         self.text_lbl.setText(f"OCR: {getattr(b, 'text', '')}\nTranslation: {getattr(b, 'translation', '')}")
+
+
+    def _on_compare_clicked(self):
+        row = self.listw.currentRow()
+        if row < 0 or row >= len(self._blks):
+            return
+        if callable(self._on_compare):
+            self._on_compare(row, self.engine_combo.currentText())

--- a/utils/automation_jobs.py
+++ b/utils/automation_jobs.py
@@ -74,3 +74,36 @@ def status_payload(job: Dict[str, Any]) -> Dict[str, Any]:
         "updated_at": float(job.get("updated_at", 0.0)),
         "has_result": job.get("result") is not None,
     }
+
+
+def normalize_task_result(result: Any) -> Dict[str, Any]:
+    if isinstance(result, dict):
+        return dict(result)
+    return {"value": result}
+
+
+def update_from_task_result(job: Dict[str, Any], result: Any) -> None:
+    payload = normalize_task_result(result)
+    warns = payload.get("warnings")
+    if isinstance(warns, list):
+        for w in warns:
+            if str(w or "").strip():
+                add_warning(job, str(w))
+    stage = payload.get("stage")
+    progress = payload.get("progress")
+    if stage is not None or progress is not None:
+        set_status(job, job.get("status") or "running", stage=str(stage or job.get("stage") or "running"), progress=float(progress if progress is not None else job.get("progress") or 0.0))
+
+
+def mark_started(job: Dict[str, Any], task: str) -> None:
+    set_status(job, "running", stage=f"starting:{task}", progress=0.02)
+    append_log(job, f"started task={task}")
+
+
+def mark_finished(job: Dict[str, Any], task: str, *, cancelled: bool = False) -> None:
+    if cancelled:
+        set_status(job, "cancelled", stage=f"cancelled:{task}", progress=1.0)
+        append_log(job, f"cancelled task={task}")
+    else:
+        set_status(job, "succeeded", stage=f"completed:{task}", progress=1.0)
+        append_log(job, f"finished task={task}")

--- a/utils/batch_parent_queue.py
+++ b/utils/batch_parent_queue.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import os
+import os.path as osp
+from dataclasses import dataclass
+from typing import Dict, List
+
+IMG_EXT = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".tif", ".tiff"}
+
+
+def _dir_has_images(d: str) -> bool:
+    try:
+        for name in os.listdir(d):
+            if osp.splitext(name)[1].lower() in IMG_EXT:
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def _iter_image_dirs(root_dir: str) -> List[str]:
+    out: List[str] = []
+    root_dir = osp.normpath(osp.abspath(root_dir))
+    for cur, dirnames, _f in os.walk(root_dir):
+        base = osp.basename(cur).lower()
+        if base in {"result", "mask", "inpainted"}:
+            dirnames[:] = []
+            continue
+        if _dir_has_images(cur):
+            out.append(osp.normpath(osp.abspath(cur)))
+    out.sort(key=lambda p: (p.count(os.sep), p.lower()))
+    return out
+
+
+@dataclass
+class BatchChildProject:
+    kind: str  # dir|cbz|zip
+    input_path: str
+    display_name: str
+
+
+def enumerate_child_projects(parent_path: str) -> List[BatchChildProject]:
+    parent_path = osp.abspath(parent_path)
+    out: List[BatchChildProject] = []
+    if osp.isdir(parent_path):
+        # nested image dirs
+        for d in _iter_image_dirs(parent_path):
+            out.append(BatchChildProject(kind='dir', input_path=d, display_name=osp.relpath(d, parent_path)))
+        # archive files in tree
+        for cur, _dirs, files in os.walk(parent_path):
+            for name in files:
+                low = name.lower()
+                if low.endswith('.cbz') or low.endswith('.zip'):
+                    p = osp.abspath(osp.join(cur, name))
+                    out.append(BatchChildProject(kind='cbz' if low.endswith('.cbz') else 'zip', input_path=p, display_name=osp.relpath(p, parent_path)))
+    else:
+        low = parent_path.lower()
+        if low.endswith('.cbz') or low.endswith('.zip'):
+            out.append(BatchChildProject(kind='cbz' if low.endswith('.cbz') else 'zip', input_path=parent_path, display_name=osp.basename(parent_path)))
+    # stable unique
+    dedup: Dict[str, BatchChildProject] = {}
+    for c in out:
+        dedup[c.input_path] = c
+    return [dedup[k] for k in sorted(dedup.keys())]
+
+
+def save_parent_batch_state(state_path: str, parent_path: str, children: List[BatchChildProject], *, statuses: Dict[str, str] | None = None) -> Dict[str, object]:
+    statuses = dict(statuses or {})
+    payload = {
+        'format': 'ballonstranslator.parent_batch_state.v1',
+        'parent_path': osp.abspath(parent_path),
+        'children': [
+            {
+                'kind': c.kind,
+                'input_path': c.input_path,
+                'display_name': c.display_name,
+                'status': statuses.get(c.input_path, 'pending'),
+            }
+            for c in children
+        ],
+    }
+    os.makedirs(osp.dirname(osp.abspath(state_path)) or '.', exist_ok=True)
+    with open(state_path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return payload
+
+
+def load_parent_batch_state(state_path: str) -> dict:
+    with open(state_path, 'r', encoding='utf-8') as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict) or payload.get('format') != 'ballonstranslator.parent_batch_state.v1':
+        raise ValueError('invalid_state_format')
+    return payload
+
+
+def update_parent_batch_status(state_path: str, input_path: str, status: str) -> dict:
+    payload = load_parent_batch_state(state_path)
+    target = osp.abspath(input_path)
+    updated = False
+    for row in payload.get('children', []) or []:
+        if osp.abspath(str(row.get('input_path', '') or '')) == target:
+            row['status'] = str(status or '').strip() or 'pending'
+            updated = True
+            break
+    if not updated:
+        raise ValueError('child_not_found')
+    with open(state_path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+    return payload
+
+
+def next_pending_child(state_payload: dict) -> dict | None:
+    for row in list((state_payload or {}).get('children') or []):
+        if str((row or {}).get('status', 'pending') or 'pending') == 'pending':
+            return dict(row)
+    return None

--- a/utils/cleanup_only_workflow.py
+++ b/utils/cleanup_only_workflow.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Tuple
 
 from PIL import Image
 import numpy as np
+from utils.mask_cleanup_quality import adaptive_mask_expand, merge_masks_with_confidence
 
 
 def _build_rect_mask(blocks, width: int, height: int):
@@ -18,7 +19,7 @@ def _build_rect_mask(blocks, width: int, height: int):
     return mask
 
 
-def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *, out_dir: str = "") -> Dict[str, object]:
+def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *, out_dir: str = "", halo_threshold: float = 0.18, inside_radius: int = 1, outside_radius: int = 2, detector_confidence: float = 1.0) -> Dict[str, object]:
     pages = [str(p) for p in (pages or []) if str(p)]
     exported: List[Tuple[str, str]] = []
     warnings: List[str] = []
@@ -29,8 +30,10 @@ def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *
     for page in pages:
         try:
             img = project.read_img(page)
-            _mask, blks = detector.detect(img, project)
-            mask = _build_rect_mask(blks or [], img.shape[1], img.shape[0])
+            det_mask, blks = detector.detect(img, project)
+            rect_mask = _build_rect_mask(blks or [], img.shape[1], img.shape[0])
+            mask = merge_masks_with_confidence(rect_mask, det_mask, confidence=detector_confidence)
+            mask = adaptive_mask_expand(mask, inside_radius=inside_radius, outside_radius=outside_radius)
             clean = inpainter.inpaint(img, mask)
             project.save_inpainted(page, clean)
             if out_dir:
@@ -48,4 +51,5 @@ def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *
         'failed': failed,
         'warnings': warnings,
         'exported': exported,
+        'mask_policy': {'inside_radius': int(inside_radius), 'outside_radius': int(outside_radius), 'detector_confidence': float(detector_confidence)},
     }

--- a/utils/cleanup_only_workflow.py
+++ b/utils/cleanup_only_workflow.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import os
+import os.path as osp
+from typing import Dict, Iterable, List, Tuple
+
+from PIL import Image
+import numpy as np
+
+
+def _build_rect_mask(blocks, width: int, height: int):
+    mask = np.zeros((height, width), dtype=np.uint8)
+    for b in blocks or []:
+        x1,y1,x2,y2 = [int(v) for v in getattr(b, "xyxy", [0,0,0,0])]
+        x1,y1 = max(0,x1), max(0,y1)
+        x2,y2 = min(width, max(x1+1,x2)), min(height, max(y1+1,y2))
+        mask[y1:y2, x1:x2] = 255
+    return mask
+
+
+def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *, out_dir: str = "") -> Dict[str, object]:
+    pages = [str(p) for p in (pages or []) if str(p)]
+    exported: List[Tuple[str, str]] = []
+    warnings: List[str] = []
+    processed = 0
+    failed = 0
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    for page in pages:
+        try:
+            img = project.read_img(page)
+            _mask, blks = detector.detect(img, project)
+            mask = _build_rect_mask(blks or [], img.shape[1], img.shape[0])
+            clean = inpainter.inpaint(img, mask)
+            project.save_inpainted(page, clean)
+            if out_dir:
+                out_path = osp.join(out_dir, f"{osp.splitext(osp.basename(page))[0]}_clean.png")
+                arr = np.asarray(clean)
+                Image.fromarray(arr).save(out_path)
+                exported.append((page, out_path))
+            processed += 1
+        except Exception as e:
+            failed += 1
+            warnings.append(f"{page}: {e}")
+    return {
+        'ok': failed == 0,
+        'processed': processed,
+        'failed': failed,
+        'warnings': warnings,
+        'exported': exported,
+    }

--- a/utils/data_path_manager.py
+++ b/utils/data_path_manager.py
@@ -18,3 +18,33 @@ def free_space_gb(path: str) -> float:
     target = path if os.path.isdir(path) else os.path.dirname(path) or "."
     st = shutil.disk_usage(target)
     return float(st.free) / float(1024 ** 3)
+
+
+def describe_data_path(override_path: str = "") -> dict:
+    path = resolve_data_path(override_path)
+    exists = os.path.isdir(path)
+    free_gb = free_space_gb(path if exists else os.path.dirname(path) or ".")
+    return {
+        "path": path,
+        "exists": exists,
+        "free_gb": round(float(free_gb), 3),
+    }
+
+
+def migrate_data_path(src: str, dst: str, *, dry_run: bool = True) -> dict:
+    src = resolve_data_path(src)
+    dst = resolve_data_path(dst)
+    moved = []
+    if not os.path.isdir(src):
+        return {"ok": False, "error": f"source_missing:{src}", "moved": moved, "dry_run": dry_run}
+    os.makedirs(dst, exist_ok=True)
+    for name in sorted(os.listdir(src)):
+        s = os.path.join(src, name)
+        d = os.path.join(dst, name)
+        moved.append({"name": name, "src": s, "dst": d, "exists_dst": os.path.exists(d)})
+        if dry_run:
+            continue
+        if os.path.exists(d):
+            continue
+        os.replace(s, d)
+    return {"ok": True, "source": src, "dest": dst, "moved": moved, "dry_run": dry_run}

--- a/utils/export_manifest.py
+++ b/utils/export_manifest.py
@@ -32,6 +32,7 @@ def build_export_manifest(
             "used_fallback_source": source_kind != "rendered",
             "completion_state": project.get_page_completion_state(page_name) if project is not None and hasattr(project, "get_page_completion_state") else "",
         })
+    renderer_info = options.get("renderer") or {}
     manifest = {
         "format": "ballonstranslator.export_manifest.v1",
         "exported_at": datetime.now(timezone.utc).isoformat(),
@@ -45,6 +46,7 @@ def build_export_manifest(
         "missing_pages": missing,
         "options": options,
         "warnings": [],
+        "renderer": renderer_info,
     }
     fallback_count = sum(1 for page in pages if page.get("used_fallback_source"))
     if fallback_count:

--- a/utils/glossary_io.py
+++ b/utils/glossary_io.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import csv
+from typing import Dict, List
+
+
+def export_glossary_csv(entries: List[Dict[str, str]], out_path: str) -> int:
+    rows = list(entries or [])
+    with open(out_path, 'w', encoding='utf-8-sig', newline='') as f:
+        wr = csv.DictWriter(f, fieldnames=['source', 'target'])
+        wr.writeheader()
+        for row in rows:
+            wr.writerow({'source': str((row or {}).get('source', '') or ''), 'target': str((row or {}).get('target', '') or '')})
+    return len(rows)
+
+
+def import_glossary_csv(path: str) -> List[Dict[str, str]]:
+    out: List[Dict[str, str]] = []
+    with open(path, 'r', encoding='utf-8-sig', newline='') as f:
+        rd = csv.DictReader(f)
+        for row in rd:
+            s = str((row or {}).get('source', '') or '').strip()
+            t = str((row or {}).get('target', '') or '').strip()
+            if s:
+                out.append({'source': s, 'target': t})
+    return out
+
+
+def preview_glossary_merge(existing: List[Dict[str, str]], incoming: List[Dict[str, str]], *, mode: str = "merge") -> Dict[str, object]:
+    mode = str(mode or "merge").strip().lower()
+    cur = list(existing or [])
+    if mode == "replace":
+        base = []
+    else:
+        base = cur
+    seen = {str((r or {}).get('source', '') or '').strip() for r in base}
+    added = []
+    skipped = []
+    for row in incoming or []:
+        src = str((row or {}).get('source', '') or '').strip()
+        tgt = str((row or {}).get('target', '') or '').strip()
+        if not src:
+            skipped.append({'source': src, 'target': tgt, 'reason': 'empty_source'})
+            continue
+        if src in seen:
+            skipped.append({'source': src, 'target': tgt, 'reason': 'duplicate_source'})
+            continue
+        added.append({'source': src, 'target': tgt})
+        seen.add(src)
+    return {
+        'mode': mode,
+        'existing_count': len(cur),
+        'incoming_count': len(list(incoming or [])),
+        'added_count': len(added),
+        'skipped_count': len(skipped),
+        'added_preview': added[:20],
+        'skipped_preview': skipped[:20],
+        'result_count': len(base) + len(added),
+    }

--- a/utils/headless_batch_contract.py
+++ b/utils/headless_batch_contract.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from typing import Set
+
+ALLOWED_STAGES = {"detect", "ocr", "translate", "inpaint"}
+
+
+def parse_stage_set(raw: str) -> Set[str]:
+    text = str(raw or "").strip().lower()
+    if not text:
+        return set(ALLOWED_STAGES)
+    selected = {part.strip() for part in text.split(",") if part.strip()}
+    invalid = sorted(selected - ALLOWED_STAGES)
+    if invalid:
+        raise ValueError(f"invalid stage(s): {', '.join(invalid)}; allowed: detect,ocr,translate,inpaint")
+    return selected

--- a/utils/headless_contract.py
+++ b/utils/headless_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 from typing import Dict, List
 
@@ -19,6 +19,7 @@ class HeadlessRunSummary:
     processed_dirs: List[str]
     skipped_dirs: List[str]
     failed_dirs: List[str]
+    warnings: List[str] = field(default_factory=list)
 
     def to_payload(self) -> Dict[str, object]:
         return {
@@ -29,6 +30,7 @@ class HeadlessRunSummary:
             "processed_dirs": list(self.processed_dirs),
             "skipped_dirs": list(self.skipped_dirs),
             "failed_dirs": list(self.failed_dirs),
+            "warnings": list(self.warnings),
         }
 
     def exit_code(self) -> int:

--- a/utils/local_automation_api.py
+++ b/utils/local_automation_api.py
@@ -88,7 +88,7 @@ class LocalAutomationApiServer:
             def _send_events(self, query: str):
                 qs = parse_qs(query or '')
                 job_id = (qs.get('job_id') or [''])[0]
-                payload: Dict[str, Any] = {'ok': True, 'job_id': job_id}
+                payload: Dict[str, Any] = {'ok': True, 'job_id': job_id, 'event': 'job_snapshot'}
                 status_fn = handlers.get('job_status')
                 logs_fn = handlers.get('job_logs')
                 if job_id and status_fn is not None:
@@ -102,7 +102,15 @@ class LocalAutomationApiServer:
                         payload['logs'] = logs_fn({'job_id': job_id}) or {}
                     except Exception as e:
                         payload['warnings'] = [str(e)]
-                data = ('event: job\n' + 'data: ' + json.dumps(payload) + '\n\n').encode('utf-8')
+                status_name = str(((payload.get('status') or {}).get('status', 'snapshot')) if isinstance(payload.get('status'), dict) else 'snapshot')
+                event_id = str(((payload.get('status') or {}).get('updated_at', '0')) if isinstance(payload.get('status'), dict) else '0')
+                lines = [
+                    f"id: {event_id}",
+                    f"event: {status_name}",
+                    'data: ' + json.dumps(payload),
+                    '',
+                ]
+                data = ('\n'.join(lines) + '\n').encode('utf-8')
                 self.send_response(200)
                 self.send_header('Content-Type', 'text/event-stream')
                 self.send_header('Cache-Control', 'no-cache')

--- a/utils/mask_cleanup_quality.py
+++ b/utils/mask_cleanup_quality.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def _dilate_binary(mask: np.ndarray, radius: int) -> np.ndarray:
+    if radius <= 0:
+        return mask.copy()
+    m = (mask > 0).astype(np.uint8)
+    out = m.copy()
+    for _ in range(int(radius)):
+        up = np.pad(out[:-1, :], ((1, 0), (0, 0)), constant_values=0)
+        dn = np.pad(out[1:, :], ((0, 1), (0, 0)), constant_values=0)
+        lf = np.pad(out[:, :-1], ((0, 0), (1, 0)), constant_values=0)
+        rg = np.pad(out[:, 1:], ((0, 0), (0, 1)), constant_values=0)
+        out = np.maximum.reduce([out, up, dn, lf, rg])
+    return (out * 255).astype(np.uint8)
+
+
+def adaptive_mask_expand(mask: np.ndarray, *, inside_radius: int = 1, outside_radius: int = 2) -> np.ndarray:
+    """Simple bubble-aware proxy: mild inside dilation + stronger outside edge dilation.
+
+    Without explicit bubble contour, this approximates quality cleanup by combining two
+    dilation passes and keeping the larger coverage edge ring from outside_radius.
+    """
+    base = (np.asarray(mask) > 0).astype(np.uint8) * 255
+    in_d = _dilate_binary(base, int(max(0, inside_radius)))
+    out_d = _dilate_binary(base, int(max(0, outside_radius)))
+    ring = ((out_d > 0) & (in_d == 0)).astype(np.uint8) * 255
+    merged = np.maximum(in_d, ring)
+    return merged.astype(np.uint8)
+
+
+def merge_masks_with_confidence(primary: np.ndarray, secondary: np.ndarray | None = None, *, confidence: float = 1.0) -> np.ndarray:
+    p = (np.asarray(primary) > 0).astype(np.uint8) * 255
+    if secondary is None:
+        return p
+    s = (np.asarray(secondary) > 0).astype(np.uint8) * 255
+    c = float(max(0.0, min(1.0, confidence)))
+    if c >= 0.75:
+        return np.maximum(p, s)
+    if c <= 0.25:
+        return p
+    # medium confidence: only keep overlap + core
+    overlap = ((p > 0) & (s > 0)).astype(np.uint8) * 255
+    return np.maximum(p, overlap)

--- a/utils/renderer_diagnostics.py
+++ b/utils/renderer_diagnostics.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+from typing import Dict, List
+
+
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except Exception:
+        return False
+
+
+def collect_renderer_diagnostics() -> Dict[str, object]:
+    optional = {
+        'uharfbuzz': _has_module('uharfbuzz'),
+        'freetype': _has_module('freetype'),
+        'python_bidi': _has_module('bidi'),
+        'arabic_reshaper': _has_module('arabic_reshaper'),
+    }
+    advanced_ready = bool(optional['uharfbuzz'] and optional['freetype'])
+    warnings: List[str] = []
+    if not optional['uharfbuzz']:
+        warnings.append('uharfbuzz not installed; advanced shaping backend unavailable.')
+    if not optional['freetype']:
+        warnings.append('freetype-py not installed; glyph metrics backend unavailable.')
+    if not optional['python_bidi']:
+        warnings.append('python-bidi not installed; RTL fallback diagnostics limited.')
+    return {
+        'default_renderer': 'qt',
+        'advanced_backend_available': advanced_ready,
+        'optional_modules': optional,
+        'warnings': warnings,
+    }

--- a/utils/server_mode_info.py
+++ b/utils/server_mode_info.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import os
+import os.path as osp
+from typing import Dict, Any
+
+
+def build_server_mode_info(*, host: str = '127.0.0.1', port: int = 39542) -> Dict[str, Any]:
+    program_path = osp.abspath(os.getcwd())
+    data_path = osp.abspath('data')
+    config_path = osp.abspath(osp.join('config', 'config.json'))
+    return {
+        'host': host,
+        'port': int(port),
+        'health_url': f'http://{host}:{int(port)}/health',
+        'routes_url': f'http://{host}:{int(port)}/routes',
+        'events_template': f'http://{host}:{int(port)}/events?job_id=<job_id>',
+        'paths': {
+            'program_path': program_path,
+            'data_path': data_path,
+            'config_path': config_path,
+        },
+        'docker_mount_hints': {
+            'models_cache': '/app/data/models',
+            'projects': '/app/projects',
+            'config': '/app/config/config.json',
+        },
+        'sample_curl': [
+            f'curl http://{host}:{int(port)}/health',
+            f"curl -X POST http://{host}:{int(port)}/project_status -H 'Content-Type: application/json' -d '{{}}'",
+        ],
+        'sample_python': (
+            "import requests\n"
+            f"base='http://{host}:{int(port)}'\n"
+            "print(requests.get(base+'/health', timeout=5).json())\n"
+            "print(requests.get(base+'/routes', timeout=5).json())\n"
+        ),
+    }

--- a/utils/translated_image_alignment.py
+++ b/utils/translated_image_alignment.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def _area(xyxy):
+    if not xyxy or len(xyxy) != 4:
+        return 0.0
+    return max(0.0, float(xyxy[2] - xyxy[0]) * float(xyxy[3] - xyxy[1]))
+
+
+def _iou(a, b):
+    ax1, ay1, ax2, ay2 = [float(v) for v in a]
+    bx1, by1, bx2, by2 = [float(v) for v in b]
+    ix1, iy1 = max(ax1, bx1), max(ay1, by1)
+    ix2, iy2 = min(ax2, bx2), min(ay2, by2)
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    if inter <= 0:
+        return 0.0
+    ua = _area(a) + _area(b) - inter
+    return inter / ua if ua > 0 else 0.0
+
+
+def align_translations_by_iou(raw_blocks: List[Any], translated_blocks: List[Any], *, min_iou: float = 0.2) -> Dict[str, Any]:
+    matched = 0
+    changed = 0
+    rows = []
+    for idx, raw_blk in enumerate(raw_blocks or []):
+        ra = getattr(raw_blk, 'xyxy', None)
+        if not ra or len(ra) != 4:
+            continue
+        best_i, best_txt = 0.0, ''
+        for tb in translated_blocks or []:
+            ta = getattr(tb, 'xyxy', None)
+            if not ta or len(ta) != 4:
+                continue
+            i = _iou(ra, ta)
+            if i > best_i:
+                best_i = i
+                best_txt = (getattr(tb, 'get_text', lambda: '')() or '').strip() or str(getattr(tb, 'translation', '') or '').strip()
+        if best_i >= float(min_iou) and best_txt:
+            matched += 1
+            old = str(getattr(raw_blk, 'translation', '') or '')
+            if old != best_txt:
+                raw_blk.translation = best_txt
+                changed += 1
+            rows.append({'index': idx, 'iou': round(best_i, 4), 'text': best_txt})
+    return {'matched': matched, 'changed': changed, 'rows': rows}

--- a/utils/translation_concordance.py
+++ b/utils/translation_concordance.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def build_concordance_from_project(project) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for page, blks in (getattr(project, 'pages', {}) or {}).items():
+        for idx, blk in enumerate(blks or []):
+            src = (getattr(blk, 'get_text', lambda: '')() or '').strip()
+            tgt = (getattr(blk, 'translation', '') or '').strip()
+            if not src and not tgt:
+                continue
+            rows.append({
+                'source': src,
+                'target': tgt,
+                'page': str(page or ''),
+                'index': int(idx),
+                'block_id': str(getattr(blk, 'api_block_id', '') or ''),
+            })
+    return rows
+
+
+def query_concordance(rows: List[Dict[str, Any]], query: str, *, in_target: bool = True, limit: int = 50) -> List[Dict[str, Any]]:
+    needle = str(query or '').strip().lower()
+    if not needle:
+        return []
+    out: List[Dict[str, Any]] = []
+    for row in rows or []:
+        src = str((row or {}).get('source', '') or '')
+        tgt = str((row or {}).get('target', '') or '')
+        hay = src.lower() + ('\n' + tgt.lower() if in_target else '')
+        if needle in hay:
+            out.append(dict(row))
+    return out[:max(1, int(limit))]


### PR DESCRIPTION
### Motivation

- Expand the local automation API and headless/server-mode surface to support Docker/container usage, stable headless contracts, and MCP-style automation commands.  
- Provide tooling for project-level concordance, glossary import/export, translated-image alignment, and parent/child batch processing to improve batch and CAT-style workflows.  
- Add utility endpoints and diagnostics for renderer capability, data-path migration, and a cleanup-only detect+inpaint workflow for non-translation runs.  

### Description

- Added new automation helpers and diagnostics under `utils/`: `server_mode_info.py`, `renderer_diagnostics.py`, `cleanup_only_workflow.py`, `batch_parent_queue.py`, `glossary_io.py`, `translated_image_alignment.py`, `translation_concordance.py`, and `headless_batch_contract.py`.  
- Extended existing utilities with data-path management and migration (`utils/data_path_manager.py`), export manifest renderer metadata (`utils/export_manifest.py`), and job lifecycle helpers and normalization (`utils/automation_jobs.py`, `utils/headless_contract.py`).  
- Enhanced the local automation server SSE snapshot to include `id` and `event` fields for forward-compatible job streaming (`utils/local_automation_api.py`), and exposed many new API routes and UI handlers in `ui/mainwindow.py` (concordance, glossary import/export/preview, OCR crop inspector rerun/compare/apply, cleanup-only, parent-batch APIs, data-path status/migration, server_mode_info, import_translated_image_align, renderer diagnostics).  
- Headless runner `scripts/batch_translate.py` now supports stage selection via `--stages`, JSON translation import/export flags (`--load-text-json`/`--save-text-json`), and surface warnings/summary fields; a small UI widget and dialog updates were added to support OCR inspector and glossary/concordance actions.  
- Added many unit tests covering the new utilities and contracts and made the model package selector dialog resilient in headless/test environments (`ui/model_package_selector_dialog.py`).  

### Testing

- Ran baseline verification with `pytest -q tests/test_local_automation_api.py tests/test_local_automation_api_routes_contract.py tests/test_lettering_proof_export.py tests/test_export_manifest.py tests/test_project_ops_protocol.py tests/test_model_package_selector_dialog.py`.  
- Observed route discovery, proof-pack/export manifest, and project-ops protocol tests passed in this environment.  
- `tests/test_model_package_selector_dialog.py` currently fails in this environment due to the qtpy widget stub not exposing `QComboBox` during import; the failure is documented for follow-up and a headless fallback was added to reduce test fragility.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c502b281c832c808a32c977e8bb19)