### PR TITLE
Fix missing rerun handler in OCR Crop Inspector

### DIFF
--- a/ui/ocr_crop_inspector_widget.py
+++ b/ui/ocr_crop_inspector_widget.py
@@ -84,6 +84,14 @@ class OcrCropInspectorWidget(QWidget):
         self.text_lbl.setText(f"OCR: {getattr(b, 'text', '')}\nTranslation: {getattr(b, 'translation', '')}")
 
 
+    def _on_rerun_clicked(self):
+        row = self.listw.currentRow()
+        if row < 0 or row >= len(self._blks):
+            return
+        if callable(self._on_rerun):
+            self._on_rerun(row, self.engine_combo.currentText())
+
+
     def _on_compare_clicked(self):
         row = self.listw.currentRow()
         if row < 0 or row >= len(self._blks):


### PR DESCRIPTION
### Motivation
- Prevent the app crash caused by `AttributeError` when `rerun_btn.clicked` was connected to a missing `_on_rerun_clicked` method in the OCR Crop Inspector widget.

### Description
- Implemented `OcrCropInspectorWidget._on_rerun_clicked` in `ui/ocr_crop_inspector_widget.py` to validate the selected row and invoke the configured rerun callback with `(row, selected_engine)`.

### Testing
- Ran `python -m py_compile ui/ocr_crop_inspector_widget.py` successfully to verify the file compiles without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cca6247b8832ca9171b6a0126c948)