### PR TITLE
Region merge tool: UI, merger logic, docs, and related UI fixes

### DIFF
--- a/docs/REGION_MERGE_TOOL.md
+++ b/docs/REGION_MERGE_TOOL.md
@@ -1,0 +1,29 @@
+# Region merge tool
+
+The Region merge tool (Tools → Region merge tool) now includes:
+
+- **Quick profile**: Conservative / Balanced / Aggressive presets for overlap/gap thresholds.
+- **Preview current page**: runs a dry-run merge and reports block count delta without applying changes.
+- **Include-only labels (whitelist)**: restrict merges to specific label classes.
+- Existing blacklist, label grouping, output shape type, and merge mode controls.
+
+## Suggested workflow
+
+1. Start with **Conservative** profile and click **Preview current page**.
+2. If under-merging, move to **Balanced** and preview again.
+3. Use **Aggressive** only for dense word-fragmented pages.
+4. Enable **Whitelist labels** to avoid merging non-dialog classes.
+
+## Notes
+
+- Preview does not mutate project data.
+- Run on current page applies in-memory immediately.
+- Run on all pages writes merged results to the project JSON.
+
+
+## How merge settings work together
+
+- **Detector collision merge** (Config → Text detector) runs during detection and is mainly for dense word-level fragments.
+- **Region merge tool** runs after detection/pipeline (manual or auto-after-run) and can further merge existing boxes with label and geometry rules.
+- If both are enabled, the effective order is: detector merge first, region merge second.
+- Use **Import detector collision-merge defaults** in Region merge to start from similar aggressiveness, then tune label constraints (whitelist/blacklist/groups).

--- a/docs/RENDERING_TEXT_FORMATTING.md
+++ b/docs/RENDERING_TEXT_FORMATTING.md
@@ -242,6 +242,7 @@ Lettering proof packs now include `lettering_proof_index.html`, a browser-friend
 - Tools → Project → **Lettering workflow...** now opens a review dialog instead of immediately applying changes. It supports current page, selected pages from the page list, or the whole project; previews ordered steps; and shows the highest-priority textboxes before running fixes.
 - The page list context menu has **Lettering workflow for selected pages...** for fewer-click multi-page typography QA.
 - The text formatting panel includes **Apply diagnostics fixes** for the selected textbox. It applies the same conservative typography polish and smart-fit logic used by layout review/API workflows.
+- Diagnostics fixes now clamp extreme one-click font-size jumps (roughly 65%–135% of current size) so a single click does not collapse text to tiny sizes or blow it up excessively; repeat if you want a larger step.
 - `POST /lettering_workflow` accepts multiple pages and returns `proof_manifests`, `warnings`, and applied action counts. Batch proof packs are supported; full batch rerender remains explicitly warned/deferred.
 - Vertical CJK rendering now keeps short ASCII tate-chu-yoko runs upright/compact in the Qt vertical layout, and proof metrics include both estimated and `precise_measured_bounds` values for clipping diagnostics.
 
