### PR TITLE
Add archive streaming, auto-format QA, SFX/glossary tooling, renderer probes, and related API/UI/tests

### DIFF
--- a/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
+++ b/docs/ALTERNATIVES_FEATURE_GAP_IMPLEMENTATION_PLAN.md
@@ -1,6 +1,6 @@
 # Alternatives Feature Gap Implementation Plan
 
-Last updated: 2026-05-19 (Phase 0 baseline audit pass 2)
+Last updated: 2026-05-19 (Phase 0 baseline audit pass 3)
 
 This document is the safety baseline for closing gaps versus manga-image-translator, Koharu, ImageTrans, manga-translator-ui, and focused cleanup tools. The rule for every phase is: audit first, extend existing Pro systems, do not duplicate equivalent functionality, and do not remove existing Pro behavior.
 
@@ -33,13 +33,12 @@ Every implementation PR in this roadmap must verify:
 
 Commands executed for baseline verification:
 
-- `pytest -q tests/test_local_automation_api.py tests/test_local_automation_api_routes_contract.py tests/test_lettering_proof_export.py tests/test_export_manifest.py tests/test_project_ops_protocol.py tests/test_model_package_selector_dialog.py`
+- `pytest -q tests/test_local_automation_api.py tests/test_local_automation_api_routes_contract.py tests/test_lettering_proof_export.py tests/test_export_manifest.py tests/test_project_ops_protocol.py tests/test_batch_parent_queue.py tests/test_model_package_selector_dialog.py`
 
 Observed results:
 
-- Route discovery, proof-pack/export manifest, and project-ops protocol tests pass.
-- Model picker dialog tests currently fail in this environment because the qtpy widget stub used by the tests does not expose `QComboBox` during import (`ui/model_package_selector_dialog.py`).
-- No startup scripts or first-run behavior code was changed in this pass; failures are documented for follow-up in the next Phase 0/1 slice.
+- Route discovery, proof-pack/export manifest, project operation protocol, parent-batch save-state, and model-picker dialog tests all pass in this environment (`18 passed`).
+- No startup scripts or first-run behavior code was changed in this pass; verification remains required for future startup/model-manager slices.
 
 ## Phase 1 — Automation, headless, and MCP parity
 

--- a/docs/LOCAL_AUTOMATION_API.md
+++ b/docs/LOCAL_AUTOMATION_API.md
@@ -77,6 +77,9 @@ curl -X POST http://127.0.0.1:39542/job_start \
 curl http://127.0.0.1:39542/events?job_id=job_123
 ```
 
+- Archive export (`kind: archive|zip|cbz`) now includes `archive_stream` metadata with `total_files`, `written_files`, and per-file `progress_events` for headless progress reporting.
+- When archive export runs under `job_start`, `job_cancel` now cooperatively cancels archive streaming and returns `archive_stream.cancelled=true` (response may return `ok:false` with a cancellation warning).
+
 ## Current limitations
 
 - The event stream currently returns a status/log snapshot rather than an infinite stream.
@@ -205,7 +208,7 @@ TM entries are persisted in project JSON as `translation_memory` and include `so
 Phase 4 now exposes profile-aware translation QA endpoints:
 
 - `POST /translation_prompt_profiles` → available profile IDs + current default
-- `POST /translation_qa_report` with optional `page`, `profile`, `retry_issue_threshold`
+- `POST /translation_qa_report` with optional `page`, `profile`, `retry_issue_threshold`, `repetition_threshold`, `untranslated_ratio_threshold` (adds repetition/source-carry QA signals and retry candidates).
 
 The QA report returns per-block issues and `retry_candidates` so automation can optionally re-run poor-quality blocks.
 
@@ -216,6 +219,8 @@ Phase 5 editor UX now includes previewable batch find/replace routes:
 
 - `POST /batch_find_replace_preview` with `pattern`, `replacement`, optional `pages`, `use_regex`, `case_sensitive`
 - `POST /batch_find_replace_apply` with either the same fields or a prior `preview` payload
+- `POST /auto_format_textboxes` with optional `{mode:"page"|"selected", indices, profile:"balanced"|"comfortable"|"dense"|"caption"|"sfx"}` to run smart-fit plus atomic bubble-fit rescue for uneven/overflowing text.
+- `POST /auto_format_qa_preview` with optional `{mode:"page"|"selected", profile, only_risky}` returns per-block before/after auto-format scores and summary metrics for live QA tooling.
 
 `preview` returns match samples without mutating the project; `apply` mutates translations and returns changed rows.
 
@@ -256,6 +261,7 @@ Phase 5 editor UX now includes previewable batch find/replace routes:
 
 - `POST /data_path_status` with optional `{path, min_free_gb}` returns resolved path, existence, free space, and threshold check.
 - `POST /data_path_migrate` with `{source, dest, dry_run=true}` previews or performs data-path migration for top-level entries.
+- `POST /batch_parent_summary` with `{state_path}` returns status counts and next pending child for resumable parent queues.
 
 
 ## Docker / server mode quickstart
@@ -280,3 +286,16 @@ Typical container mount hints from the payload:
 ## Import translated image alignment API
 
 - `POST /import_translated_image_align` with `{page, translated_image, min_iou?}` detects/OCRs the translated image and maps translations back to raw blocks by IoU.
+
+## SFX dictionary and glossary extraction API
+
+Phase 4 now also exposes SFX dictionary and glossary-candidate extraction routes:
+
+- `POST /sfx_dictionary_query` with `{query, limit=50, include_defaults=true}`
+- `POST /sfx_dictionary_import` with `{path}` (JSON/CSV)
+- `POST /sfx_dictionary_export` with optional `{format:"json"|"csv", path}`
+- `POST /glossary_extract_candidates` with optional `{min_freq=2}`
+- `POST /glossary_extract_apply` with `{candidates:[{source,target,approved}]}`
+- `POST /renderer_backend_probe` returns optional shaping backend capability, install hints, and platform diagnostics (alias of `renderer_diagnostics`).
+
+`glossary_extract_apply` is non-destructive: only approved, non-duplicate terms are merged into `translation_glossary`.

--- a/tests/test_archive_stream_export.py
+++ b/tests/test_archive_stream_export.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from utils.archive_stream_export import write_archive_streaming
+
+
+def test_archive_streaming_writes_progress_and_archive(tmp_path: Path):
+    src = tmp_path / 'src'
+    src.mkdir()
+    (src / 'a.txt').write_text('a', encoding='utf-8')
+    (src / 'b.txt').write_text('b', encoding='utf-8')
+    out = tmp_path / 'out.zip'
+    rst = write_archive_streaming(str(src), str(out))
+    assert out.exists()
+    assert rst['written_files'] == 2
+    assert rst['progress_events'][-1]['progress'] == 1.0
+
+
+def test_archive_streaming_can_cancel(tmp_path: Path):
+    src = tmp_path / 'src2'
+    src.mkdir()
+    for i in range(4):
+        (src / f'{i}.txt').write_text(str(i), encoding='utf-8')
+    out = tmp_path / 'out2.zip'
+    called = {'n': 0}
+
+    def cancel_check():
+        called['n'] += 1
+        return called['n'] > 2
+
+    rst = write_archive_streaming(str(src), str(out), cancel_check=cancel_check)
+    assert rst['cancelled'] is True
+    assert rst['written_files'] < rst['total_files']
+
+
+def test_archive_streaming_progress_hook_receives_events(tmp_path: Path):
+    src = tmp_path / 'src3'
+    src.mkdir()
+    (src / 'a.txt').write_text('a', encoding='utf-8')
+    (src / 'b.txt').write_text('b', encoding='utf-8')
+    out = tmp_path / 'out3.zip'
+    events = []
+    rst = write_archive_streaming(str(src), str(out), progress_hook=lambda ev: events.append(ev))
+    assert rst['written_files'] == 2
+    assert len(events) == 2
+    assert events[-1]['progress'] == 1.0

--- a/tests/test_auto_format_qa.py
+++ b/tests/test_auto_format_qa.py
@@ -1,0 +1,21 @@
+from types import SimpleNamespace
+
+from utils.fontformat import FontFormat
+from utils.auto_format_qa import score_auto_format_candidates, summarize_auto_format_scores
+
+
+def test_auto_format_qa_scores_rows():
+    blk = SimpleNamespace(
+        xyxy=[0, 0, 120, 60],
+        translation='This is a long line that usually needs balancing for comic bubbles',
+        get_text=lambda: 'src',
+        fontformat=FontFormat(font_size=24, writing_mode='horizontal_ltr', fit_mode='shrink', line_break_strategy='balanced'),
+    )
+    rows = score_auto_format_candidates([blk], profile='balanced')
+    assert len(rows) == 1
+    assert rows[0]['index'] == 0
+    assert 'before_score' in rows[0]
+    assert 'after_score' in rows[0]
+    summary = summarize_auto_format_scores(rows)
+    assert summary['count'] == 1
+    assert 'avg_delta' in summary

--- a/tests/test_batch_parent_queue.py
+++ b/tests/test_batch_parent_queue.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child
+from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child, summarize_parent_batch_state
 
 
 def test_enumerate_child_projects_collects_dirs_and_archives(tmp_path: Path):
@@ -42,3 +42,19 @@ def test_parent_state_load_update_and_next_pending(tmp_path: Path):
         assert nxt is None
     else:
         assert nxt is not None
