### PR TITLE
Import QDoubleSpinBox to fix NameError in module_parse_widgets

### DIFF
--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -10,7 +10,7 @@ from utils.shared import CONFIG_COMBOBOX_LONG, size2width, CONFIG_COMBOBOX_SHORT
 from utils.config import pcfg
 from utils.module_tiers import format_module_tier_tooltip
 
-from qtpy.QtWidgets import QPlainTextEdit, QHBoxLayout, QVBoxLayout, QWidget, QLabel, QCheckBox, QLineEdit, QGridLayout, QPushButton, QMessageBox, QSpinBox
+from qtpy.QtWidgets import QPlainTextEdit, QHBoxLayout, QVBoxLayout, QWidget, QLabel, QCheckBox, QLineEdit, QGridLayout, QPushButton, QMessageBox, QSpinBox, QDoubleSpinBox
 from qtpy.QtCore import Qt, Signal, QTimer
 from qtpy.QtGui import QDoubleValidator
 


### PR DESCRIPTION
### Motivation
- `TextDetectConfigPanel` uses `QDoubleSpinBox` but `ui/module_parse_widgets.py` did not import it, causing a startup `NameError` during UI initialization.

### Description
- Add `QDoubleSpinBox` to the `qtpy.QtWidgets` import line in `ui/module_parse_widgets.py` to make the type available where it is used.

### Testing
- Ran `python -m py_compile ui/module_parse_widgets.py` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cd438acfc832c8bc8bc42db3ac5c3)