@@ -328,3 +329,12 @@ Automation API now also supports long-task job controls via POST routes: `job_st
 MCP-friendly aliases are also available on POST routes to reduce client glue code: `project_open` → `open_project`, `pipeline_run` → `run_pipeline`, `scene_edit` → `apply_edit`, `render` → `render_current_page`.
 
 Job lifecycle routes also include `jobs_list` and `job_result`, and job retention/log limits are configurable in Settings for long-running automation sessions.
+
+
+## Detection merge tuning
+
+In **Config → Text detector**, enable **Merge nearby detected blocks (word-level cleanup)** when a page is split into many tiny word boxes. Tune:
+- **Min blocks**: only run merge on dense pages (default 18).
+- **Gap ratio**: higher values merge more aggressively.
+
+For normal bubble detection, keep this disabled to avoid accidental merges between nearby bubbles.

--- a/ui/custom_widget/message.py
+++ b/ui/custom_widget/message.py
@@ -20,8 +20,13 @@ class MessageBox(QMessageBox):
 
         if frame_less:
             self.setWindowFlags(Qt.WindowType.FramelessWindowHint)
-        if modal:
-            self.setModal(modal)
+        modal_flag = modal
+        if isinstance(modal_flag, str):
+            modal_flag = modal_flag.strip().lower() in {"1", "true", "yes", "on"}
+        else:
+            modal_flag = bool(modal_flag)
+        if modal_flag:
+            self.setModal(True)
         # Force Qt-drawn dialogs so they inherit app stylesheet (dark/light) instead of OS-native white popups.
         self.setOption(QMessageBox.Option.DontUseNativeDialog, True)
         if btn_type is not None:

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -126,6 +126,12 @@ class PageListView(QListWidget):
         self.setIconSize(QSize(shared.PAGELIST_THUMBNAIL_SIZE, shared.PAGELIST_THUMBNAIL_SIZE))
         self.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
 
+
+    def _item_page_name(self, item: QListWidgetItem) -> str:
+        if item is None:
+            return ''
+        return item.data(Qt.ItemDataRole.UserRole) or item.text()
+
     def keyPressEvent(self, event: QKeyEvent):
         if event.key() == Qt.Key.Key_A and event.modifiers() in (Qt.KeyboardModifier.ControlModifier, Qt.KeyboardModifier.MetaModifier):
             self.selectAll()
@@ -172,31 +178,31 @@ class PageListView(QListWidget):
         elif rst == select_all_pages_act:
             self.selectAll()
         elif selected_items and rst == translate_act:
-            self.translate_images.emit([item.text() for item in selected_items])
+            self.translate_images.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and 'lettering_workflow_act' in locals() and rst == lettering_workflow_act:
-            self.lettering_workflow_requested.emit([item.text() for item in selected_items])
+            self.lettering_workflow_requested.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and rst == run_detect_act:
-            self.run_detect_images.emit([item.text() for item in selected_items])
+            self.run_detect_images.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and rst == run_ocr_act:
-            self.run_ocr_images.emit([item.text() for item in selected_items])
+            self.run_ocr_images.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and rst == run_translate_act:
-            self.run_translate_images.emit([item.text() for item in selected_items])
+            self.run_translate_images.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and rst == run_inpaint_act:
-            self.run_inpaint_images.emit([item.text() for item in selected_items])
+            self.run_inpaint_images.emit([self._item_page_name(item) for item in selected_items])
         elif selected_items and rst == ignore_act:
-            self.toggle_ignore_requested.emit([item.text() for item in selected_items], True)
+            self.toggle_ignore_requested.emit([self._item_page_name(item) for item in selected_items], True)
         elif selected_items and rst == include_act:
-            self.toggle_ignore_requested.emit([item.text() for item in selected_items], False)
+            self.toggle_ignore_requested.emit([self._item_page_name(item) for item in selected_items], False)
         elif selected_items and rst == mark_todo_act:
-            self.set_completion_requested.emit([item.text() for item in selected_items], 'todo')
+            self.set_completion_requested.emit([self._item_page_name(item) for item in selected_items], 'todo')
         elif selected_items and rst == mark_translated_act:
-            self.set_completion_requested.emit([item.text() for item in selected_items], 'translated')
+            self.set_completion_requested.emit([self._item_page_name(item) for item in selected_items], 'translated')
         elif selected_items and rst == mark_reviewed_act:
-            self.set_completion_requested.emit([item.text() for item in selected_items], 'reviewed')
+            self.set_completion_requested.emit([self._item_page_name(item) for item in selected_items], 'reviewed')
         elif selected_items and rst == mark_exported_act:
-            self.set_completion_requested.emit([item.text() for item in selected_items], 'exported')
+            self.set_completion_requested.emit([self._item_page_name(item) for item in selected_items], 'exported')
         elif selected_items and rst == remove_act:
-            self.remove_images.emit([item.text() for item in selected_items])
+            self.remove_images.emit([self._item_page_name(item) for item in selected_items])
 
         return super().contextMenuEvent(e)
 
@@ -345,6 +351,26 @@ class MainWindow(mainwindow_cls):
         if title:
             dialog.setWindowTitle(title)
         dialog.show()   # exec_ will block main thread
+
+
+    def _show_status_message(self, message: str, timeout_ms: int = 5000):
+        """Best-effort status message helper for frameless builds without QStatusBar."""
+        msg = str(message or "").strip()
+        if not msg:
+            return
+        try:
+            status_fn = getattr(self, 'statusBar', None)
+            status_obj = status_fn() if callable(status_fn) else None
+            if status_obj is not None and hasattr(status_obj, 'showMessage'):
+                status_obj.showMessage(msg, int(timeout_ms))
+                return
+        except Exception:
+            pass
+        try:
+            if hasattr(self, 'pipelineInsightsPanel') and self.pipelineInsightsPanel is not None:
+                self.pipelineInsightsPanel.add_event('STATUS', msg)
+        except Exception:
+            pass
 
     def register_view_widget(self, widget: ViewWidget):
         assert widget.config_name not in shared.config_name_to_view_widget
@@ -3246,6 +3272,7 @@ class MainWindow(mainwindow_cls):
                 QListWidgetItem(QIcon(osp.join(self.imgtrans_proj.directory, imgname)), imgname)
         for imgname in self.imgtrans_proj.pages:
             lstitem =  item_func(imgname)
+            lstitem.setData(Qt.ItemDataRole.UserRole, imgname)
             self.pageList.addItem(lstitem)
             if imgname == self.imgtrans_proj.current_img:
                 self.pageList.setCurrentItem(lstitem)
@@ -3385,7 +3412,7 @@ class MainWindow(mainwindow_cls):
         if item is not None:
             if self.save_on_page_changed:
                 self.conditional_save()
-            self.imgtrans_proj.set_current_img(item.text())
+            self.imgtrans_proj.set_current_img(item.data(Qt.ItemDataRole.UserRole) or item.text())
             self.canvas.clear_undostack(update_saved_step=True)
             self.canvas.updateCanvas()
             self.st_manager.updateSceneTextitems()
@@ -3893,8 +3920,12 @@ class MainWindow(mainwindow_cls):
                     self.pageList.setCurrentRow(row)
 
     def shortcutTextedit(self):
-        if self.centralStackWidget.currentIndex() == 1:
-            self.bottomBar.texteditChecker.click()
+        if not self._has_open_project():
+            return
+        if self.centralStackWidget.currentIndex() != 1:
+            self._show_main_content()
+        self.bottomBar.setPipelineVisible(True)
+        self.bottomBar.texteditChecker.click()
 
     def shortcutTextblock(self):
         if self.centralStackWidget.currentIndex() == 1:
@@ -3902,8 +3933,12 @@ class MainWindow(mainwindow_cls):
                 self.bottomBar.textblockChecker.click()
 
     def shortcutDrawboard(self):
-        if self.centralStackWidget.currentIndex() == 1:
-            self.bottomBar.paintChecker.click()
+        if not self._has_open_project():
+            return
+        if self.centralStackWidget.currentIndex() != 1:
+            self._show_main_content()
+        self.bottomBar.setPipelineVisible(True)
+        self.bottomBar.paintChecker.click()
 
     def shortcutSpellCheckPanel(self):
         """Show Spell check panel (PR #974)."""
@@ -4149,7 +4184,7 @@ class MainWindow(mainwindow_cls):
             result, target_indices = self._layout_review_result_for_scope(mode)
         except Exception as e:
             self.pipelineInsightsPanel.add_warning('LAYOUT_REVIEW', str(e))
-            self.statusBar().showMessage(self.tr('Layout review unavailable: {0}').format(str(e)), 5000)
+            self._show_status_message(self.tr('Layout review unavailable: {0}').format(str(e)), 5000)
             return
         summary = self._summarize_layout_review_result(result)
         dlg = LayoutReviewReportDialog(result, self)
@@ -4164,10 +4199,10 @@ class MainWindow(mainwindow_cls):
             if self.imgtrans_proj and self.imgtrans_proj.directory:
                 self.imgtrans_proj.save()
             self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Applied {0} layout fix action(s).').format(applied))
-            self.statusBar().showMessage(self.tr('Layout review applied {0} fix action(s).').format(applied), 5000)
+            self._show_status_message(self.tr('Layout review applied {0} fix action(s).').format(applied), 5000)
         else:
             self.pipelineInsightsPanel.add_event('LAYOUT', self.tr('Layout review found no applicable fixes.'))
-            self.statusBar().showMessage(self.tr('Layout review: no applicable fixes.'), 4000)
+            self._show_status_message(self.tr('Layout review: no applicable fixes.'), 4000)
         if summary['issues'] > 0:
             self.pipelineInsightsPanel.add_warning('LAYOUT_REVIEW', self.tr('{0} issue(s), {1} proposed fix(es).').format(summary['issues'], summary['actions']))
 
@@ -4664,8 +4699,9 @@ class MainWindow(mainwindow_cls):
             from utils import merger
             
             self.merge_dialog = MergeDialog(self)
-            self.merge_dialog.run_current_clicked.connect(lambda: self.run_merge_task(on_current=True))
-            self.merge_dialog.run_all_clicked.connect(lambda: self.run_merge_task(on_current=False))
+            self.merge_dialog.preview_current_clicked.connect(lambda: self.run_merge_task(on_current=True, dry_run=True))
+            self.merge_dialog.run_current_clicked.connect(lambda: self.run_merge_task(on_current=True, dry_run=False))
+            self.merge_dialog.run_all_clicked.connect(lambda: self.run_merge_task(on_current=False, dry_run=False))
         
         if self.merge_dialog.isVisible():
             self.merge_dialog.raise_()
@@ -5144,7 +5180,7 @@ class MainWindow(mainwindow_cls):
         except Exception:
             pass
 
-    def run_merge_task(self, on_current=False):
+    def run_merge_task(self, on_current=False, dry_run=False):
         """Run the region merge task."""
         from utils import merger
         from qtpy.QtWidgets import QMessageBox
@@ -5154,6 +5190,8 @@ class MainWindow(mainwindow_cls):
             return
         
         config = self.merge_dialog.get_config()
+        if bool(getattr(getattr(pcfg, "module", None), "merge_nearby_blocks_collision", False)) and mode in ("all_pages", "current_page"):
+            self._show_status_message(self.tr("Detector collision-merge and Region merge are both enabled; Region merge runs as a second pass."), 6000)
         
         if on_current:
             # Run on current page — operate in memory, no file I/O
@@ -5200,11 +5238,14 @@ class MainWindow(mainwindow_cls):
                 final_shapes = initial_shapes
             
             if total_merged > 0:
+                final_count = len(final_shapes)
+                if dry_run:
+                    self._msg_information("Preview", f"Merge preview: {initial_count} -> {final_count} blocks (would reduce by {initial_count - final_count})")
+                    return
                 # Convert dicts back to TextBlock and update memory
                 self.imgtrans_proj.pages[current_img] = [TextBlock(**blk_dict) for blk_dict in final_shapes]
                 self.canvas.updateCanvas()
                 self.st_manager.updateSceneTextitems()
-                final_count = len(final_shapes)
                 self._msg_information("Success", f"Merge done: {initial_count} -> {final_count} blocks (reduced by {initial_count - final_count})")
             else:
                 raw_labels = set(s.get('label') for s in initial_shapes)
@@ -6144,9 +6185,12 @@ class MainWindow(mainwindow_cls):
         if not hasattr(self, 'merge_dialog') or self.merge_dialog is None:
             from .merge_dialog import MergeDialog
             self.merge_dialog = MergeDialog(self)
-            self.merge_dialog.run_current_clicked.connect(lambda: self.run_merge_task(on_current=True))
-            self.merge_dialog.run_all_clicked.connect(lambda: self.run_merge_task(on_current=False))
+            self.merge_dialog.preview_current_clicked.connect(lambda: self.run_merge_task(on_current=True, dry_run=True))
+            self.merge_dialog.run_current_clicked.connect(lambda: self.run_merge_task(on_current=True, dry_run=False))
+            self.merge_dialog.run_all_clicked.connect(lambda: self.run_merge_task(on_current=False, dry_run=False))
         config = self.merge_dialog.get_config()
+        if bool(getattr(getattr(pcfg, "module", None), "merge_nearby_blocks_collision", False)) and mode in ("all_pages", "current_page"):
+            self._show_status_message(self.tr("Detector collision-merge and Region merge are both enabled; Region merge runs as a second pass."), 6000)
         if mode == 'all_pages':
             img_list = list(self.imgtrans_proj.pages.keys())
             if not img_list:
@@ -6649,7 +6693,7 @@ class MainWindow(mainwindow_cls):
 
     def _selected_page_names(self) -> List[str]:
         try:
-            return [item.text() for item in self.pageList.selectedItems()]
+            return [(item.data(Qt.ItemDataRole.UserRole) or item.text()) for item in self.pageList.selectedItems()]
         except Exception:
             return []
 
@@ -7109,6 +7153,9 @@ class MainWindow(mainwindow_cls):
         """Persist user-visible completion state for selected pages."""
         if not pagenames or self.imgtrans_proj.is_empty:
             return
+        state = str(state or 'todo').strip().lower()
+        if state not in {'todo', 'translated', 'reviewed', 'exported'}:
+            state = 'todo'
         for name in pagenames:
             self.imgtrans_proj.set_page_completion_state(name, state)
         if self.imgtrans_proj.directory:
@@ -7147,9 +7194,15 @@ class MainWindow(mainwindow_cls):
             item = self.pageList.item(i)
             if item is None:
                 continue
-            name = item.text()
+            name = item.data(Qt.ItemDataRole.UserRole) or item.text()
             is_ignored = self.imgtrans_proj.is_page_ignored(name) if not self.imgtrans_proj.is_empty else False
             state = self.imgtrans_proj.get_page_completion_state(name) if not self.imgtrans_proj.is_empty else 'todo'
+            state_prefix = {'todo': '◻', 'translated': '🟦', 'reviewed': '🟩', 'exported': '🟨'}.get(state, '◻')
+            display_name = f"{state_prefix} {name}"
+            if is_ignored:
+                display_name = f"⏭ {display_name}"
+            if item.text() != display_name:
+                item.setText(display_name)
             tips = [self.tr('Completion: {0}').format(labels.get(state, state))]
             if is_ignored:
                 tips.append(self.tr('Ignored in run (right-click → Include in run to process)'))

--- a/ui/merge_dialog.py
+++ b/ui/merge_dialog.py
@@ -1,4 +1,4 @@
-from qtpy.QtWidgets import QDialog, QVBoxLayout, QGroupBox, QFormLayout, QComboBox, QLineEdit, QPlainTextEdit, QCheckBox, QSpinBox, QLabel, QRadioButton, QButtonGroup, QHBoxLayout, QPushButton
+from qtpy.QtWidgets import QDialog, QVBoxLayout, QGroupBox, QFormLayout, QComboBox, QLineEdit, QPlainTextEdit, QCheckBox, QSpinBox, QLabel, QRadioButton, QButtonGroup, QHBoxLayout, QPushButton, QMessageBox
 from qtpy.QtCore import Signal, Qt
 from qtpy.QtWidgets import QSizePolicy
 from qtpy.QtGui import QShowEvent, QCloseEvent
@@ -9,6 +9,7 @@ class MergeDialog(QDialog):
     # Signals: emitted when user clicks run buttons
     run_current_clicked = Signal()  # Run on current file
     run_all_clicked = Signal()      # Run on all files
+    preview_current_clicked = Signal()  # Preview on current file (no apply)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -50,7 +51,13 @@ class MergeDialog(QDialog):
         self.merge_mode = QComboBox()
         for text, data in self.merge_mode_map.items():
             self.merge_mode.addItem(text, userData=data)
-        main_layout.addRow(self.tr("Merge mode:"), self.merge_mode)
+        self.profile_combo = QComboBox()
+        self.profile_combo.addItem(self.tr("Custom"), "custom")
+        self.profile_combo.addItem(self.tr("Conservative (safe)"), "conservative")
+        self.profile_combo.addItem(self.tr("Balanced"), "balanced")
+        self.profile_combo.addItem(self.tr("Aggressive (dense text)"), "aggressive")
+        self.profile_combo.currentIndexChanged.connect(self._on_profile_changed)
+        main_layout.addRow(self.tr("Quick profile:"), self.profile_combo)
         self.layout.addWidget(main_group)
 
         # --- Text reading order (by label) ---
@@ -82,6 +89,17 @@ class MergeDialog(QDialog):
         for text, data in self.label_strategy_map.items():
             self.label_merge_strategy.addItem(text, userData=data)
         label_layout.addRow(self.tr("Label merge strategy:"), self.label_merge_strategy)
+
+        self.enable_include_labels = QCheckBox(self.tr("Enable include-only labels (whitelist)"))
+        self.enable_include_labels.setChecked(False)
+        label_layout.addRow(self.enable_include_labels)
+
+        self.include_labels = QLineEdit()
+        self.include_labels.setText(self.tr("balloon,qipao,shuqing,changfangtiao,hengxie"))
+        self.include_labels.setPlaceholderText(self.tr("e.g. balloon,qipao"))
+        self.include_labels.setEnabled(False)
+        self.enable_include_labels.toggled.connect(self.include_labels.setEnabled)
+        label_layout.addRow(self.tr("Whitelist labels:"), self.include_labels)
 
         self.enable_exclude_labels = QCheckBox(self.tr("Enable exclude-from-merge labels (blacklist)"))
         self.enable_exclude_labels.setChecked(True)
@@ -180,24 +198,41 @@ class MergeDialog(QDialog):
         result_type_layout.addWidget(self.radio_output_rectangle)
         result_type_layout.addWidget(self.radio_output_rotation)
 
-        self.layout.addWidget(result_type_group)
+        # --- Coordination / interaction summary --- #
+        coordination_group = QGroupBox(self.tr("Merge coordination"))
+        coordination_layout = QVBoxLayout(coordination_group)
+        self.sync_from_detector_btn = QPushButton(self.tr("Import detector collision-merge defaults"))
+        self.sync_from_detector_btn.setToolTip(self.tr("Copy detector collision merge thresholds (Config → Text detector) into this dialog as a starting point."))
+        self.sync_from_detector_btn.clicked.connect(self._import_detector_defaults)
+        coordination_layout.addWidget(self.sync_from_detector_btn)
+        self.interaction_hint = QLabel(self.tr("Region merge (this tool) runs after/independent from detector merge. If both are enabled, detector merge happens first during detection, then region merge can further combine boxes."))
+        self.interaction_hint.setWordWrap(True)
+        self.interaction_hint.setStyleSheet("color: gray; font-size: 0.9em;")
+        coordination_layout.addWidget(self.interaction_hint)
+        self.layout.addWidget(coordination_group)
 
         # --- Buttons --- #
         button_layout = QHBoxLayout()
+        self.preview_current_button = QPushButton(self.tr("Preview current page"))
         self.run_current_button = QPushButton(self.tr("Run on current page"))
         self.run_all_button = QPushButton(self.tr("Run on all pages"))
         self.cancel_button = QPushButton(self.tr("Cancel"))
 
+        button_layout.addWidget(self.preview_current_button)
         button_layout.addWidget(self.run_current_button)
         button_layout.addWidget(self.run_all_button)
         button_layout.addWidget(self.cancel_button)
         button_layout.addStretch()
 
+        self.preview_current_button.clicked.connect(self.on_preview_current)
         self.run_current_button.clicked.connect(self.on_run_current)
         self.run_all_button.clicked.connect(self.on_run_all)
         self.cancel_button.clicked.connect(self.reject)
 
         self.layout.addLayout(button_layout)
+
+    def on_preview_current(self):
+        self.preview_current_clicked.emit()
 
     def on_run_current(self):
         self.run_current_clicked.emit()
@@ -215,6 +250,9 @@ class MergeDialog(QDialog):
             "rtl_labels": self.rtl_labels_edit.text().strip(),
             "ttb_labels": self.ttb_labels_edit.text().strip(),
             "label_merge_strategy": self.label_merge_strategy.currentData(),
+            "profile": self.profile_combo.currentData(),
+            "enable_include_labels": self.enable_include_labels.isChecked(),
+            "include_labels": self.include_labels.text().strip(),
             "enable_exclude_labels": self.enable_exclude_labels.isChecked(),
             "exclude_labels": self.exclude_labels.text().strip(),
             "require_same_label": self.require_same_label.isChecked(),
@@ -247,11 +285,19 @@ class MergeDialog(QDialog):
             self.rtl_labels_edit.setText(d.get("rtl_labels", ""))
         if "ttb_labels" in d:
             self.ttb_labels_edit.setText(d.get("ttb_labels", ""))
+        prof = d.get("profile")
+        if prof is not None:
+            idx = self.profile_combo.findData(prof)
+            if idx >= 0:
+                self.profile_combo.setCurrentIndex(idx)
         strat = d.get("label_merge_strategy")
         if strat is not None:
             idx = self.label_merge_strategy.findData(strat)
             if idx >= 0:
                 self.label_merge_strategy.setCurrentIndex(idx)
+        self.enable_include_labels.setChecked(d.get("enable_include_labels", False))
+        if "include_labels" in d:
+            self.include_labels.setText(d.get("include_labels", ""))
         self.enable_exclude_labels.setChecked(d.get("enable_exclude_labels", True))
         if "exclude_labels" in d:
             self.exclude_labels.setText(d.get("exclude_labels", ""))
@@ -282,6 +328,46 @@ class MergeDialog(QDialog):
         self.save_settings_to_pcfg()
         super().closeEvent(event)
 
+    def _import_detector_defaults(self):
+        try:
+            enabled = bool(getattr(getattr(pcfg, "module", None), "merge_nearby_blocks_collision", False))
+            gap_ratio = float(getattr(getattr(pcfg, "module", None), "merge_nearby_blocks_gap_ratio", 1.5) or 1.5)
+            min_blocks = int(getattr(getattr(pcfg, "module", None), "merge_nearby_blocks_min_blocks", 18) or 18)
+            approx_gap = max(1, int(round(10.0 * gap_ratio)))
+            approx_overlap = int(max(55, min(98, 100 - (gap_ratio - 1.0) * 20)))
+            self.max_vertical_gap.setValue(approx_gap)
+            self.max_horizontal_gap.setValue(approx_gap)
+            self.min_width_overlap_ratio.setValue(approx_overlap)
+            self.min_height_overlap_ratio.setValue(approx_overlap)
+            if enabled and min_blocks >= 24:
+                self.profile_combo.setCurrentIndex(self.profile_combo.findData("aggressive"))
+            elif enabled:
+                self.profile_combo.setCurrentIndex(self.profile_combo.findData("balanced"))
+            QMessageBox.information(self, self.tr("Imported"), self.tr("Imported detector defaults. You can still fine-tune for region merge."))
+        except Exception as e:
+            QMessageBox.warning(self, self.tr("Import failed"), str(e))
+
+    def _on_profile_changed(self):
+        profile = self.profile_combo.currentData()
+        if profile == "conservative":
+            self.max_vertical_gap.setValue(2)
+            self.max_horizontal_gap.setValue(2)
+            self.min_width_overlap_ratio.setValue(95)
+            self.min_height_overlap_ratio.setValue(95)
+            self.require_same_label.setChecked(True)
+        elif profile == "balanced":
+            self.max_vertical_gap.setValue(10)
+            self.max_horizontal_gap.setValue(10)
+            self.min_width_overlap_ratio.setValue(90)
+            self.min_height_overlap_ratio.setValue(90)
+            self.require_same_label.setChecked(False)
+        elif profile == "aggressive":
+            self.max_vertical_gap.setValue(24)
+            self.max_horizontal_gap.setValue(24)
+            self.min_width_overlap_ratio.setValue(65)
+            self.min_height_overlap_ratio.setValue(65)
+            self.require_same_label.setChecked(False)
+
     def get_config(self):
         """Return merge config from dialog."""
         config = {}
@@ -296,6 +382,12 @@ class MergeDialog(QDialog):
         for label in [l.strip() for l in self.ttb_labels_edit.text().split(',') if l.strip()]:
             per_label_directions[label] = 'TTB'
         config["PER_LABEL_DIRECTIONS"] = per_label_directions
+
+        if self.enable_include_labels.isChecked():
+            included = self.include_labels.text().strip()
+            config["LABELS_TO_INCLUDE_IN_MERGE"] = set(l.strip() for l in included.split(",") if l.strip())
+        else:
+            config["LABELS_TO_INCLUDE_IN_MERGE"] = set()
 
         if self.enable_exclude_labels.isChecked():
             excluded = self.exclude_labels.text().strip()

--- a/ui/model_manager_dialog.py
+++ b/ui/model_manager_dialog.py
@@ -156,7 +156,7 @@ class ModelManagerDialog(QDialog):
         # --- Download section ---
         download_group = QGroupBox(self.tr('Download models'))
         download_layout = QVBoxLayout(download_group)
-        desc = QLabel(self.tr('Select the models you want to download. Only modules with a predefined file list are listed.'))
+        desc = QLabel(self.tr('Select models to prepare. Modules that require first-use/on-load download are listed too (disabled here) so you can see full availability.'))
         desc.setWordWrap(True)
         download_layout.addWidget(desc)
         btn_row = QHBoxLayout()
@@ -203,8 +203,6 @@ class ModelManagerDialog(QDialog):
         row, col = 0, 0
         max_cols = 3
         for mod in self._module_infos:
-            if not mod['can_download']:
-                continue
             cb = QCheckBox(mod['display_name'])
             meta = mod.get('manifest_meta') or {}
             tooltip_bits = []
@@ -218,6 +216,12 @@ class ModelManagerDialog(QDialog):
             if tooltip_bits:
                 cb.setToolTip('\n'.join(tooltip_bits))
             cb.setToolTip(self._build_module_tooltip(mod))
+            if not mod.get('can_download', False):
+                cb.setEnabled(False)
+                reason = self.tr('Managed on first use (no explicit file list)')
+                if mod.get('download_mode') == 'no_download_list':
+                    reason = self.tr('No built-in downloader (install dependencies/model manually)')
+                cb.setToolTip((cb.toolTip() + '\n' if cb.toolTip() else '') + reason)
             cb.setProperty('module_info', mod)
             self.downloadCheckboxLayout.addWidget(cb, row, col)
             self._check_boxes.append(cb)

--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -699,6 +699,34 @@ class TextDetectConfigPanel(ModuleConfigParseWidget):
         self.vlayout.addWidget(self.tertiary_params_container)
         self._update_tertiary_params_visibility()
 
+        # Collision-based post-merge (word-level OCR cleanup)
+        self.merge_nearby_blocks_checker = QCheckBox(self.tr('Merge nearby detected blocks (word-level cleanup)'))
+        self.merge_nearby_blocks_checker.setToolTip(self.tr(
+            'When enabled, nearby text boxes can be merged after detection to fix word-level fragmentation. '
+            'Recommended when one bubble is split into many tiny boxes.'))
+        self.merge_nearby_blocks_checker.setChecked(bool(getattr(pcfg.module, 'merge_nearby_blocks_collision', False)))
+        self.merge_nearby_blocks_checker.clicked.connect(self._on_merge_nearby_blocks_changed)
+        merge_hl = QHBoxLayout()
+        merge_hl.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        merge_hl.addWidget(self.merge_nearby_blocks_checker)
+        merge_hl.addWidget(QLabel(self.tr('Min blocks:')))
+        self.merge_nearby_min_blocks_spinbox = QSpinBox()
+        self.merge_nearby_min_blocks_spinbox.setRange(4, 200)
+        self.merge_nearby_min_blocks_spinbox.setValue(int(getattr(pcfg.module, 'merge_nearby_blocks_min_blocks', 18) or 18))
+        self.merge_nearby_min_blocks_spinbox.setToolTip(self.tr('Only run merge when at least this many boxes are detected on a page.'))
+        self.merge_nearby_min_blocks_spinbox.valueChanged.connect(self._on_merge_nearby_min_blocks_changed)
+        merge_hl.addWidget(self.merge_nearby_min_blocks_spinbox)
+        merge_hl.addWidget(QLabel(self.tr('Gap ratio:')))
+        self.merge_nearby_gap_ratio_spinbox = QDoubleSpinBox()
+        self.merge_nearby_gap_ratio_spinbox.setRange(0.5, 4.0)
+        self.merge_nearby_gap_ratio_spinbox.setSingleStep(0.1)
+        self.merge_nearby_gap_ratio_spinbox.setDecimals(2)
+        self.merge_nearby_gap_ratio_spinbox.setValue(float(getattr(pcfg.module, 'merge_nearby_blocks_gap_ratio', 1.5) or 1.5))
+        self.merge_nearby_gap_ratio_spinbox.setToolTip(self.tr('Higher values merge more aggressively across nearby boxes.'))
+        self.merge_nearby_gap_ratio_spinbox.valueChanged.connect(self._on_merge_nearby_gap_ratio_changed)
+        merge_hl.addWidget(self.merge_nearby_gap_ratio_spinbox)
+        self.vlayout.addLayout(merge_hl)
+
     def _on_dual_detect_changed(self):
         pcfg.module.enable_dual_detect = self.dual_detect_checker.isChecked()
         self._update_secondary_params_visibility()
@@ -723,9 +751,11 @@ class TextDetectConfigPanel(ModuleConfigParseWidget):
         pcfg.module.enable_tertiary_detect = self.tertiary_detect_checker.isChecked()
         self._update_tertiary_params_visibility()
 
+
     def _on_tertiary_detector_changed(self, name: str):
         pcfg.module.textdetector_tertiary = (name or '').strip()
         self._update_tertiary_params_visibility()
+
 
     def _update_tertiary_params_visibility(self):
         ter_enabled = self.tertiary_detect_checker.isChecked()
@@ -756,6 +786,17 @@ class TextDetectConfigPanel(ModuleConfigParseWidget):
         self.tertiary_params_layout.addWidget(widget)
         widget.show()
         self.tertiary_visible_widget = widget
+
+
+    def _on_merge_nearby_blocks_changed(self):
+        enabled = self.merge_nearby_blocks_checker.isChecked()
+        pcfg.module.merge_nearby_blocks_collision = enabled
+
+    def _on_merge_nearby_min_blocks_changed(self, value: int):
+        pcfg.module.merge_nearby_blocks_min_blocks = int(value)
+
+    def _on_merge_nearby_gap_ratio_changed(self, value: float):
+        pcfg.module.merge_nearby_blocks_gap_ratio = float(value)
 
     def _on_tertiary_param_edited(self, param_key: str, param_content: dict):
         ter_name = (self.tertiary_detector_combobox.currentText() or '').strip()

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -1066,8 +1066,16 @@ class FontFormatPanel(Widget):
                     self.textblk_item.setPlainText(smart.text)
                 if getattr(self.textblk_item, 'blk', None) is not None:
                     self.textblk_item.blk.translation = smart.text
-            if abs(float(smart.font_size or 0.0) - float(getattr(fmt, 'font_size', 0.0) or 0.0)) > 0.2:
-                params.append(('font_size', float(smart.font_size)))
+            cur_font_size = float(getattr(fmt, 'font_size', 24.0) or 24.0)
+            target_font_size = float(smart.font_size or cur_font_size)
+            # Guardrail: diagnostics "quick fix" should not nuke layout by extreme jumps in one click.
+            min_step = max(6.0, cur_font_size * 0.65)
+            max_step = min(120.0, cur_font_size * 1.35)
+            clamped_font_size = max(min_step, min(max_step, target_font_size))
+            if abs(clamped_font_size - cur_font_size) > 0.2:
+                params.append(('font_size', float(clamped_font_size)))
+                if abs(clamped_font_size - target_font_size) > 0.2:
+                    (smart.actions or []).append(self.tr('font-size-clamped'))
             if smart.letter_spacing != getattr(fmt, 'letter_spacing', smart.letter_spacing):
                 params.append(('letter_spacing', float(smart.letter_spacing)))
             if smart.line_spacing != getattr(fmt, 'line_spacing', smart.line_spacing):
@@ -1076,7 +1084,7 @@ class FontFormatPanel(Widget):
             canvas = getattr(SW, 'canvas', None)
             if canvas is not None:
                 canvas.setProjSaveState(True)
-            self.letteringDiagnosticsLabel.setText(self.tr("Applied diagnostics fixes: {0}").format(', '.join((cleanup.actions or []) + (smart.actions or [])) or self.tr('none')))
+            self.letteringDiagnosticsLabel.setText(self.tr("Applied diagnostics fixes: {0} · font {1:.1f}px→{2:.1f}px").format(', '.join((cleanup.actions or []) + (smart.actions or [])) or self.tr('none'), cur_font_size, float(getattr(fmt, 'font_size', cur_font_size) or cur_font_size)))
         except Exception as exc:
             self.letteringDiagnosticsLabel.setText(self.tr("Diagnostics fix failed: {0}").format(exc))
 

--- a/utils/merger.py
+++ b/utils/merger.py
@@ -154,6 +154,9 @@ def get_merge_group_for_label(label, config):
 
 
 def can_labels_merge(label1, label2, config):
+    include_set = config.get("LABELS_TO_INCLUDE_IN_MERGE", set()) or set()
+    if include_set and (label1 not in include_set or label2 not in include_set):
+        return False
     if label1 in config.get("LABELS_TO_EXCLUDE_FROM_MERGE", set()) or label2 in config.get("LABELS_TO_EXCLUDE_FROM_MERGE", set()):
         return False
 

--- a/utils/model_manager.py
+++ b/utils/model_manager.py
@@ -215,6 +215,7 @@ def get_all_downloadable_modules() -> List[Dict[str, Any]]:
                 "description": description,
                 "module_class": module_class,
                 "can_download": can_download,
+                "download_mode": "explicit" if can_download else ("on_load" if on_load else "no_download_list"),
                 "manifest_meta": manifest_meta,
                 "estimated_download_size_bytes": dl_meta["estimated_download_size_bytes"],
                 "target_paths": dl_meta["target_paths"],


### PR DESCRIPTION
### Motivation

- Provide a richer Region Merge UX with quick profiles, preview (dry-run) for current page, whitelist support, and clearer interaction with detector-level collision-merge settings. 
- Harden a few UI flows (page list identity handling, frameless builds status messages) and prevent extreme one-click typography jumps from diagnostics fixes.
- Surface detector/manager download metadata and document new merge and rendering workflows.

### Description

- Added a new documentation page `docs/REGION_MERGE_TOOL.md` and updated `docs/RENDERING_TEXT_FORMATTING.md` with workflow, API, and rendering/lettering changes. 
- Merge dialog (`ui/merge_dialog.py`) was significantly extended with quick profiles (Conservative/Balanced/Aggressive), a `Preview current page` dry-run button and signal, include-only label (whitelist) controls, detector-default import, and coordination text explaining ordering vs detector merge. 
- Main window integrations (`ui/mainwindow.py`) now wire the preview dry-run signal, added `dry_run` handling to `run_merge_task`, show a best-effort `_show_status_message` for frameless builds, and updated page-list handling to store/use page names via `Qt.UserRole` so context-menu actions operate on canonical page IDs. 
- Page list context emits and selection helpers were changed to use `_item_page_name` and `_selected_page_names`, and page list items now show completion/ignored prefixes in the displayed text. 
- Detector UI (`ui/module_parse_widgets.py`) added collision-based post-merge controls (`merge_nearby_blocks_*`) to tune word-level cleanup after detection. 
- `utils/merger.py` updated to support include-only labels, kept other merge heuristics, and retained rectangle/rotated output options; no behavior-breaking rewrites beyond new whitelist logic and small refactors. 
- `ui/text_panel.py` clamps extreme one-click font-size jumps during diagnostics fixes (approx 65%–135% of current size) and appends a short font-change summary to the diagnostics label. 
- `ui/custom_widget/message.py` improved handling of the `modal` parameter (accepts truthy strings) for `MessageBox`. 
- `ui/model_manager_dialog.py` and `utils/model_manager.py` improve module download UI by enabling/disabling checkboxes for modules that cannot be explicitly downloaded, adding `download_mode` metadata and contextual tooltips. 

### Testing

- Ran the project's automated test suite via `pytest -q` against the changed modules and observed all tests passing. 
- Performed a lightweight UI smoke check (open Merge dialog, toggle profiles, preview current page, and apply conservative merge on a small sample project) with expected behavior for dry-run and apply flows. 
- No new automated tests were added in this change. }

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cd008faf0832ca47db033253657a9)