+
+
+def test_parent_state_summary_counts(tmp_path: Path):
+    root = tmp_path / 'root'
+    (root / 'ch1').mkdir(parents=True)
+    (root / 'ch1' / '001.png').write_bytes(b'x')
+    children = enumerate_child_projects(str(root))
+    state_path = tmp_path / 'state.json'
+    save_parent_batch_state(str(state_path), str(root), children)
+    loaded = load_parent_batch_state(str(state_path))
+    first = loaded['children'][0]['input_path']
+    update_parent_batch_status(str(state_path), first, 'done')
+    loaded2 = load_parent_batch_state(str(state_path))
+    summary = summarize_parent_batch_state(loaded2)
+    assert summary['total'] == len(loaded2['children'])
+    assert summary['counts']['done'] >= 1

--- a/tests/test_cleanup_only_workflow.py
+++ b/tests/test_cleanup_only_workflow.py
@@ -42,3 +42,5 @@ def test_cleanup_only_returns_mask_policy(tmp_path):
     proj = P(tmp_path)
     rst = run_cleanup_only_pages(proj, D(), I(), ['001.png'], out_dir=str(tmp_path / 'out2'))
     assert rst['mask_policy']['outside_radius'] >= rst['mask_policy']['inside_radius']
+    assert isinstance(rst['halo_stats'], list)
+    assert rst['halo_stats'][0]['page'] == '001.png'

--- a/tests/test_export_manifest.py
+++ b/tests/test_export_manifest.py
@@ -68,3 +68,20 @@ def test_export_manifest_includes_renderer_info(tmp_path):
     project = Project()
     manifest = write_export_manifest(project, str(out), [("p1.png", str(page))], [], options={"renderer": {"default_renderer": "qt", "advanced_backend_available": False}})
     assert manifest["renderer"]["default_renderer"] == "qt"
+    assert manifest["pages"][0]["renderer_used"] == "qt"
+
+
+def test_export_manifest_warns_when_advanced_requested_but_unavailable(tmp_path):
+    out = tmp_path / "out"
+    page = out / "001.png"
+    out.mkdir()
+    page.write_bytes(b"x")
+    project = Project()
+    manifest = write_export_manifest(
+        project,
+        str(out),
+        [("p1.png", str(page))],
+        [],
+        options={"renderer": {"default_renderer": "qt", "advanced_backend_available": False}, "requested_advanced_renderer": True},
+    )
+    assert any("Advanced renderer was requested" in w for w in manifest["warnings"])

--- a/tests/test_glossary_extraction.py
+++ b/tests/test_glossary_extraction.py
@@ -1,0 +1,9 @@
+from utils.glossary_extraction import extract_glossary_candidates
+
+
+def test_extract_glossary_candidates_recurring_terms():
+    rows = extract_glossary_candidates(['Alice used Fireball', 'Alice cast Fireball again', 'Bob watched'], min_freq=2)
+    terms = {r['source']: r for r in rows}
+    assert 'Alice' in terms
+    assert 'Fireball' in terms
+    assert terms['Alice']['frequency'] == 2

--- a/tests/test_renderer_diagnostics.py
+++ b/tests/test_renderer_diagnostics.py
@@ -5,4 +5,7 @@ def test_renderer_diagnostics_shape():
     d = collect_renderer_diagnostics()
     assert d['default_renderer'] == 'qt'
     assert 'optional_modules' in d
+    assert 'features' in d
+    assert 'install_hints' in d
+    assert 'platform' in d
     assert 'warnings' in d

--- a/tests/test_sfx_dictionary.py
+++ b/tests/test_sfx_dictionary.py
@@ -1,0 +1,17 @@
+from utils.sfx_dictionary import default_sfx_dictionary, query_sfx_dictionary, merge_sfx_entries
+
+
+def test_sfx_query_hits_defaults():
+    rows = default_sfx_dictionary()
+    hits = query_sfx_dictionary(rows, 'bang')
+    assert hits
+    assert hits[0]['target'] == 'BANG'
+
+
+def test_sfx_merge_updates_and_adds():
+    existing = [{'source': 'バン', 'target': 'BANG', 'style': 'impact'}]
+    incoming = [{'source': 'バン', 'target': 'BOOM', 'style': 'impact'}, {'source': 'ギラ', 'target': 'GLINT', 'style': 'fx'}]
+    out = merge_sfx_entries(existing, incoming)
+    assert out['updated'] == 1
+    assert out['added'] == 1
+    assert any(r['target'] == 'BOOM' for r in out['entries'])

--- a/tests/test_smart_text_formatting.py
+++ b/tests/test_smart_text_formatting.py
@@ -1,0 +1,29 @@
+from utils.text_rendering import smart_fit_text_to_box
+
+
+def test_smart_fit_rebalances_long_text_for_narrow_box():
+    text = "This is a very long sentence that should be wrapped more evenly across lines for comic bubbles"
+    rst = smart_fit_text_to_box(
+        text=text,
+        font_size=24,
+        box_size=(120, 70),
+        writing_mode='horizontal_ltr',
+        fit_mode='shrink',
+        line_break_strategy='balanced',
+    )
+    assert isinstance(rst.text, str)
+    assert '\n' in rst.text
+    assert any(a in rst.actions for a in ['balance_lines', 'rebalance_for_overflow', 'shrink_to_fit'])
+
+
+def test_smart_fit_keeps_vertical_mode_for_cjk_vertical_boxes():
+    rst = smart_fit_text_to_box(
+        text='第12話!? 魔王復活',
+        font_size=24,
+        box_size=(60, 180),
+        writing_mode='auto',
+        fit_mode='shrink',
+        line_break_strategy='cjk_strict',
+    )
+    assert rst.resolved_writing_mode in {'vertical_rl', 'horizontal_ltr', 'rtl'}
+    assert rst.diagnostics.get('fit') is not None

--- a/tests/test_structured_ocr_export.py
+++ b/tests/test_structured_ocr_export.py
@@ -18,6 +18,7 @@ class Block:
     label = "speech"
     confidence = 0.75
     fontformat = FontFormat(font_family="Arial", font_size=24, alignment=1)
+    api_block_id = "tbx_abc123"
 
     def get_text(self):
         return "こんにちは"
@@ -46,6 +47,8 @@ def test_structured_ocr_export_contains_page_block_geometry_and_font():
     assert page["blocks"][0]["source_text"] == "こんにちは"
     assert page["blocks"][0]["font"]["alignment"] == 1
     assert page["blocks"][0]["xyxy"] == [1.0, 2.0, 30.0, 40.0]
+    assert page["blocks"][0]["block_id"] == "tbx_abc123"
+    assert page["blocks"][0]["order_label"] == "1.1"
 
 
 def test_structured_ocr_export_can_sort_blocks_by_reading_order():

--- a/tests/test_translation_qa_profiles.py
+++ b/tests/test_translation_qa_profiles.py
@@ -22,3 +22,19 @@ def test_qa_report_retry_candidates_by_issue_count():
     blocks = [B('alpha beta', 'alpha beta alpha beta alpha beta alpha beta')]
     report = build_translation_qa_report(blocks, glossary=[{'source': 'alpha', 'target': '阿尔法'}], profile='dialogue', retry_issue_threshold=2)
     assert report['retry_candidates'] == [0]
+
+
+def test_qa_report_detects_repetition_and_carryover_ratios():
+    blocks = [B('hero attacks now', 'hero hero hero hero hero')]
+    report = build_translation_qa_report(
+        blocks,
+        glossary=[],
+        profile='dialogue',
+        retry_issue_threshold=1,
+        repetition_threshold=0.4,
+        untranslated_ratio_threshold=0.6,
+    )
+    row = report['rows'][0]
+    assert row['repetition_ratio'] >= 0.4
+    assert row['source_carry_ratio'] >= 0.6
+    assert report['retry_candidates'] == [0]

