### PR TITLE
Align spell-check bottom-bar button and update spellcheck SVGs

### DIFF
--- a/icons/bottombar_spellcheck.svg
+++ b/icons/bottombar_spellcheck.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg class="icon" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg" width="128" height="128">
-  <g fill="none" stroke="#96a4cd" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <g fill="none" stroke="#697186" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
     <path d="M27 36h52"/>
     <path d="M27 58h47"/>
     <path d="M27 80h34"/>

--- a/icons/bottombar_spellcheck_activate.svg
+++ b/icons/bottombar_spellcheck_activate.svg
@@ -1,3 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
-  <path fill="#36A3FF" d="M5.25 4.5h8.5c.41 0 .75.34.75.75s-.34.75-.75.75h-8.5c-.41 0-.75-.34-.75-.75s.34-.75.75-.75Zm0 4h11.5c.41 0 .75.34.75.75s-.34.75-.75.75H5.25c-.41 0-.75-.34-.75-.75s.34-.75.75-.75Zm0 4h6.25c.41 0 .75.34.75.75s-.34.75-.75.75H5.25c-.41 0-.75-.34-.75-.75s.34-.75.75-.75Zm14.53.72a.75.75 0 0 1 0 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-2.25-2.25a.75.75 0 1 1 1.06-1.06l1.72 1.72 3.97-3.97a.75.75 0 0 1 1.06 0Z"/>
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <g fill="none" stroke="#96a4cd" stroke-width="9" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M27 36h52"/>
+    <path d="M27 58h47"/>
+    <path d="M27 80h34"/>
+    <path d="M76 78l14 14 25-34"/>
+  </g>
 </svg>

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -1914,11 +1914,11 @@ class BottomBar(Widget):
         # QToolButton style metrics can shift this icon differently in the
         # settings stack vs the normal canvas stack.
         self.spellCheckChecker.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
-        self.spellCheckChecker.setFixedSize(44, 34)
+        self.spellCheckChecker.setFixedSize(44, 40)
         self.spellCheckChecker.setIconSize(QSize(28, 28))
+        self.spellCheckChecker.setStyleSheet("QToolButton { padding: 0px; margin: 0px; }")
         self.spellCheckChecker.setCheckable(True)
         self.spellCheckChecker.setAutoRaise(True)
-        self.spellCheckChecker.setFixedSize(44, 40)
         self.spellCheckChecker.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonIconOnly)
         self.spellCheckChecker.setToolTip(self.tr('Spell check panel: review OCR/translation spelling issues'))
         self.spellCheckChecker.setAccessibleName(self.tr('Spell check panel'))
@@ -1984,6 +1984,7 @@ class BottomBar(Widget):
         self.hlayout.addWidget(self.paintChecker)
         self.hlayout.addWidget(self.texteditChecker)
         self.hlayout.addWidget(self.spellCheckChecker)
+        self.hlayout.addSpacing(6)
         self.hlayout.addWidget(self.textblockChecker)
         self.hlayout.setContentsMargins(0, 0, 10, WINDOW_BORDER_WIDTH)
         self.hlayout.setAlignment(Qt.AlignmentFlag.AlignVCenter)

--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -10,7 +10,7 @@ from utils.shared import CONFIG_COMBOBOX_LONG, size2width, CONFIG_COMBOBOX_SHORT
 from utils.config import pcfg
 from utils.module_tiers import format_module_tier_tooltip
 
-from qtpy.QtWidgets import QPlainTextEdit, QHBoxLayout, QVBoxLayout, QWidget, QLabel, QCheckBox, QLineEdit, QGridLayout, QPushButton, QMessageBox, QSpinBox
+from qtpy.QtWidgets import QPlainTextEdit, QHBoxLayout, QVBoxLayout, QWidget, QLabel, QCheckBox, QLineEdit, QGridLayout, QPushButton, QMessageBox, QSpinBox, QDoubleSpinBox
 from qtpy.QtCore import Qt, Signal, QTimer
 from qtpy.QtGui import QDoubleValidator
 


### PR DESCRIPTION
### Motivation
- Ensure the bottom-bar spell-check button icon is visually centered and consistent with neighboring mode buttons and provide an explicit SVG fallback for themes that lack a QSS image rule. 
- Fix a missing Qt widget import to enable use of double-valued spin boxes in parameter widgets.

### Description
- Updated `icons/bottombar_spellcheck.svg` and replaced `icons/bottombar_spellcheck_activate.svg` with standardized 128×128 SVGs and adjusted stroke color to better match the theme.
- Modified `ui/mainwindowbars.py` to set the spell-check button metrics with `setFixedSize(44, 40)`, `setIconSize(QSize(28, 28))`, add `setStyleSheet("QToolButton { padding: 0px; margin: 0px; }")`, removed a duplicate sizing call, and inserted `hlayout.addSpacing(6)` to improve spacing in the bottom bar.
- Added `QDoubleSpinBox` to the imports in `ui/module_parse_widgets.py` so double spin boxes can be used in parameter input widgets.

### Testing
- No automated tests were run for these UI and asset changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0cd438acfc832c8bc8bc42db3ac5c3)