--- a/ui/auto_format_qa_widget.py
+++ b/ui/auto_format_qa_widget.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QLabel, QTableWidget, QTableWidgetItem, QPushButton, QHBoxLayout, QComboBox, QCheckBox
+
+from utils.auto_format_qa import score_auto_format_candidates, summarize_auto_format_scores
+from utils.renderer_diagnostics import collect_renderer_diagnostics
+
+
+class AutoFormatQADialog(QDialog):
+    def __init__(self, parent, block_items, apply_callback):
+        super().__init__(parent)
+        self._block_items = list(block_items or [])
+        self._apply_callback = apply_callback
+        self.setWindowTitle(self.tr('Auto-format QA (Before/After)'))
+        self.resize(920, 520)
+
+        lay = QVBoxLayout(self)
+        self.hint = QLabel(self)
+        self.hint.setWordWrap(True)
+        lay.addWidget(self.hint)
+
+        ctl = QHBoxLayout()
+        self.profile = QComboBox(self)
+        for p in ('balanced', 'comfortable', 'dense', 'caption', 'sfx'):
+            self.profile.addItem(p, p)
+        ctl.addWidget(QLabel(self.tr('Profile:'), self))
+        ctl.addWidget(self.profile)
+        self.refresh_btn = QPushButton(self.tr('Refresh Preview'), self)
+        self.only_risky = QCheckBox(self.tr('Only risky/improvable'), self)
+        self.apply_all_btn = QPushButton(self.tr('Apply to All Listed'), self)
+        ctl.addWidget(self.refresh_btn)
+        ctl.addWidget(self.only_risky)
+        ctl.addWidget(self.apply_all_btn)
+        ctl.addStretch(1)
+        lay.addLayout(ctl)
+
+        self.table = QTableWidget(self)
+        self.table.setColumnCount(8)
+        self.table.setHorizontalHeaderLabels([
+            self.tr('Idx'), self.tr('Text preview'), self.tr('Before score'), self.tr('After score'),
+            self.tr('Δ score'), self.tr('Before overflow'), self.tr('After overflow'), self.tr('After actions')
+        ])
+        lay.addWidget(self.table)
+
+        self.refresh_btn.clicked.connect(self.refresh)
+        self.apply_all_btn.clicked.connect(self.apply_all)
+        self.profile.currentIndexChanged.connect(self.refresh)
+        self.only_risky.clicked.connect(self.refresh)
+
+        self.refresh()
+
+    def refresh(self):
+        profile = str(self.profile.currentData() or 'balanced')
+        rows = score_auto_format_candidates([getattr(x, 'blk', None) for x in self._block_items], profile=profile)
+        if self.only_risky.isChecked():
+            rows = [r for r in rows if bool(r.get('before_overflow')) or float(r.get('improvement', 0.0) or 0.0) > 0.04]
+        summary = summarize_auto_format_scores(rows)
+        self.table.setRowCount(len(rows))
+        for r, row in enumerate(rows):
+            vals = [
+                str(row.get('index', '')),
+                str(row.get('text_preview', '')),
+                f"{float(row.get('before_score', 0.0)):.3f}",
+                f"{float(row.get('after_score', 0.0)):.3f}",
+                f"{float(row.get('improvement', 0.0)):+.3f}",
+                'Y' if row.get('before_overflow') else 'N',
+                'Y' if row.get('after_overflow') else 'N',
+                ', '.join(row.get('after_actions', []) or []),
+            ]
+            for c, v in enumerate(vals):
+                self.table.setItem(r, c, QTableWidgetItem(v))
+        self.table.resizeColumnsToContents()
+
+        d = collect_renderer_diagnostics()
+        self.setWindowTitle(self.tr('Auto-format QA (Before/After) - {0} blocks, improved {1}').format(summary.get('count', 0), summary.get('improved_count', 0)))
+        if not d.get('advanced_backend_available', False):
+            hints = ', '.join(d.get('install_hints', [])[:3])
+            self.hint.setText(self.tr('Advanced shaping backend is unavailable on this environment. Auto-format preview still works with Qt fallback. Suggested installs: {0}').format(hints))
+        else:
+            self.hint.setText(self.tr('Advanced shaping backend available. Scores reflect current layout heuristics and can be applied directly.'))
+
+    def apply_all(self):
+        profile = str(self.profile.currentData() or 'balanced')
+        indices = [int(getattr(item, 'idx', -1)) for item in self._block_items if int(getattr(item, 'idx', -1)) >= 0]
+        if self._apply_callback is not None:
+            self._apply_callback(indices, profile)
+        self.accept()

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -72,6 +72,7 @@ from .project_ops_dialog import ProjectOpsDialog
 from .reading_order_editor_dialog import ReadingOrderEditorDialog
 from .layout_review_report_dialog import LayoutReviewReportDialog
 from .lettering_workflow_dialog import LetteringWorkflowDialog
+from .auto_format_qa_widget import AutoFormatQADialog
 from utils.fontformat import pt2px
 from utils.image_colorization import apply_colorization
 from utils.structured_ocr_export import build_structured_ocr_export
@@ -86,12 +87,16 @@ from utils.cleanup_only_workflow import run_cleanup_only_pages
 from utils.data_path_manager import describe_data_path, migrate_data_path
 from utils.server_mode_info import build_server_mode_info
 from utils.translated_image_alignment import align_translations_by_iou
-from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child
+from utils.batch_parent_queue import enumerate_child_projects, save_parent_batch_state, load_parent_batch_state, update_parent_batch_status, next_pending_child, summarize_parent_batch_state
 from utils.glossary_io import export_glossary_csv, import_glossary_csv, preview_glossary_merge
+from utils.sfx_dictionary import default_sfx_dictionary, query_sfx_dictionary, merge_sfx_entries, export_sfx_dictionary, import_sfx_dictionary
+from utils.glossary_extraction import extract_glossary_candidates
 from utils.batch_find_replace import preview_batch_find_replace, apply_batch_find_replace
 from utils.layered_psd_export import build_layered_psd_handoff
 from utils.svg_text_export import build_svg_text_handoff
 from utils.lettering_proof_export import build_lettering_proof_pack
+from utils.archive_stream_export import write_archive_streaming
+from utils.auto_format_qa import score_auto_format_candidates, summarize_auto_format_scores
 from utils.text_rendering import locale_aware_upper
 from utils.local_automation_api import LocalAutomationApiServer
 from utils.automation_api_contract import normalize_job_task
@@ -927,16 +932,23 @@ class MainWindow(mainwindow_cls):
             'glossary_export': self._api_glossary_export,
             'glossary_import': self._api_glossary_import,
             'glossary_import_preview': self._api_glossary_import_preview,
+            'sfx_dictionary_query': self._api_sfx_dictionary_query,
+            'sfx_dictionary_import': self._api_sfx_dictionary_import,
+            'sfx_dictionary_export': self._api_sfx_dictionary_export,
+            'glossary_extract_candidates': self._api_glossary_extract_candidates,
+            'glossary_extract_apply': self._api_glossary_extract_apply,
             'ocr_rerun_block': self._api_ocr_rerun_block,
             'ocr_compare_block': self._api_ocr_compare_block,
             'ocr_apply_compare_choice': self._api_ocr_apply_compare_choice,
             'renderer_diagnostics': self._api_renderer_diagnostics,
+            'renderer_backend_probe': self._api_renderer_diagnostics,
             'cleanup_only': self._api_cleanup_only,
             'batch_parent_enumerate': self._api_batch_parent_enumerate,
             'batch_parent_save_state': self._api_batch_parent_save_state,
             'batch_parent_load_state': self._api_batch_parent_load_state,
             'batch_parent_update_status': self._api_batch_parent_update_status,
             'batch_parent_next_pending': self._api_batch_parent_next_pending,
+            'batch_parent_summary': self._api_batch_parent_summary,
             'data_path_status': self._api_data_path_status,
             'data_path_migrate': self._api_data_path_migrate,
             'server_mode_info': self._api_server_mode_info,
@@ -949,6 +961,8 @@ class MainWindow(mainwindow_cls):
             'rendering_presets': self._api_rendering_presets,
             'fix_rendering_issues': self._api_fix_rendering_issues,
             'smart_fit_textboxes': self._api_smart_fit_textboxes,
+            'auto_format_textboxes': self._api_auto_format_textboxes,
+            'auto_format_qa_preview': self._api_auto_format_qa_preview,
             'atomic_bubble_fit': self._api_atomic_bubble_fit,
             'polish_typography': self._api_polish_typography,
             'export_rendering_qa': self._api_export_rendering_qa,
@@ -1003,7 +1017,7 @@ class MainWindow(mainwindow_cls):
     def _api_job_start(self, body: dict):
         task = normalize_job_task(str((body or {}).get('task', '') or ''))
         payload = dict((body or {}).get('payload') or {})
-        job_id = f"job_{int(time.time() * 1000)}_{threading.get_ident()}"
+        payload['__job_id'] = job_id = f"job_{int(time.time() * 1000)}_{threading.get_ident()}"
         job = new_job(job_id, task)
         with self._api_jobs_lock:
             self._api_jobs[job_id] = job
@@ -1289,6 +1303,16 @@ class MainWindow(mainwindow_cls):
         nxt = next_pending_child(payload)
         return {'ok': True, 'state_path': state_path, 'next_pending': nxt, 'has_pending': nxt is not None}
 
+    def _api_batch_parent_summary(self, body: dict):
+        return self._api_call_ui(self._api_batch_parent_summary_ui, body)
+
+    def _api_batch_parent_summary_ui(self, body: dict):
+        state_path = str((body or {}).get('state_path', '') or '').strip()
+        if not state_path:
+            raise ValueError('state_path is required')
+        payload = load_parent_batch_state(state_path)
+        return {'ok': True, 'state_path': state_path, 'summary': summarize_parent_batch_state(payload)}
+
     def _api_server_mode_info(self, body: dict):
         return self._api_call_ui(self._api_server_mode_info_ui, body)
 
@@ -1468,7 +1492,7 @@ class MainWindow(mainwindow_cls):
             self.pipelineInsightsPanel.add_event('API', self.tr('Batch export via API: {0} page(s)').format(result.get('exported', 0)))
             return {'ok': True, **(result or {})}
         if kind in {'archive', 'zip', 'cbz'}:
-            import tempfile, zipfile
+            import tempfile
             archive_format = 'cbz' if kind == 'cbz' or str((body or {}).get('archive_format', '')).lower() == 'cbz' else 'zip'
             archive_path = str((body or {}).get('archive_path', '') or '').strip()
             out_dir = str((body or {}).get('out_dir', '') or '').strip()
@@ -1487,13 +1511,31 @@ class MainWindow(mainwindow_cls):
             if not archive_path:
                 archive_path = osp.join(self.imgtrans_proj.directory, 'exports', ('exported.cbz' if archive_format == 'cbz' else 'exported.zip'))
             os.makedirs(osp.dirname(archive_path), exist_ok=True)
-            with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-                for root, _dirs, files in os.walk(out_dir):
-                    for fn in sorted(files):
-                        fp = osp.join(root, fn)
-                        zf.write(fp, osp.relpath(fp, out_dir))
+            job_id = str((body or {}).get('__job_id', '') or '').strip()
+
+            def _cancel_check() -> bool:
+                if not job_id:
+                    return False
+                with self._api_jobs_lock:
+                    j = self._api_jobs.get(job_id)
+                    return bool(j and j.get('cancel_requested'))
+
+            def _progress_hook(ev: dict):
+                if not job_id:
+                    return
+                with self._api_jobs_lock:
+                    j = self._api_jobs.get(job_id)
+                    if not j:
+                        return
+                    p = float((ev or {}).get('progress', 0.0) or 0.0)
+                    set_status(j, 'running', stage='archive_stream', progress=min(0.99, 0.45 + p * 0.5))
+                    append_log(j, f"archive {int((ev or {}).get('index', 0))}/{int((ev or {}).get('total', 0))}: {(ev or {}).get('relative_path', '')}")
+
+            stream_result = write_archive_streaming(out_dir, archive_path, cancel_check=_cancel_check if job_id else None, progress_hook=_progress_hook if job_id else None)
             self.pipelineInsightsPanel.add_event('API', self.tr('Archive export via API: {0}').format(archive_path))
-            return {'ok': True, 'archive_path': archive_path, 'archive_format': archive_format, **(result or {})}
+            if stream_result.get('cancelled'):
+                return {'ok': False, 'archive_path': archive_path, 'archive_format': archive_format, 'archive_stream': stream_result, 'warnings': ['archive export cancelled'], **(result or {})}
+            return {'ok': True, 'archive_path': archive_path, 'archive_format': archive_format, 'archive_stream': stream_result, **(result or {})}
         if kind in {'current_page', 'render_current_page'}:
             return self._api_render_current_page_ui(body)
         if kind in {'structured_ocr', 'ocr_json'}:
@@ -1884,6 +1926,45 @@ class MainWindow(mainwindow_cls):
             self.imgtrans_proj.save()
         return {'ok': True, 'page': self.imgtrans_proj.current_img, 'mode': mode, 'changed': changed, 'indices': indices}
 
+    def _api_auto_format_textboxes(self, body: dict):
+        return self._api_call_ui(self._api_auto_format_textboxes_ui, body)
+
+    def _api_auto_format_textboxes_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+            raise ValueError('open a project and select a page first')
+        mode = str((body or {}).get('mode', 'page') or 'page').strip().lower()
+        if mode == 'selected':
+            indices = [blk.idx for blk in self.canvas.selected_text_items()]
+        else:
+            indices = [blk.idx for blk in getattr(self.st_manager, 'textblk_item_list', [])]
+        explicit = (body or {}).get('indices')
+        if explicit is not None:
+            indices = [int(i) for i in explicit]
+        profile = str((body or {}).get('profile', 'balanced') or 'balanced')
+        changed = self.st_manager.auto_format_textboxes(indices=indices, push_undo=False, profile=profile)
+        if changed and self.imgtrans_proj and self.imgtrans_proj.directory:
+            self.imgtrans_proj.save()
+        self.pipelineInsightsPanel.add_event('API', self.tr('Auto text formatting updated {0} text boxes').format(changed))
+        return {'ok': True, 'page': self.imgtrans_proj.current_img, 'mode': mode, 'changed': changed, 'indices': indices, 'profile': profile}
+
+    def _api_auto_format_qa_preview(self, body: dict):
+        return self._api_call_ui(self._api_auto_format_qa_preview_ui, body)
+
+    def _api_auto_format_qa_preview_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+            raise ValueError('open a project and select a page first')
+        mode = str((body or {}).get('mode', 'page') or 'page').strip().lower()
+        only_risky = bool((body or {}).get('only_risky', False))
+        if mode == 'selected':
+            block_items = self.canvas.selected_text_items()
+        else:
+            block_items = list(getattr(self.st_manager, 'textblk_item_list', []) or [])
+        profile = str((body or {}).get('profile', 'balanced') or 'balanced')
+        rows = score_auto_format_candidates([getattr(x, 'blk', None) for x in block_items], profile=profile)
+        if only_risky:
+            rows = [r for r in rows if bool(r.get('before_overflow')) or float(r.get('improvement', 0.0) or 0.0) > 0.04]
+        return {'ok': True, 'page': self.imgtrans_proj.current_img, 'mode': mode, 'profile': profile, 'rows': rows, 'summary': summarize_auto_format_scores(rows)}
+
     def _api_fix_rendering_issues(self, body: dict):
         return self._api_call_ui(self._api_fix_rendering_issues_ui, body)
 
@@ -2273,6 +2354,82 @@ class MainWindow(mainwindow_cls):
     def _api_translation_prompt_profiles(self, body: dict):
         return {'ok': True, 'profiles': sorted(PROMPT_PROFILES.keys()), 'default': getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue')}
 
+    def _api_sfx_dictionary_query(self, body: dict):
+        return self._api_call_ui(self._api_sfx_dictionary_query_ui, body)
+
+    def _api_sfx_dictionary_query_ui(self, body: dict):
+        query = str((body or {}).get('query', '') or '')
+        limit = int((body or {}).get('limit', 50) or 50)
+        include_defaults = bool((body or {}).get('include_defaults', True))
+        store = list(getattr(self.imgtrans_proj, 'sfx_dictionary', []) or [])
+        rows = (default_sfx_dictionary() + store) if include_defaults else store
+        hits = query_sfx_dictionary(rows, query, limit=limit)
+        return {'ok': True, 'count': len(hits), 'results': hits}
+
+    def _api_sfx_dictionary_import(self, body: dict):
+        return self._api_call_ui(self._api_sfx_dictionary_import_ui, body)
+
+    def _api_sfx_dictionary_import_ui(self, body: dict):
+        in_path = str((body or {}).get('path', '') or '').strip()
+        if not in_path:
+            raise ValueError('missing_path')
+        incoming = import_sfx_dictionary(in_path)
+        store = list(getattr(self.imgtrans_proj, 'sfx_dictionary', []) or [])
+        merged = merge_sfx_entries(store, incoming)
+        self.imgtrans_proj.sfx_dictionary = merged['entries']
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'added': merged['added'], 'updated': merged['updated'], 'count': merged['count']}
+
+    def _api_sfx_dictionary_export(self, body: dict):
+        return self._api_call_ui(self._api_sfx_dictionary_export_ui, body)
+
+    def _api_sfx_dictionary_export_ui(self, body: dict):
+        fmt = str((body or {}).get('format', 'json') or 'json').strip().lower()
+        out_path = str((body or {}).get('path', '') or '').strip()
+        if not out_path:
+            base = self.imgtrans_proj.directory if self.imgtrans_proj is not None else os.getcwd()
+            out_path = osp.join(base, 'sfx_dictionary.csv' if fmt == 'csv' else 'sfx_dictionary.json')
+        entries = list(getattr(self.imgtrans_proj, 'sfx_dictionary', []) or [])
+        count = export_sfx_dictionary(entries, out_path, fmt=fmt)
+        return {'ok': True, 'path': out_path, 'count': int(count), 'format': fmt}
+
+    def _api_glossary_extract_candidates(self, body: dict):
+        return self._api_call_ui(self._api_glossary_extract_candidates_ui, body)
+
+    def _api_glossary_extract_candidates_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        min_freq = int((body or {}).get('min_freq', 2) or 2)
+        texts = []
+        for _page, blks in (self.imgtrans_proj.pages or {}).items():
+            for blk in blks or []:
+                texts.append((getattr(blk, 'get_text', lambda: '')() or '').strip())
+        rows = extract_glossary_candidates(texts, min_freq=min_freq)
+        return {'ok': True, 'count': len(rows), 'candidates': rows}
+
+    def _api_glossary_extract_apply(self, body: dict):
+        return self._api_call_ui(self._api_glossary_extract_apply_ui, body)
+
+    def _api_glossary_extract_apply_ui(self, body: dict):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty:
+            raise ValueError('open a project first')
+        candidates = list((body or {}).get('candidates', []) or [])
+        approved = []
+        for row in candidates:
+            if bool((row or {}).get('approved', True)):
+                src = str((row or {}).get('source', '') or '').strip()
+                if src:
+                    approved.append({'source': src, 'target': str((row or {}).get('target', '') or '').strip()})
+        store = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
+        seen = {str((r or {}).get('source', '') or '').strip() for r in store}
+        for row in approved:
+            if row['source'] not in seen:
+                store.append(row)
+                seen.add(row['source'])
+        self.imgtrans_proj.translation_glossary = store
+        self.canvas.setProjSaveState(True)
+        return {'ok': True, 'applied': len(approved), 'result_count': len(store)}
+
     def _api_translation_qa_report(self, body: dict):
         return self._api_call_ui(self._api_translation_qa_report_ui, body)
 
@@ -2285,8 +2442,17 @@ class MainWindow(mainwindow_cls):
         blocks = list((self.imgtrans_proj.pages or {}).get(page, []) or [])
         profile = str((body or {}).get('profile', '') or getattr(pcfg.module, 'translation_prompt_profile_default', 'dialogue') or 'dialogue')
         retry_threshold = int((body or {}).get('retry_issue_threshold', getattr(pcfg.module, 'translation_qa_retry_issue_threshold', 2)) or 2)
+        repetition_threshold = float((body or {}).get('repetition_threshold', 0.45) or 0.45)
+        untranslated_ratio_threshold = float((body or {}).get('untranslated_ratio_threshold', 0.85) or 0.85)
         glossary = list(getattr(self.imgtrans_proj, 'translation_glossary', []) or [])
-        report = build_translation_qa_report(blocks, glossary, profile=profile, retry_issue_threshold=retry_threshold)
+        report = build_translation_qa_report(
+            blocks,
+            glossary,
+            profile=profile,
+            retry_issue_threshold=retry_threshold,
+            repetition_threshold=repetition_threshold,
+            untranslated_ratio_threshold=untranslated_ratio_threshold,
+        )
         report['page'] = page
         return {'ok': True, 'report': report}
 
@@ -3298,6 +3464,8 @@ class MainWindow(mainwindow_cls):
         self.titleBar.layout_review_page_trigger.connect(self.shortcutLayoutReviewPage)
         self.titleBar.layout_review_config_trigger.connect(self.shortcutLayoutReviewConfig)
         self.titleBar.lettering_workflow_trigger.connect(self.on_lettering_workflow_current_page)
+        if hasattr(self.titleBar, 'auto_format_qa_trigger'):
+            self.titleBar.auto_format_qa_trigger.connect(self.on_open_auto_format_qa)
         self.titleBar.next_rendering_issue_trigger.connect(self.on_next_rendering_issue)
         self.titleBar.show_model_download_diag_trigger.connect(self.on_show_model_download_diagnostics)
         self.titleBar.copy_startup_diag_trigger.connect(self.on_copy_startup_diagnostics)
@@ -6488,6 +6656,25 @@ class MainWindow(mainwindow_cls):
     def on_lettering_workflow_current_page(self):
         self.on_lettering_workflow_pages(self._selected_page_names())
 
+    def on_open_auto_format_qa(self):
+        if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
+            create_info_dialog({'title': self.tr('Auto-format QA'), 'text': self.tr('Open a project and select a page first.')})
+            return
+        selected = self.canvas.selected_text_items()
+        block_items = selected if selected else list(getattr(self.st_manager, 'textblk_item_list', []) or [])
+        if not block_items:
+            create_info_dialog({'title': self.tr('Auto-format QA'), 'text': self.tr('No text boxes on current page.')})
+            return
+
+        def _apply(indices, profile):
+            changed = self.st_manager.auto_format_textboxes(indices=indices, push_undo=True, profile=profile)
+            if changed and self.imgtrans_proj and self.imgtrans_proj.directory:
+                self.imgtrans_proj.save()
+            self.pipelineInsightsPanel.add_event('TYPO_QA', self.tr('Auto-format QA applied changes to {0} text box(es)').format(changed))
+
+        dlg = AutoFormatQADialog(self, block_items, _apply)
+        dlg.exec()
+
     def on_lettering_workflow_pages(self, page_names: List[str] = None):
         if self.imgtrans_proj is None or self.imgtrans_proj.is_empty or not self.imgtrans_proj.current_img:
             create_info_dialog({'title': self.tr('Lettering workflow'), 'text': self.tr('Open a project and select a page first.')})
@@ -7929,4 +8116,3 @@ class MainWindow(mainwindow_cls):
             create_info_dialog({'title': self.tr('Glossary import'), 'text': self.tr('Added entries: {0} (total: {1})').format(rst.get('added', 0), rst.get('entries', 0))})
         except Exception as e:
             create_error_dialog(e, self.tr('Failed to import glossary'))
-

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -761,6 +761,9 @@ class TitleBar(Widget):
         letteringWorkflowAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'menu_text_style.svg')), self.tr('Lettering workflow...'), self)
         letteringWorkflowAction.setToolTip(self.tr('Plan/apply typography polish, smart fit, layout review, proof export, and render steps for current, selected, or all pages.'))
         self.lettering_workflow_trigger = letteringWorkflowAction.triggered
+        autoFormatQaAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'search.svg')), self.tr('Auto-format QA (before/after)...'), self)
+        autoFormatQaAction.setToolTip(self.tr('Live preview per-block auto-format score before and after applying bubble-aware formatting.'))
+        self.auto_format_qa_trigger = autoFormatQaAction.triggered
 
         nextRenderingIssueAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'search-stop.svg')), self.tr('Next rendering issue'), self)
         nextRenderingIssueAction.setToolTip(self.tr('Select the next textbox with overflow, glyph, mask, or writing-mode warnings on the current page.'))
@@ -793,6 +796,7 @@ class TitleBar(Widget):
         projectMenu.addAction(layoutReviewPageAction)
         projectMenu.addAction(layoutReviewConfigAction)
         projectMenu.addAction(letteringWorkflowAction)
+        projectMenu.addAction(autoFormatQaAction)
         projectMenu.addAction(nextRenderingIssueAction)
         projectMenu.addSeparator()
         projectMenu.addAction(translationQaAction)
@@ -2068,4 +2072,3 @@ class BottomBar(Widget):
         self._run_btn_pulse_up.setEndValue(up_sz)
         self._run_btn_pulse_down.setStartValue(up_sz)
         self._run_btn_pulse_down.setEndValue(icon_sz)
-

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -1869,6 +1869,13 @@ class SceneTextManager(QObject):
                 self.mainwindow.pipelineInsightsPanel.add_event('TYPO_QA', self.tr('Auto lettering assist updated {0} text box(es)').format(changed))
         return changed
 
+    def auto_format_textboxes(self, indices: List[int] = None, push_undo: bool = True, profile: str = "balanced") -> int:
+        """High-level auto formatter: smart-fit first, then atomic bubble-fit rescue for difficult boxes."""
+        changed = self.smart_fit_textboxes(indices=indices, push_undo=push_undo)
+        # Follow up with atomic fit to smooth uneven lines / reduce overflow where smart-fit still struggles.
+        rescued = self.atomic_bubble_fit_textboxes(indices=indices, push_undo=False, profile=profile)
+        return int(changed) + int(rescued)
+
     def onAutoLetteringAssist(self):
         self.auto_lettering_assist_textboxes(indices=None, push_undo=True)
 

--- a/utils/archive_stream_export.py
+++ b/utils/archive_stream_export.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import os.path as osp
+import zipfile
+from typing import Callable, Dict, List, Tuple
+
+
+def collect_files(root_dir: str) -> List[Tuple[str, str]]:
+    out: List[Tuple[str, str]] = []
+    for root, _dirs, files in os.walk(root_dir):
+        for fn in sorted(files):
+            full = osp.join(root, fn)
+            rel = osp.relpath(full, root_dir)
+            out.append((full, rel))
+    return out
+
+
+def write_archive_streaming(
+    source_dir: str,
+    archive_path: str,
+    *,
+    cancel_check: Callable[[], bool] | None = None,
+    progress_hook: Callable[[Dict[str, object]], None] | None = None,
+) -> Dict[str, object]:
+    files = collect_files(source_dir)
+    os.makedirs(osp.dirname(archive_path) or '.', exist_ok=True)
+    total = len(files)
+    written = 0
+    progress: List[Dict[str, object]] = []
+    cancelled = False
+    with zipfile.ZipFile(archive_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+        for idx, (full, rel) in enumerate(files, start=1):
+            if cancel_check is not None and bool(cancel_check()):
+                cancelled = True
+                break
+            zf.write(full, rel)
+            written += 1
+            event = {'index': idx, 'total': total, 'relative_path': rel, 'progress': float(idx) / float(max(1, total))}
+            progress.append(event)
+            if progress_hook is not None:
+                try:
+                    progress_hook(dict(event))
+                except Exception:
+                    pass
+    return {
+        'archive_path': archive_path,
+        'source_dir': source_dir,
+        'total_files': total,
+        'written_files': written,
+        'cancelled': cancelled,
+        'progress_events': progress,
+    }

--- a/utils/auto_format_qa.py
+++ b/utils/auto_format_qa.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from utils.text_rendering import smart_fit_text_to_box, plan_atomic_bubble_fit
+
+
+def _block_text(block: Any) -> str:
+    return (getattr(block, 'translation', '') or getattr(block, 'get_text', lambda: '')() or '').strip()
+
+
+def score_auto_format_candidates(blocks: List[Any], *, profile: str = 'balanced') -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for idx, blk in enumerate(blocks or []):
+        ff = getattr(blk, 'fontformat', None)
+        if ff is None:
+            continue
+        xyxy = list(getattr(blk, 'xyxy', []) or [])
+        if len(xyxy) < 4:
+            continue
+        w = max(1.0, float(xyxy[2]) - float(xyxy[0]))
+        h = max(1.0, float(xyxy[3]) - float(xyxy[1]))
+        text = _block_text(blk)
+        if not text:
+            continue
+        before = smart_fit_text_to_box(
+            text=text,
+            font_size=float(getattr(ff, 'font_size', 24) or 24),
+            box_size=(w, h),
+            writing_mode=getattr(ff, 'writing_mode', 'auto'),
+            fit_mode=getattr(ff, 'fit_mode', 'shrink'),
+            line_spacing=float(getattr(ff, 'line_spacing', 1.15) or 1.15),
+            letter_spacing=float(getattr(ff, 'letter_spacing', 1.0) or 1.0),
+            padding=float(getattr(ff, 'text_padding', 0.0) or 0.0),
+            stroke_width=float(getattr(ff, 'stroke_width', 0.0) or 0.0),
+            secondary_stroke_width=float(getattr(ff, 'secondary_stroke_width', 0.0) or 0.0),
+            line_break_strategy=getattr(ff, 'line_break_strategy', 'auto'),
+        )
+        after = plan_atomic_bubble_fit(
+            text=text,
+            font_size=float(getattr(ff, 'font_size', 24) or 24),
+            box_size=(w, h),
+            writing_mode=getattr(ff, 'writing_mode', 'auto'),
+            fit_mode=getattr(ff, 'fit_mode', 'shrink'),
+            line_break_strategy=getattr(ff, 'line_break_strategy', 'auto'),
+            line_spacing=float(getattr(ff, 'line_spacing', 1.15) or 1.15),
+            letter_spacing=float(getattr(ff, 'letter_spacing', 1.0) or 1.0),
+            padding=float(getattr(ff, 'text_padding', 0.0) or 0.0),
+            stroke_width=float(getattr(ff, 'stroke_width', 0.0) or 0.0),
+            secondary_stroke_width=float(getattr(ff, 'secondary_stroke_width', 0.0) or 0.0),
+            profile=profile,
+        )
+        rows.append({
+            'index': idx,
+            'text_preview': text[:80],
+            'before_score': float(before.quality_score),
+            'after_score': float(after.quality_score),
+            'before_overflow': bool(before.overflow),
+            'after_overflow': bool(after.overflow),
+            'before_actions': list(before.actions or []),
+            'after_actions': list(after.actions or []),
+            'improvement': float(after.quality_score) - float(before.quality_score),
+        })
+    return rows
+
+
+def summarize_auto_format_scores(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+    rows = list(rows or [])
+    improved = [r for r in rows if float(r.get('improvement', 0.0) or 0.0) > 0.01]
+    overflow_before = sum(1 for r in rows if bool(r.get('before_overflow')))
+    overflow_after = sum(1 for r in rows if bool(r.get('after_overflow')))
+    return {
+        'count': len(rows),
+        'improved_count': len(improved),
+        'overflow_before': overflow_before,
+        'overflow_after': overflow_after,
+        'avg_delta': round(sum(float(r.get('improvement', 0.0) or 0.0) for r in rows) / max(1, len(rows)), 4),
+    }

--- a/utils/batch_parent_queue.py
+++ b/utils/batch_parent_queue.py
@@ -115,3 +115,18 @@ def next_pending_child(state_payload: dict) -> dict | None:
         if str((row or {}).get('status', 'pending') or 'pending') == 'pending':
             return dict(row)
     return None
+
+
+def summarize_parent_batch_state(state_payload: dict) -> dict:
+    rows = list((state_payload or {}).get('children') or [])
+    by_status: Dict[str, int] = {}
+    for row in rows:
+        st = str((row or {}).get('status', 'pending') or 'pending').strip() or 'pending'
+        by_status[st] = by_status.get(st, 0) + 1
+    return {
+        'format': str((state_payload or {}).get('format', '') or ''),
+        'parent_path': str((state_payload or {}).get('parent_path', '') or ''),
+        'total': len(rows),
+        'counts': by_status,
+        'next_pending': next_pending_child(state_payload),
+    }

--- a/utils/cleanup_only_workflow.py
+++ b/utils/cleanup_only_workflow.py
@@ -25,6 +25,8 @@ def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *
     warnings: List[str] = []
     processed = 0
     failed = 0
+    halo_flags: List[str] = []
+    halo_stats: List[Dict[str, object]] = []
     if out_dir:
         os.makedirs(out_dir, exist_ok=True)
     for page in pages:
@@ -34,6 +36,17 @@ def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *
             rect_mask = _build_rect_mask(blks or [], img.shape[1], img.shape[0])
             mask = merge_masks_with_confidence(rect_mask, det_mask, confidence=detector_confidence)
             mask = adaptive_mask_expand(mask, inside_radius=inside_radius, outside_radius=outside_radius)
+            try:
+                from modules.mask_diagnostics import build_mask_diagnostics
+                diag = build_mask_diagnostics(mask, threshold=127, dilate_iter=1) or {}
+                stats = (diag.get("stats") or {})
+            except Exception:
+                stats = {}
+            halo_ratio = float(stats.get("edge_halo_ratio", 0.0) or 0.0)
+            halo_stats.append({"page": page, "edge_halo_ratio": halo_ratio, "mask_fill_ratio": float(stats.get("mask_fill_ratio", 0.0) or 0.0)})
+            if halo_ratio >= float(halo_threshold):
+                halo_flags.append(page)
+                warnings.append(f"{page}: edge halo ratio {halo_ratio:.3f} >= threshold {float(halo_threshold):.3f}")
             clean = inpainter.inpaint(img, mask)
             project.save_inpainted(page, clean)
             if out_dir:
@@ -51,5 +64,7 @@ def run_cleanup_only_pages(project, detector, inpainter, pages: Iterable[str], *
         'failed': failed,
         'warnings': warnings,
         'exported': exported,
+        'halo_flags': halo_flags,
+        'halo_stats': halo_stats,
         'mask_policy': {'inside_radius': int(inside_radius), 'outside_radius': int(outside_radius), 'detector_confidence': float(detector_confidence)},
     }

--- a/utils/export_manifest.py
+++ b/utils/export_manifest.py
@@ -22,6 +22,7 @@ def build_export_manifest(
     pages = []
     for idx, (page_name, path) in enumerate(exported_paths or [], start=1):
         source_kind = str(export_sources.get(page_name, "rendered") or "rendered")
+        page_renderer = (options.get("page_renderers", {}) or {}).get(page_name, "")
         pages.append({
             "index": idx,
             "page": page_name,
@@ -31,6 +32,7 @@ def build_export_manifest(
             "source_kind": source_kind,
             "used_fallback_source": source_kind != "rendered",
             "completion_state": project.get_page_completion_state(page_name) if project is not None and hasattr(project, "get_page_completion_state") else "",
+            "renderer_used": str(page_renderer or (options.get("renderer", {}) or {}).get("default_renderer", "qt")),
         })
     renderer_info = options.get("renderer") or {}
     manifest = {
@@ -53,6 +55,8 @@ def build_export_manifest(
         manifest["warnings"].append(f"{fallback_count} page(s) used inpainted/original fallback sources because rendered results were missing.")
     if missing:
         manifest["warnings"].append(f"{len(missing)} page(s) had no rendered result/source at export time.")
+    if bool((options.get("requested_advanced_renderer", False))) and not bool(renderer_info.get("advanced_backend_available", False)):
+        manifest["warnings"].append("Advanced renderer was requested but optional shaping backend is unavailable; Qt fallback renderer was used.")
     return manifest
 
 

--- a/utils/glossary_extraction.py
+++ b/utils/glossary_extraction.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Dict, List
+
+_TOKEN = re.compile(r"[A-Za-z][A-Za-z'\-]{2,}|[\u3040-\u30ff\u3400-\u9fff]{2,}")
+
+
+def extract_glossary_candidates(texts: List[str], *, min_freq: int = 2) -> List[Dict[str, object]]:
+    c = Counter()
+    for t in texts or []:
+        for tok in _TOKEN.findall(str(t or "")):
+            c[tok] += 1
+    out: List[Dict[str, object]] = []
+    for term, freq in c.items():
+        if freq < max(1, int(min_freq)):
+            continue
+        category = "Recurring"
+        if term[:1].isupper() and term[1:].islower():
+            category = "Person/Name"
+        elif any("\u4e00" <= ch <= "\u9fff" for ch in term):
+            category = "CJK Term"
+        out.append({"source": term, "target": "", "category": category, "frequency": int(freq)})
+    out.sort(key=lambda r: (-int(r["frequency"]), str(r["source"])))
+    return out

--- a/utils/proj_imgtrans.py
+++ b/utils/proj_imgtrans.py
@@ -110,6 +110,7 @@ class ProjImgTrans:
         self.inpainted_array: np.ndarray = None
         self.translation_glossary: List[Dict[str, str]] = []  # [{"source": "...", "target": "..."}]
         self.translation_memory: List[Dict[str, str]] = []  # [{source,target,page,block_id}]
+        self.sfx_dictionary: List[Dict[str, str]] = []  # [{source,target,style}]
         self.series_context_path: str = ""  # Folder or ID for cross-chapter consistency (e.g. urban_immortal_cultivator)
         self.run_profiles: Dict[str, Dict] = {}  # project-local snapshots of selected run/module settings
         if directory is not None:
@@ -190,6 +191,7 @@ class ProjImgTrans:
 
         self.translation_glossary = proj_dict.get('translation_glossary') or []
         self.translation_memory = proj_dict.get('translation_memory') or []
+        self.sfx_dictionary = proj_dict.get('sfx_dictionary') or []
 
         self.series_context_path = (proj_dict.get('series_context_path') or "").strip()
         self.run_profiles = proj_dict.get('run_profiles') or {}
@@ -415,6 +417,8 @@ class ProjImgTrans:
             out['translation_glossary'] = self.translation_glossary
         if getattr(self, 'translation_memory', None):
             out['translation_memory'] = self.translation_memory
+        if getattr(self, 'sfx_dictionary', None):
+            out['sfx_dictionary'] = self.sfx_dictionary
         if getattr(self, 'series_context_path', None):
             out['series_context_path'] = self.series_context_path
         if getattr(self, 'run_profiles', None):

--- a/utils/renderer_backend_probe.py
+++ b/utils/renderer_backend_probe.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import importlib.util
+import platform
+from typing import Dict, List
+
+
+def _has_module(name: str) -> bool:
+    try:
+        return importlib.util.find_spec(name) is not None
+    except Exception:
+        return False
+
+
+def probe_renderer_backends() -> Dict[str, object]:
+    optional = {
+        'uharfbuzz': _has_module('uharfbuzz'),
+        'freetype': _has_module('freetype'),
+        'python_bidi': _has_module('bidi'),
+        'arabic_reshaper': _has_module('arabic_reshaper'),
+        'PIL': _has_module('PIL'),
+    }
+    features = {
+        'arabic_shaping': bool(optional['uharfbuzz'] and optional['python_bidi'] and optional['arabic_reshaper']),
+        'bidi_support': bool(optional['python_bidi']),
+        'glyph_bounds': bool(optional['freetype']),
+        'vertical_cjk_layout_hints': True,  # qt/default path supports current layout hints
+        'fallback_chain_diagnostics': True,
+    }
+    advanced_backend = bool(optional['uharfbuzz'] and optional['freetype'])
+    warnings: List[str] = []
+    install_hints: List[str] = []
+    if not optional['uharfbuzz']:
+        warnings.append('uharfbuzz not installed; advanced shaping backend unavailable.')
+        install_hints.append('pip install uharfbuzz')
+    if not optional['freetype']:
+        warnings.append('freetype-py not installed; true glyph bounds backend unavailable.')
+        install_hints.append('pip install freetype-py')
+    if not optional['python_bidi']:
+        warnings.append('python-bidi not installed; RTL/bidi diagnostics limited.')
+        install_hints.append('pip install python-bidi')
+    if not optional['arabic_reshaper']:
+        warnings.append('arabic-reshaper not installed; Arabic fallback shaping is limited.')
+        install_hints.append('pip install arabic-reshaper')
+
+    return {
+        'default_renderer': 'qt',
+        'advanced_backend_available': advanced_backend,
+        'optional_modules': optional,
+        'features': features,
+        'platform': {
+            'system': platform.system(),
+            'release': platform.release(),
+            'python': platform.python_version(),
+        },
+        'install_hints': sorted(set(install_hints)),
+        'warnings': warnings,
+    }

--- a/utils/renderer_diagnostics.py
+++ b/utils/renderer_diagnostics.py
@@ -1,34 +1,9 @@
 from __future__ import annotations
 
-import importlib.util
-from typing import Dict, List
+from typing import Dict
 
-
-def _has_module(name: str) -> bool:
-    try:
-        return importlib.util.find_spec(name) is not None
-    except Exception:
-        return False
+from .renderer_backend_probe import probe_renderer_backends
 
 
 def collect_renderer_diagnostics() -> Dict[str, object]:
-    optional = {
-        'uharfbuzz': _has_module('uharfbuzz'),
-        'freetype': _has_module('freetype'),
-        'python_bidi': _has_module('bidi'),
-        'arabic_reshaper': _has_module('arabic_reshaper'),
-    }
-    advanced_ready = bool(optional['uharfbuzz'] and optional['freetype'])
-    warnings: List[str] = []
-    if not optional['uharfbuzz']:
-        warnings.append('uharfbuzz not installed; advanced shaping backend unavailable.')
-    if not optional['freetype']:
-        warnings.append('freetype-py not installed; glyph metrics backend unavailable.')
-    if not optional['python_bidi']:
-        warnings.append('python-bidi not installed; RTL fallback diagnostics limited.')
-    return {
-        'default_renderer': 'qt',
-        'advanced_backend_available': advanced_ready,
-        'optional_modules': optional,
-        'warnings': warnings,
-    }
+    return probe_renderer_backends()

--- a/utils/sfx_dictionary.py
+++ b/utils/sfx_dictionary.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import csv
+import json
+from typing import Dict, List
+
+_DEFAULT = [
+    {"source": "ドン", "target": "THUD", "style": "impact"},
+    {"source": "バン", "target": "BANG", "style": "impact"},
+    {"source": "ザアア", "target": "SHHHH", "style": "ambient"},
+    {"source": "キラ", "target": "SPARKLE", "style": "fx"},
+]
+
+
+def default_sfx_dictionary() -> List[Dict[str, str]]:
+    return [dict(r) for r in _DEFAULT]
+
+
+def _norm(v: str) -> str:
+    return str(v or "").strip().lower()
+
+
+def query_sfx_dictionary(entries: List[Dict[str, str]], query: str, *, limit: int = 50) -> List[Dict[str, str]]:
+    needle = _norm(query)
+    if not needle:
+        return []
+    out: List[Dict[str, str]] = []
+    for row in entries or []:
+        src = str((row or {}).get("source", "") or "")
+        tgt = str((row or {}).get("target", "") or "")
+        sty = str((row or {}).get("style", "") or "")
+        hay = f"{src}\n{tgt}\n{sty}".lower()
+        if needle in hay:
+            out.append({"source": src, "target": tgt, "style": sty})
+    return out[: max(1, int(limit))]
+
+
+def merge_sfx_entries(existing: List[Dict[str, str]], incoming: List[Dict[str, str]]) -> Dict[str, object]:
+    merged = [dict(r) for r in (existing or [])]
+    by_key = {_norm(r.get("source", "")): i for i, r in enumerate(merged) if _norm(r.get("source", ""))}
+    added = 0
+    updated = 0
+    for row in incoming or []:
+        src = str((row or {}).get("source", "") or "").strip()
+        if not src:
+            continue
+        tgt = str((row or {}).get("target", "") or "").strip()
+        sty = str((row or {}).get("style", "") or "").strip()
+        k = _norm(src)
+        payload = {"source": src, "target": tgt, "style": sty}
+        if k in by_key:
+            merged[by_key[k]] = payload
+            updated += 1
+        else:
+            by_key[k] = len(merged)
+            merged.append(payload)
+            added += 1
+    return {"entries": merged, "added": added, "updated": updated, "count": len(merged)}
+
+
+def export_sfx_dictionary(entries: List[Dict[str, str]], out_path: str, fmt: str = "json") -> int:
+    fmt = str(fmt or "json").strip().lower()
+    rows = list(entries or [])
+    if fmt == "csv":
+        with open(out_path, "w", encoding="utf-8-sig", newline="") as f:
+            wr = csv.DictWriter(f, fieldnames=["source", "target", "style"])
+            wr.writeheader()
+            for r in rows:
+                wr.writerow({"source": r.get("source", ""), "target": r.get("target", ""), "style": r.get("style", "")})
+    else:
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(rows, f, ensure_ascii=False, indent=2)
+    return len(rows)
+
+
+def import_sfx_dictionary(path: str) -> List[Dict[str, str]]:
+    low = path.lower()
+    if low.endswith(".csv"):
+        out = []
+        with open(path, "r", encoding="utf-8-sig", newline="") as f:
+            for row in csv.DictReader(f):
+                src = str((row or {}).get("source", "") or "").strip()
+                if src:
+                    out.append({"source": src, "target": str((row or {}).get("target", "") or "").strip(), "style": str((row or {}).get("style", "") or "").strip()})
+        return out
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    out = []
+    for row in data or []:
+        src = str((row or {}).get("source", "") or "").strip()
+        if src:
+            out.append({"source": src, "target": str((row or {}).get("target", "") or "").strip(), "style": str((row or {}).get("style", "") or "").strip()})
+    return out

--- a/utils/structured_ocr_export.py
+++ b/utils/structured_ocr_export.py
@@ -79,10 +79,13 @@ def build_structured_ocr_export(project, pages: Optional[Iterable[str]] = None, 
         out_blocks = []
         for block_index, block in enumerate(blocks):
             text = block.get_text() if hasattr(block, "get_text") else getattr(block, "text", "")
+            block_id = str(getattr(block, "api_block_id", "") or "")
             out_blocks.append(
                 {
                     "index": block_index,
+                    "order_label": f"{page_index + 1}.{block_index + 1}",
                     "source_index": original_index.get(id(block), block_index),
+                    "block_id": block_id,
                     "reading_order": resolved_reading_order,
                     "xyxy": _as_list(getattr(block, "xyxy", None)),
                     "lines": _as_list(getattr(block, "lines", None)),

--- a/utils/text_rendering.py
+++ b/utils/text_rendering.py
@@ -1608,10 +1608,29 @@ def smart_fit_text_to_box(
     active_line_spacing = max(0.6, float(line_spacing or 1.0))
 
     if allow_balance and resolved != WRITING_MODE_VERTICAL_RL:
+        # Try multiple candidate line targets and keep the best wrap quality, not just a single width guess.
+        compact = active_text.replace("\n", " ").strip()
         avg = max(1.0, max(1.0, float(font_size or 1.0)) * 0.56 * active_spacing)
-        balanced = balance_lines(active_text.replace("\n", " "), max(2, int(max(1.0, eff_size[0] - 2 * float(padding or 0.0)) / avg)), active_break)
-        if balanced and balanced != active_text:
-            active_text = balanced
+        base_chars = max(2, int(max(1.0, eff_size[0] - 2 * float(padding or 0.0)) / avg))
+        candidate_line_counts = []
+        est_lines = int(max(1.0, eff_size[1]) / max(1.0, float(font_size or 1.0) * active_line_spacing))
+        for delta in (-1, 0, 1, 2):
+            candidate_line_counts.append(max(1, est_lines + delta))
+        best_text = active_text
+        best_score = float("inf")
+        for line_count in sorted(set(candidate_line_counts)):
+            chars = max(2, int(max(2.0, glyph_advance_units(compact, resolved) / max(1.0, line_count) / 0.56)))
+            chars = max(2, min(base_chars * 2, chars))
+            cand = balance_lines(compact, chars, active_break)
+            if not cand:
+                continue
+            quality = line_break_quality(cand, chars, active_break, resolved)
+            score = float(quality.raggedness) + (0.9 if quality.has_widow else 0.0) + (1.1 if quality.has_kinsoku_violation else 0.0) + abs(len((cand or "").splitlines()) - line_count) * 0.2
+            if score < best_score:
+                best_score = score
+                best_text = cand
+        if best_text and best_text != active_text:
+            active_text = best_text
             actions.append("balance_lines")
 
     size, fitted_text, diag = fit_font_size_to_box(
@@ -1645,7 +1664,22 @@ def smart_fit_text_to_box(
             line_spacing=active_line_spacing, letter_spacing=active_spacing,
             padding=padding, stroke_width=stroke_width, secondary_stroke_width=secondary_stroke_width, line_break_strategy=active_break,
             shadow_radius=shadow_radius, shadow_offset=shadow_offset,
-        )
+            )
+
+    # Second-pass rebalancing for stubborn overflow: rebalance with measured width constraints and refit.
+    if allow_balance and diag.overflow and resolved != WRITING_MODE_VERTICAL_RL:
+        overflow_ratio_x = max(1.0, float(diag.measured_bounds[0] or 1.0) / max(1.0, eff_size[0]))
+        tighter_chars = max(2, int(max(2.0, (max(1.0, eff_size[0] - 2 * float(padding or 0.0)) / max(1.0, float(font_size or 1.0) * 0.56 * active_spacing)) / overflow_ratio_x)))
+        tightened = balance_lines(fitted_text.replace("\n", " "), tighter_chars, active_break)
+        if tightened and tightened != fitted_text:
+            actions.append("rebalance_for_overflow")
+            size, fitted_text, diag = fit_font_size_to_box(
+                tightened, font_size, eff_size, active_fit, active_mode,
+                min_font_size=min_font_size, max_font_size=max_font_size,
+                line_spacing=active_line_spacing, letter_spacing=active_spacing,
+                padding=padding, stroke_width=stroke_width, secondary_stroke_width=secondary_stroke_width, line_break_strategy=active_break,
+                shadow_radius=shadow_radius, shadow_offset=shadow_offset,
+            )
 
     if size < float(font_size or size) - 0.2:
         actions.append("shrink_to_fit")

--- a/utils/translation_qa_profiles.py
+++ b/utils/translation_qa_profiles.py
@@ -24,6 +24,8 @@ def build_translation_qa_report(
     *,
     profile: str = "dialogue",
     retry_issue_threshold: int = 2,
+    repetition_threshold: float = 0.45,
+    untranslated_ratio_threshold: float = 0.85,
 ) -> Dict[str, Any]:
     cfg = resolve_prompt_profile(profile)
     rows: List[Dict[str, Any]] = []
@@ -32,15 +34,34 @@ def build_translation_qa_report(
         src = (getattr(b, "text", "") or getattr(b, "get_text", lambda: "")() or "").strip()
         tgt = (getattr(b, "translation", "") or "").strip()
         issues = check_translation_guardrails(src, tgt, glossary=glossary or [], max_len_ratio=float(cfg["max_len_ratio"]))
+        src_tokens = [x for x in src.lower().split() if x]
+        tgt_tokens = [x for x in tgt.lower().split() if x]
+        rep_ratio = 0.0
+        if tgt_tokens and not cfg.get("allow_same_text", False):
+            rep_ratio = 1.0 - (len(set(tgt_tokens)) / float(len(tgt_tokens)))
+            if rep_ratio >= float(repetition_threshold):
+                issues.append(f"High repetition ratio ({rep_ratio:.2f})")
+        carry_ratio = 0.0
+        if src_tokens and tgt_tokens:
+            src_set = set(src_tokens)
+            overlap = sum(1 for tok in tgt_tokens if tok in src_set)
+            carry_ratio = overlap / float(len(tgt_tokens))
+            if carry_ratio >= float(untranslated_ratio_threshold) and not cfg.get("allow_same_text", False):
+                issues.append(f"High source carry-over ratio ({carry_ratio:.2f})")
         if cfg.get("allow_same_text", False):
             issues = [x for x in issues if "Untranslated source carry-over" not in x]
         if len(issues) >= int(retry_issue_threshold):
             retry_candidates.append(idx)
-        rows.append({"index": idx, "source": src, "translation": tgt, "issues": issues, "issue_count": len(issues)})
+        rows.append({"index": idx, "source": src, "translation": tgt, "issues": issues, "issue_count": len(issues), "repetition_ratio": round(rep_ratio, 4), "source_carry_ratio": round(carry_ratio, 4)})
     return {
         "profile": profile,
         "rows": rows,
         "total_blocks": len(rows),
         "issue_blocks": sum(1 for r in rows if r["issue_count"] > 0),
         "retry_candidates": retry_candidates,
+        "thresholds": {
+            "retry_issue_threshold": int(retry_issue_threshold),
+            "repetition_threshold": float(repetition_threshold),
+            "untranslated_ratio_threshold": float(untranslated_ratio_threshold),
+        },
     }


### PR DESCRIPTION
### Motivation

- Extend the local automation API and UI with headless-friendly archive streaming, auto-format QA, SFX/glossary extraction, and renderer probing to close parity gaps for headless/export, QA, and glossary/SFX workflows.
- Persist and surface extra project metadata (SFX dictionary) and export diagnostics so headless workflows can report progress, cancellation, and renderer fallbacks.

### Description

- Implemented archive streaming with cancel/progress support via `utils/archive_stream_export.py` and hooked it into API export path so `POST /export` with `kind: archive|zip|cbz` returns `archive_stream` metadata and respects `job_cancel` when run under `job_start` using `__job_id` payload.
- Added auto-format QA scoring and summary helpers in `utils/auto_format_qa.py` plus an interactive `AutoFormatQADialog` UI in `ui/auto_format_qa_widget.py`, and integrated API/UI handlers (`auto_format_textboxes`, `auto_format_qa_preview`) in `ui/mainwindow.py` and a titlebar trigger in `ui/mainwindowbars.py`.
- Added SFX dictionary management (`utils/sfx_dictionary.py`) and glossary extraction (`utils/glossary_extraction.py`) utilities, with API handlers in `ui/mainwindow.py` for query/import/export and candidate extraction/apply; persisted project-level `sfx_dictionary` in `utils/proj_imgtrans.py`.
- Introduced renderer backend probing in `utils/renderer_backend_probe.py` and updated `utils/renderer_diagnostics.py` to delegate diagnostics and expose richer fields (`features`, `install_hints`, `platform`) used by UI and export logic.
- Enhanced structured OCR export to include stable `block_id` and `order_label` in `utils/structured_ocr_export.py` and export manifest to include per-page renderer info and a warning when an advanced renderer was requested but unavailable in `utils/export_manifest.py`.
- Added parent-batch summarization helper `summarize_parent_batch_state` in `utils/batch_parent_queue.py` and surfaced it via `batch_parent_summary` API in `ui/mainwindow.py`.
- Improved cleanup-only workflow to report `halo_stats` and `halo_flags` using optional `modules.mask_diagnostics` in `utils/cleanup_only_workflow.py`.
- Enhanced text layout heuristics in `utils/text_rendering.py` with multi-candidate balancing and a second-pass rebalance for overflow to improve auto-format quality.
- Extended translation QA profiles in `utils/translation_qa_profiles.py` to detect repetition and source-carry-over ratios and surface thresholds in reports.
- Added a collection of unit tests covering archive streaming, auto-format QA, batch parent queue summary, cleanup-only halo stats, export manifest warnings, renderer diagnostics, SFX dictionary, smart text formatting, structured OCR export, glossary extraction, and translation QA profile enhancements under `tests/`.

### Testing

- Executed the baseline Phase 0 verification command shown in docs: `pytest -q tests/test_local_automation_api.py tests/test_local_automation_api_routes_contract.py tests/test_lettering_proof_export.py tests/test_export_manifest.py tests/test_project_ops_protocol.py tests/test_batch_parent_queue.py tests/test_model_package_selector_dialog.py` and observed all tests passing (`18 passed`).
- Added and ran unit tests for the new helpers and API surfaces (new files under `tests/` such as `test_archive_stream_export.py`, `test_auto_format_qa.py`, `test_sfx_dictionary.py`, `test_glossary_extraction.py`, `test_renderer_diagnostics.py`, `test_structured_ocr_export.py`, and others) as part of CI and they pass in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0c9d81a9b8832c8aca18045a06957f)