### PR TITLE
Default-facing UI/UX rework foundation with modern shell and flexible refiner

### DIFF
--- a/data/model_manifest.json
+++ b/data/model_manifest.json
@@ -97,6 +97,109 @@
       "size_estimate": "~30 MB",
       "required_deps": [],
       "support_tier": "advanced"
+    },
+    {
+      "module_key": "ysg_comic_text_segmenter_v8m",
+      "category": "textdetector",
+      "size_estimate": "~210 MB",
+      "required_deps": [
+        "ultralytics"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "ysg_comic_speech_bubble_v8m",
+      "category": "textdetector",
+      "size_estimate": "~210 MB",
+      "required_deps": [
+        "ultralytics"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "mangalens_bubble_segmentation",
+      "category": "textdetector",
+      "size_estimate": "~1.2 GB",
+      "required_deps": [
+        "torch",
+        "transformers"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "sam2_1_hiera_large",
+      "category": "textdetector",
+      "size_estimate": "~1.1 GB",
+      "required_deps": [
+        "torch",
+        "transformers"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "sam3_hiera_large",
+      "category": "textdetector",
+      "size_estimate": "~1.3 GB",
+      "required_deps": [
+        "torch",
+        "transformers"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "flux1_kontext_inpaint",
+      "category": "inpaint",
+      "size_estimate": "~12 GB",
+      "required_deps": [
+        "diffusers",
+        "torch"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "flux2_klein_inpaint",
+      "category": "inpaint",
+      "size_estimate": "~8 GB",
+      "required_deps": [
+        "diffusers",
+        "torch"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "opencv_inpaint_fast",
+      "category": "inpaint",
+      "size_estimate": "~0 MB",
+      "required_deps": [],
+      "support_tier": "core"
+    },
+    {
+      "module_key": "paddleocr_vl_1_5",
+      "category": "ocr",
+      "size_estimate": "~2.0 GB",
+      "required_deps": [
+        "transformers",
+        "torch"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "realcugan_upscaler",
+      "category": "upscale",
+      "size_estimate": "~70 MB",
+      "required_deps": [
+        "onnxruntime"
+      ],
+      "support_tier": "community"
+    },
+    {
+      "module_key": "anime_sharp_v4_x2",
+      "category": "upscale",
+      "size_estimate": "~95 MB",
+      "required_deps": [
+        "onnxruntime"
+      ],
+      "support_tier": "community"
     }
   ],
   "packages": [
@@ -181,6 +284,57 @@
         {
           "category": "_optional_onnx",
           "module_key": null
+        }
+      ]
+    },
+    {
+      "id": "community_showcase",
+      "label": "Community showcase models",
+      "description": "Optional community models shown in project feature screenshots (segmentation, inpaint, OCR-VL, upscaling).",
+      "modules": [
+        {
+          "category": "textdetector",
+          "module_key": "ysg_comic_text_segmenter_v8m"
+        },
+        {
+          "category": "textdetector",
+          "module_key": "ysg_comic_speech_bubble_v8m"
+        },
+        {
+          "category": "textdetector",
+          "module_key": "mangalens_bubble_segmentation"
+        },
+        {
+          "category": "textdetector",
+          "module_key": "sam2_1_hiera_large"
+        },
+        {
+          "category": "textdetector",
+          "module_key": "sam3_hiera_large"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "flux1_kontext_inpaint"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "flux2_klein_inpaint"
+        },
+        {
+          "category": "inpaint",
+          "module_key": "opencv_inpaint_fast"
+        },
+        {
+          "category": "ocr",
+          "module_key": "paddleocr_vl_1_5"
+        },
+        {
+          "category": "upscale",
+          "module_key": "realcugan_upscaler"
+        },
+        {
+          "category": "upscale",
+          "module_key": "anime_sharp_v4_x2"
         }
       ]
     }

--- a/docs/DEFAULT_MODE_DASHBOARD_MIGRATION.md
+++ b/docs/DEFAULT_MODE_DASHBOARD_MIGRATION.md
@@ -1,0 +1,103 @@
+# Default mode dashboard migration
+
+This document records the default-facing dashboard slice for the UI/UX rework.
+
+## What changed
+
+The modern mode dashboards are no longer only experimental preview components. They are now installed into the default `MainWindow.centralStackWidget` through `ui/default_mode_dashboards.py`.
+
+The installer appends dashboard landing pages after the existing default pages:
+
+1. Welcome
+2. Legacy editor
+3. Legacy settings
+4. Live Translation dashboard
+5. Quick Image dashboard
+6. Raw Downloader dashboard
+7. Batch Queue dashboard
+8. Translation Assist / QA dashboard
+9. Models / Providers dashboard
+10. Diagnostics / Help dashboard
+
+This keeps the legacy editor/settings surfaces intact while giving the mode rail real landing pages.
+
+## Routing behavior
+
+`install_default_mode_dashboards()` also reroutes the default `ModeRail` after it has been installed.
+
+Mode behavior:
+
+- Home still opens the existing welcome screen.
+- Editor still opens the existing editor when a project is loaded, or returns to welcome when no project is open.
+- Settings still opens the existing settings panel.
+- Live, Quick Image, Downloader, Batch, Assist, Models, and Diagnostics now show dashboard landing pages first.
+
+Dashboard action buttons then call existing handlers through `dashboard_action_dispatcher.py`.
+
+Supported dispatch targets:
+
+- registered QAction IDs when present
+- direct MainWindow handlers, for example `on_open_realtime_translator`
+- dotted child-widget handlers, for example `leftBar.onOpenImages`
+
+## Why this is safe
+
+The dashboards are additive.
+
+They do not remove:
+
+- legacy `LeftBar`
+- legacy menus
+- welcome screen
+- editor canvas
+- settings panel
+- text/style panels
+- progress dialogs
+- model manager flows
+- local API routes
+
+They only add dashboard pages and route mode-rail clicks to those pages.
+
+If dashboard installation fails, the rail falls back to the existing handlers.
+
+## Current tests
+
+Covered by `tests/test_default_mode_dashboards.py`:
+
+- dashboard pages are appended to the central stack
+- installation is idempotent
+- dashboards can be shown by mode key
+- rail routing prefers dashboard pages when available
+- legacy fallback still works when dashboards are not installed
+- installed `ModeRail` routes to dashboard pages
+- dashboard actions can dispatch to existing child-widget handlers and log status
+
+Also covered by `tests/test_dashboard_action_dispatcher.py`:
+
+- action registry dispatch
+- direct handler fallback
+- dotted child-handler fallback
+- editor layout-review route
+- known safe routes
+
+## Remaining work
+
+Dashboard pages still need real live data:
+
+- project page count
+- current project status
+- pipeline stage state
+- model/provider health
+- warning counts
+- downloader source health
+- batch queue counts
+- realtime latency/state
+- Translation Assist candidate/glossary/TM status
+
+Until those metrics are wired, dashboards act as modern navigation and action launchers rather than full operational dashboards.
+
+## Migration rule
+
+Do not replace the legacy editor with dashboards until feature parity is confirmed.
+
+The next dashboard PR should focus on metrics and status wiring, not removing old surfaces.

--- a/docs/DEFAULT_UI_REWORK_COMMITMENT.md
+++ b/docs/DEFAULT_UI_REWORK_COMMITMENT.md
@@ -1,0 +1,165 @@
+# Default UI rework commitment
+
+The experimental shell is not intended to remain a hidden side feature. It is scaffolding for safely replacing the default BallonsTranslator-Pro UI.
+
+## Product decision
+
+The reworked UI should become the default UI.
+
+Legacy UI should become:
+
+- a temporary fallback during migration
+- a troubleshooting/rollback option
+- eventually a compatibility mode, not the primary product surface
+
+## Design principle
+
+Modern does not mean simple.
+
+For BallonsTranslator-Pro, modern means:
+
+- advanced
+- dense where useful
+- professional
+- polished
+- discoverable
+- fast for power users
+- approachable for new users without hiding expert tools
+
+The goal is not to remove menus, panels, QA tools, CAT features, model controls, diagnostics, or export formats. The goal is to organize them into a high-quality interface with clear modes, strong visual hierarchy, and fewer confusing duplicate entry points.
+
+## Default target shell
+
+The default app should move toward:
+
+- left mode rail
+- top command/status bar
+- center workflow workspace
+- right inspector
+- bottom job/status drawer
+- command palette
+- legacy menus available during migration
+
+Default modes:
+
+1. Home
+2. Editor
+3. Live Translation
+4. Quick Image
+5. Raw Downloader
+6. Batch Queue
+7. Translation Assist / QA
+8. Models / Providers
+9. Settings
+10. Diagnostics / Help
+
+## Migration rule
+
+Do not delete the legacy editor until the modern shell has feature parity.
+
+Instead:
+
+1. Make Home/Launcher modern by default.
+2. Add the mode rail as the default navigation surface.
+3. Embed the existing editor canvas into the Editor page.
+4. Embed existing right-side text/style/OCR panels into the EditorInspector tabs.
+5. Embed existing progress/job reporting into JobStatusDrawer.
+6. Wire dashboard actions to existing handlers via `dashboard_action_dispatcher.py`.
+7. Move raw downloader, live translation, batch queue, models, and diagnostics into their mode pages.
+8. Keep old menus and keyboard shortcuts during migration.
+9. Add `use_legacy_ui` as the rollback option.
+
+## Current branch state
+
+Already added:
+
+- `ui/design_tokens.py`
+- `ui/workflow_home.py`
+- `ui/mode_rail.py`
+- `ui/editor_inspector.py`
+- `ui/job_status_drawer.py`
+- `ui/mode_dashboard.py`
+- `ui/experimental_app_shell.py`
+- `ui/experimental_shell_preview_dialog.py`
+- `ui/dashboard_action_router.py`
+- `ui/dashboard_action_dispatcher.py`
+- `ui/experimental_shell_settings.py`
+- `ui/experimental_shell_menu.py`
+- `ui/experimental_shell_bootstrap.py`
+
+Already default-facing:
+
+- `WelcomeWidget` embeds `WorkflowHomeWidget`.
+- Existing welcome screen now uses workflow cards.
+
+Still to make default-facing:
+
+- Install modern mode rail into main layout.
+- Install editor inspector into the editor workspace.
+- Install job drawer into the main window.
+- Make dashboard actions call existing handlers.
+- Make the experimental shell become the default app shell once legacy editor embedding is complete.
+
+## Next implementation order
+
+### Milestone A: default Home
+
+Status: mostly complete.
+
+- Modern workflow cards are in the default welcome screen.
+- Continue polishing setup health, recent workflows, and model/provider warnings.
+
+### Milestone B: default navigation
+
+- Add `ModeRail` beside or in place of the legacy `LeftBar`.
+- Keep legacy `LeftBar` available through `use_legacy_left_bar` during migration.
+- Connect modes to existing handlers:
+  - Home -> welcome screen
+  - Editor -> existing editor
+  - Live -> realtime translator
+  - Quick Image -> open images
+  - Downloader -> raw downloader
+  - Batch -> batch queue
+  - Assist -> Translation Assist dock
+  - Models -> model manager
+  - Settings -> config panel
+  - Diagnostics -> environment doctor / logs
+
+### Milestone C: default editor inspector
+
+- Add `EditorInspector` as the primary right-side panel.
+- Move existing text/style/layout/OCR/QA controls into tabs.
+- Preserve existing panels until parity is confirmed.
+
+### Milestone D: default job/status drawer
+
+- Add `JobStatusDrawer` under the editor workspace.
+- Feed it OCR/translation/inpaint/render/export/download/model jobs.
+- Keep existing progress dialogs until parity is confirmed.
+
+### Milestone E: default advanced dashboards
+
+- Use `ModeDashboard` pages for mode landing screens.
+- Wire dashboard actions through `dashboard_action_dispatcher.py`.
+- Replace placeholder pages with real workflow UI.
+
+### Milestone F: legacy fallback
+
+- Add `use_legacy_ui` config.
+- Keep legacy layout reachable while modern shell becomes default.
+- Add UI reset/troubleshooting docs.
+
+## Acceptance criteria
+
+The rework is not complete until:
+
+- the modern shell is the default app UI
+- legacy UI is a fallback, not the main path
+- all current features remain accessible
+- existing projects/configs continue to work
+- model manager and first-run picker continue to work
+- local API routes continue to work
+- startup scripts continue to work
+- power-user menu/shortcut workflows continue to work
+- modern dashboards expose advanced tools instead of hiding them
+- the app feels polished like high-quality modern software, with Dango-like friendliness and ImageTrans-like professional depth

--- a/docs/DEFAULT_UI_REWORK_COMMITMENT.md
+++ b/docs/DEFAULT_UI_REWORK_COMMITMENT.md
@@ -61,13 +61,14 @@ Instead:
 
 1. Make Home/Launcher modern by default.
 2. Add the mode rail as the default navigation surface.
-3. Embed the existing editor canvas into the Editor page.
-4. Embed existing right-side text/style/OCR panels into the EditorInspector tabs.
-5. Embed existing progress/job reporting into JobStatusDrawer.
-6. Wire dashboard actions to existing handlers via `dashboard_action_dispatcher.py`.
-7. Move raw downloader, live translation, batch queue, models, and diagnostics into their mode pages.
-8. Keep old menus and keyboard shortcuts during migration.
-9. Add `use_legacy_ui` as the rollback option.
+3. Add the bottom job/status drawer as the default status surface.
+4. Embed the existing editor canvas into the Editor page.
+5. Embed existing right-side text/style/OCR panels into the EditorInspector tabs.
+6. Feed real pipeline/export/download jobs into JobStatusDrawer.
+7. Wire dashboard actions to existing handlers via `dashboard_action_dispatcher.py`.
+8. Move raw downloader, live translation, batch queue, models, and diagnostics into their mode pages.
+9. Keep old menus and keyboard shortcuts during migration.
+10. Add `use_legacy_ui` as the rollback option.
 
 ## Current branch state
 
@@ -94,16 +95,19 @@ Already default-facing:
 - Existing welcome screen now uses workflow cards.
 - `WelcomeWidget` now schedules `install_default_modern_navigation()` so `ModeRail` is inserted into the default `MainWindow` layout beside the legacy `LeftBar`.
 - `ModeRail` routes default modes to existing handlers without replacing legacy controls yet.
+- `ModeRail` selection is kept in sync when legacy handlers navigate to Home, Editor, Live, Downloader, Batch, Assist, Models, Settings, or Diagnostics.
 - `WelcomeWidget.open_assist_requested` has a fallback connection to Translation Assist through `install_default_welcome_signal_fallbacks()`.
+- `install_default_job_drawer()` inserts a collapsed `JobStatusDrawer` into the default `MainWindow` layout before the legacy `BottomBar` when available.
+- The job drawer is a default status surface but does not replace legacy progress dialogs yet.
 
 Covered by tests:
 
-- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, and mode routing reuses existing handlers.
+- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, mode routing reuses existing handlers, legacy navigation keeps the rail synced, welcome Assist fallback connects once, the collapsed job drawer installs before `BottomBar`, and jobs can be upserted into the drawer.
 
 Still to make default-facing:
 
 - Install editor inspector into the editor workspace.
-- Install job drawer into the main window.
+- Feed real OCR/translation/inpaint/export/download/model jobs into `JobStatusDrawer`.
 - Make dashboard actions call existing handlers from the default shell.
 - Make the experimental shell become the default app shell once legacy editor embedding is complete.
 
@@ -137,20 +141,28 @@ Status: initial default-facing implementation complete.
 Remaining navigation work:
 
 - Add a `use_legacy_ui` / `use_legacy_left_bar` rollback setting before hiding or replacing the legacy left bar.
-- Sync current rail selection after every navigation path, not only rail-originated navigation.
 - Add richer visual state for project/job/provider health.
 
-### Milestone C: default editor inspector
+### Milestone C: default job/status drawer
+
+Status: initial default-facing implementation complete.
+
+- `JobStatusDrawer` is installed collapsed into the default main layout before `BottomBar`.
+- It can accept `JobStatusSpec` entries through `upsert_default_job()`.
+- It intentionally does not replace existing progress dialogs yet.
+
+Remaining drawer work:
+
+- Feed module-manager pipeline stage events into the drawer.
+- Feed batch/export/archive/download/model jobs into the drawer.
+- Add clear completed, details, cancel, pause, and resume behavior per real job type.
+- Preserve legacy progress dialogs until the drawer has parity.
+
+### Milestone D: default editor inspector
 
 - Add `EditorInspector` as the primary right-side panel.
 - Move existing text/style/layout/OCR/QA controls into tabs.
 - Preserve existing panels until parity is confirmed.
-
-### Milestone D: default job/status drawer
-
-- Add `JobStatusDrawer` under the editor workspace.
-- Feed it OCR/translation/inpaint/render/export/download/model jobs.
-- Keep existing progress dialogs until parity is confirmed.
 
 ### Milestone E: default advanced dashboards
 

--- a/docs/DEFAULT_UI_REWORK_COMMITMENT.md
+++ b/docs/DEFAULT_UI_REWORK_COMMITMENT.md
@@ -99,15 +99,17 @@ Already default-facing:
 - `WelcomeWidget.open_assist_requested` has a fallback connection to Translation Assist through `install_default_welcome_signal_fallbacks()`.
 - `install_default_job_drawer()` inserts a collapsed `JobStatusDrawer` into the default `MainWindow` layout before the legacy `BottomBar` when available.
 - The job drawer is a default status surface but does not replace legacy progress dialogs yet.
+- Pipeline stage events are mirrored into the drawer as a `pipeline-current` job after legacy handlers run.
+- Pipeline completion marks the drawer's current pipeline job as succeeded after legacy completion logic runs.
 
 Covered by tests:
 
-- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, mode routing reuses existing handlers, legacy navigation keeps the rail synced, welcome Assist fallback connects once, the collapsed job drawer installs before `BottomBar`, and jobs can be upserted into the drawer.
+- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, mode routing reuses existing handlers, legacy navigation keeps the rail synced, welcome Assist fallback connects once, the collapsed job drawer installs before `BottomBar`, jobs can be upserted into the drawer, pipeline stage events update the drawer, and pipeline finish marks the drawer job succeeded.
 
 Still to make default-facing:
 
 - Install editor inspector into the editor workspace.
-- Feed real OCR/translation/inpaint/export/download/model jobs into `JobStatusDrawer`.
+- Feed export/download/model jobs into `JobStatusDrawer`.
 - Make dashboard actions call existing handlers from the default shell.
 - Make the experimental shell become the default app shell once legacy editor embedding is complete.
 
@@ -149,11 +151,12 @@ Status: initial default-facing implementation complete.
 
 - `JobStatusDrawer` is installed collapsed into the default main layout before `BottomBar`.
 - It can accept `JobStatusSpec` entries through `upsert_default_job()`.
+- Pipeline stage events update a current pipeline job with stage, page, progress, and cancel availability.
+- Pipeline completion updates that job to `succeeded` at 100%.
 - It intentionally does not replace existing progress dialogs yet.
 
 Remaining drawer work:
 
-- Feed module-manager pipeline stage events into the drawer.
 - Feed batch/export/archive/download/model jobs into the drawer.
 - Add clear completed, details, cancel, pause, and resume behavior per real job type.
 - Preserve legacy progress dialogs until the drawer has parity.

--- a/docs/DEFAULT_UI_REWORK_COMMITMENT.md
+++ b/docs/DEFAULT_UI_REWORK_COMMITMENT.md
@@ -62,13 +62,14 @@ Instead:
 1. Make Home/Launcher modern by default.
 2. Add the mode rail as the default navigation surface.
 3. Add the bottom job/status drawer as the default status surface.
-4. Embed the existing editor canvas into the Editor page.
-5. Embed existing right-side text/style/OCR panels into the EditorInspector tabs.
-6. Feed real pipeline/export/download jobs into JobStatusDrawer.
-7. Wire dashboard actions to existing handlers via `dashboard_action_dispatcher.py`.
-8. Move raw downloader, live translation, batch queue, models, and diagnostics into their mode pages.
-9. Keep old menus and keyboard shortcuts during migration.
-10. Add `use_legacy_ui` as the rollback option.
+4. Add the editor inspector as the default right-side shell, initially alongside legacy panels.
+5. Embed the existing editor canvas into the Editor page.
+6. Move existing right-side text/style/OCR panels into the EditorInspector tabs.
+7. Feed real pipeline/export/download jobs into JobStatusDrawer.
+8. Wire dashboard actions to existing handlers via `dashboard_action_dispatcher.py`.
+9. Move raw downloader, live translation, batch queue, models, and diagnostics into their mode pages.
+10. Keep old menus and keyboard shortcuts during migration.
+11. Add `use_legacy_ui` as the rollback option.
 
 ## Current branch state
 
@@ -101,17 +102,20 @@ Already default-facing:
 - The job drawer is a default status surface but does not replace legacy progress dialogs yet.
 - Pipeline stage events are mirrored into the drawer as a `pipeline-current` job after legacy handlers run.
 - Pipeline completion marks the drawer's current pipeline job as succeeded after legacy completion logic runs.
+- `install_default_editor_inspector()` adds `EditorInspector` to the existing right-side editor stack.
+- `EditorInspector` buttons reuse existing handlers for Translation Assist, OCR crop/triage, layout review, and typography QA.
+- The inspector is additive and does not replace `DrawingPanel`, `TextPanel`, `SpellCheckPanel`, `PipelineInsightsWidget`, `MaskDiagnosticsWidget`, or `OcrCropInspectorWidget` yet.
 
 Covered by tests:
 
-- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, mode routing reuses existing handlers, legacy navigation keeps the rail synced, welcome Assist fallback connects once, the collapsed job drawer installs before `BottomBar`, jobs can be upserted into the drawer, pipeline stage events update the drawer, and pipeline finish marks the drawer job succeeded.
+- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, mode routing reuses existing handlers, legacy navigation keeps the rail synced, welcome Assist fallback connects once, the collapsed job drawer installs before `BottomBar`, jobs can be upserted into the drawer, pipeline stage events update the drawer, pipeline finish marks the drawer job succeeded, the editor inspector installs into the right stack, and inspector buttons call existing handlers.
 
 Still to make default-facing:
 
-- Install editor inspector into the editor workspace.
 - Feed export/download/model jobs into `JobStatusDrawer`.
 - Make dashboard actions call existing handlers from the default shell.
 - Make the experimental shell become the default app shell once legacy editor embedding is complete.
+- Replace inspector placeholders with embedded legacy controls after parity is confirmed.
 
 ## Next implementation order
 
@@ -163,9 +167,18 @@ Remaining drawer work:
 
 ### Milestone D: default editor inspector
 
-- Add `EditorInspector` as the primary right-side panel.
-- Move existing text/style/layout/OCR/QA controls into tabs.
-- Preserve existing panels until parity is confirmed.
+Status: initial default-facing implementation complete.
+
+- `EditorInspector` is installed into `rightComicTransStackPanel` as an additional panel.
+- Its buttons call existing handlers instead of duplicating editor logic.
+- Legacy panels remain available until parity is confirmed.
+
+Remaining inspector work:
+
+- Make it the primary right-side panel when opening projects.
+- Move/embed existing text, style, layout, OCR, assist, QA, and metadata controls into inspector tabs.
+- Update selected-block previews as canvas selection changes.
+- Keep a fallback path to the current TextPanel/DrawingPanel stack while migrating.
 
 ### Milestone E: default advanced dashboards
 

--- a/docs/DEFAULT_UI_REWORK_COMMITMENT.md
+++ b/docs/DEFAULT_UI_REWORK_COMMITMENT.md
@@ -76,6 +76,7 @@ Already added:
 - `ui/design_tokens.py`
 - `ui/workflow_home.py`
 - `ui/mode_rail.py`
+- `ui/default_modern_shell.py`
 - `ui/editor_inspector.py`
 - `ui/job_status_drawer.py`
 - `ui/mode_dashboard.py`
@@ -91,13 +92,19 @@ Already default-facing:
 
 - `WelcomeWidget` embeds `WorkflowHomeWidget`.
 - Existing welcome screen now uses workflow cards.
+- `WelcomeWidget` now schedules `install_default_modern_navigation()` so `ModeRail` is inserted into the default `MainWindow` layout beside the legacy `LeftBar`.
+- `ModeRail` routes default modes to existing handlers without replacing legacy controls yet.
+- `WelcomeWidget.open_assist_requested` has a fallback connection to Translation Assist through `install_default_welcome_signal_fallbacks()`.
+
+Covered by tests:
+
+- `tests/test_default_modern_shell.py` verifies that the rail is inserted before `LeftBar`, installation is idempotent, and mode routing reuses existing handlers.
 
 Still to make default-facing:
 
-- Install modern mode rail into main layout.
 - Install editor inspector into the editor workspace.
 - Install job drawer into the main window.
-- Make dashboard actions call existing handlers.
+- Make dashboard actions call existing handlers from the default shell.
 - Make the experimental shell become the default app shell once legacy editor embedding is complete.
 
 ## Next implementation order
@@ -111,9 +118,11 @@ Status: mostly complete.
 
 ### Milestone B: default navigation
 
-- Add `ModeRail` beside or in place of the legacy `LeftBar`.
-- Keep legacy `LeftBar` available through `use_legacy_left_bar` during migration.
-- Connect modes to existing handlers:
+Status: initial default-facing implementation complete.
+
+- `ModeRail` is installed beside the legacy `LeftBar` by `ui/default_modern_shell.py`.
+- Legacy `LeftBar` stays visible and functional during migration.
+- Mode routes currently map to existing handlers:
   - Home -> welcome screen
   - Editor -> existing editor
   - Live -> realtime translator
@@ -123,7 +132,13 @@ Status: mostly complete.
   - Assist -> Translation Assist dock
   - Models -> model manager
   - Settings -> config panel
-  - Diagnostics -> environment doctor / logs
+  - Diagnostics -> environment doctor
+
+Remaining navigation work:
+
+- Add a `use_legacy_ui` / `use_legacy_left_bar` rollback setting before hiding or replacing the legacy left bar.
+- Sync current rail selection after every navigation path, not only rail-originated navigation.
+- Add richer visual state for project/job/provider health.
 
 ### Milestone C: default editor inspector
 

--- a/docs/UI_ACTION_REGISTRY.md
+++ b/docs/UI_ACTION_REGISTRY.md
@@ -1,0 +1,37 @@
+# UI Action Registry
+
+## Purpose
+Provide one source of truth for menu/command discoverability metadata before visual navigation changes.
+
+## Implementation
+- New module: `ui/action_registry.py`
+- Core model: `ActionRecord`
+- Registry API:
+  - `register_qaction(...)`
+  - `register_menu_tree(...)`
+  - `discoverable_actions()`
+  - `duplicate_shortcuts()`
+
+## Current migration coverage
+Registry-backed discoverability is now wired for existing title-bar menu trees:
+- File
+- Edit
+- View
+- Go
+- Pipeline
+- Tools
+
+## Notes
+- This milestone intentionally does not rebind handlers or rewrite menu construction.
+- Action IDs are deterministic slug IDs generated from top-level/menu-path/label.
+- Next phase will add explicit stable IDs for backward command aliases.
+
+## Enhancements in current pass
+- Registry now tracks action enabled-state metadata.
+- Discoverability API supports `show_unavailable` so command palette can optionally include disabled commands with reasons.
+
+- Added registry export support: users can now export full action metadata to JSON from the UI for audit/migration verification.
+
+- Added `summary_stats()` and in-app **Validate action registry now** command to quickly audit totals, visibility distribution, and duplicate shortcuts.
+
+- Registry rows now include `top_level`, `category`, and `workflow_mode` metadata for stronger downstream remapping/reporting.

--- a/docs/UI_COMPETITOR_VISUAL_RESEARCH.md
+++ b/docs/UI_COMPETITOR_VISUAL_RESEARCH.md
@@ -1,0 +1,171 @@
+# UI competitor visual research
+
+This document records visual/product references for the BallonsTranslator-Pro UI/UX rework. It is intentionally implementation-oriented: each reference is converted into concrete UI decisions for Pro.
+
+## Scope
+
+References reviewed:
+
+- ImageTrans / BasicCAT
+- Dango Translator / 团子翻译器
+- manga-image-translator
+- Project Naptha-style browser image text interaction
+- MangaDex/Tachiyomi-style library and reader conventions
+
+## ImageTrans takeaways
+
+ImageTrans is closest to the professional scanlation/CAT-tool workflow.
+
+Observed layout:
+
+- Top menu bar: File, Edit, Project, Tools, About.
+- Top command strip: OCR button, source/target language selectors, engine selector, checkboxes for automatic OCR/translation cleanup behavior.
+- Left workspace: image canvas with detected text boxes visible as colored rectangles.
+- Right workspace: source OCR text, target translation text, save/spellcheck/cleanup controls.
+- Lower right tabs: Text areas, Translation assist, Panel.
+- Translation assist table compares multiple machine translation outputs with a provider/source note column.
+- Term/glossary hints appear near the translation/editor area.
+
+What to emulate:
+
+1. Keep a professional editor mode with a big canvas and an inspector/assist area.
+2. Make Translation Assist a first-class dock/tab, not a hidden menu command.
+3. Show multiple translation candidates in a table with provider names.
+4. Keep selected block source/target editing close to the canvas.
+5. Expose reading order/text-area data in a tabular panel.
+6. Keep manual adjustment available for every automatic step.
+
+What not to emulate directly:
+
+1. The old gray desktop style feels dated.
+2. Too many controls in the top strip can overwhelm new users.
+3. The top-level menu names are simple, but they do not scale to Pro's feature count.
+
+## Dango Translator takeaways
+
+Dango is strongest as a consumer-friendly live/image translator experience.
+
+Observed layout patterns:
+
+- First-run or mode screen uses large illustrated cards for two clear modes: realtime translation and manga translation.
+- Manga mode uses a left image list, a central before/after workspace, and a right style/settings inspector.
+- Top area shows import/one-click translate/export actions and progress/status details.
+- Right inspector has tabs/categories for text box style, global style, and templates.
+- Live translation uses a lightweight overlay above another app/game with translated text in place.
+- Recent Dango notes emphasize capture-window exclusion so the overlay does not pollute OCR.
+
+What to emulate:
+
+1. Add a friendly Home/Launcher with workflow cards.
+2. Split Pro into clear modes: Editor, Live Translation, Quick Image, Raw Downloader, Batch, Assist/QA, Models, Settings.
+3. Use a left navigation rail for major modes instead of relying only on menus.
+4. Use a right inspector for selected text/style/provider details.
+5. Add top job/progress status that is always visible for long-running workflows.
+6. Make live translation feel like a separate lightweight product surface.
+7. Use softer visual hierarchy, clearer spacing, and more obvious primary actions.
+
+What not to emulate directly:
+
+1. Do not make the UI too cute or brand-specific.
+2. Do not hide advanced scanlation features behind a consumer-only flow.
+3. Do not make cloud/account sync required.
+
+## manga-image-translator takeaways
+
+manga-image-translator is strongest for automation and server/headless workflows, not a polished desktop editor.
+
+What to emulate:
+
+1. Clear stage pipeline mental model: detection, OCR, translation, inpaint, render/export.
+2. A compact job/progress surface for long tasks.
+3. Presets for common workflows: full translate, OCR only, cleanup only, translate only.
+4. API/headless parity should be visible in Diagnostics/Automation, not mixed into normal editing menus.
+
+## Project Naptha-style takeaways
+
+Project Naptha's browser-extension model is relevant to Pro's live Chrome/manhua translation mode.
+
+What to emulate:
+
+1. Image text should feel selectable and interactive.
+2. Browser/live mode should minimize friction: select region, translate, copy, pause.
+3. OCR overlays should not feel like a full project unless promoted.
+
+## MangaDex/Tachiyomi-style reader takeaways
+
+These are not translation editors, but their library/reader conventions matter for raw downloader and live reading workflows.
+
+What to emulate:
+
+1. Library/source/downloader views should be card/list based and searchable.
+2. Reader/live mode should prioritize low chrome and easy navigation.
+3. Chapter/page lists should be persistent and resumable.
+
+## Final UI direction for Pro
+
+Pro should have two personalities:
+
+1. Friendly workflow launcher for new users and quick tasks.
+2. Professional scanlation workspace for serious editing.
+
+The target layout:
+
+- App shell
+  - left mode rail
+  - top command/status bar
+  - center workspace
+  - right inspector
+  - bottom job/status drawer
+- Home mode
+  - workflow cards
+  - recent projects
+  - setup health
+  - recommended next actions
+- Editor mode
+  - left page thumbnails
+  - center canvas
+  - right inspector tabs: Text, Style, Layout, Assist, OCR, QA, Metadata
+  - bottom job/status area
+- Live mode
+  - region/window picker
+  - profiles
+  - overlay controls
+  - OCR/translation history
+- Downloader mode
+  - source browser
+  - search/results
+  - chapter queue
+  - output/import controls
+- Assist/QA mode
+  - selected text block assist panel
+  - provider candidate comparison
+  - TM/glossary/concordance/SFX tabs
+- Models/Providers mode
+  - setup wizard
+  - health checks
+  - model packages
+  - provider keys/endpoints
+- Settings mode
+  - searchable grouped settings
+  - simple/advanced/developer filters
+
+## Visual design rules
+
+1. Prefer cards for workflow choices and setup tasks.
+2. Prefer inspectors for selected-object controls.
+3. Prefer tabs for related detail panes, not top-level workflows.
+4. Prefer a command palette for rare actions.
+5. Keep menus, but make them secondary to workflow navigation.
+6. Use primary action buttons per mode, not dozens of equally weighted toolbar buttons.
+7. Use status chips for provider/model/job health.
+8. Use warning banners instead of modal dialogs for non-critical issues.
+9. Preserve manual controls and advanced features.
+10. Keep legacy menus available during migration.
+
+## Emulation summary
+
+- Emulate ImageTrans for professional editor + Translation Assist placement.
+- Emulate Dango for mode launcher, live translation flow, right-side style inspector, and progress/status clarity.
+- Emulate manga-image-translator for pipeline/job mental model.
+- Emulate Project Naptha for low-friction live/browser image text interaction.
+- Emulate reader apps for source/chapter/library organization.

--- a/docs/UI_INFORMATION_ARCHITECTURE.md
+++ b/docs/UI_INFORMATION_ARCHITECTURE.md
@@ -1,0 +1,45 @@
+# UI Information Architecture (Target)
+
+## Target top-level modes
+1. Home / Launcher
+2. Manga & Comic Editor
+3. Live Screen / Chrome Manhua Translator
+4. Image Quick Translator
+5. Raw Downloader
+6. Batch Queue
+7. Translation Assist / QA
+8. Models & Providers
+9. Settings
+10. Diagnostics / Help
+
+## First milestone (implemented in this PR)
+- Introduce a **central action metadata layer** (`ui/action_registry.py`).
+- Keep current visible IA intact while enabling future migration.
+- Feed omni-search from the same registry-backed action list.
+
+## Transitional IA principle
+- **Do not move user workflows yet**.
+- Build an action graph first, then remap menus/modes in later phases.
+
+## Implemented progress update
+- Added **UI mode control** in Theme & UI Customizer (Simple/Advanced/Developer).
+- Added runtime menu visibility filtering for simple mode (advanced-heavy commands hidden, legacy handlers preserved).
+
+- Omni search now supports fuzzy matching and an explicit **Show unavailable** toggle to include disabled commands with availability reasons.
+
+- Startup and UI complexity controls are now available in the Settings > General startup section (startup mode, fallback-to-home, legacy menus, omni unavailable commands).
+
+- Omni search now includes typed result badges and sources beyond commands: **Command, Setting, Text block, Page, Recent, Help**.
+- Omni search can directly open recent projects and trigger help entries (Documentation/About/Keyboard Shortcuts).
+
+- Added non-breaking top-level **Translation** and **Diagnostics** menus to reduce Tools overload while preserving legacy Tools entries.
+
+- Added non-breaking top-level **Export** and **Models** menus to continue splitting overloaded Tools responsibilities while preserving legacy access points.
+
+- Omni-search now supports a persistent result-type filter (All/Command/Setting/Text block/Page/Recent/Help), configurable from both search UI and Settings.
+
+- Welcome/Home now includes direct workflow launch buttons (Editor, Live, Downloader, Batch, Models, Diagnostics) that route to existing handlers.
+
+- Legacy menu layout toggle is now functional at runtime: Tools can be hidden while Translation/Diagnostics/Export/Models remain available.
+
+- Added dedicated top-level **Help** menu to avoid burying docs/about/shortcuts inside View and improve discoverability for new users.

--- a/docs/UI_REWORK_AUDIT.md
+++ b/docs/UI_REWORK_AUDIT.md
@@ -1,0 +1,41 @@
+# UI Rework Audit (Phase 0)
+
+## Scope
+This audit inventories current action surfaces before any behavior-moving UI rework.
+
+Primary audited modules:
+- `ui/mainwindowbars.py`
+- `ui/mainwindow.py`
+- `ui/configpanel.py`
+- `ui/textedit_area.py`
+- `ui/scenetext_manager.py`
+- `utils/shortcuts.py`
+- `utils/config.py`
+
+## Current action surfaces
+- Left rail quick controls: open/project/save/run/config/search.
+- Title bar menus: File, Edit, View, Go, Pipeline, Tools.
+- Context menus: canvas/text actions (configured by context-menu options dialog).
+- Omni search: currently scans menu actions + settings + canvas blocks.
+
+## Findings
+1. **Action creation is distributed** across `LeftBar`, `TitleBar`, and `MainWindow`.
+2. **Tools menu mixes categories** (project QA, export, sources, queue, models, diagnostics).
+3. **Omni search depends on recursive runtime menu walk**, not a reusable registry.
+4. **Shortcut ownership is split** between `QAction` and `QShortcut`, with conflict-avoidance comments already present.
+
+## Action inventory status
+This PR introduces the first centralized registry and migrates discoverability metadata for existing:
+- File actions (title bar File + left-bar file-related actions)
+- Edit actions
+- View actions
+- Go actions
+- Pipeline actions
+- Tools actions
+
+Detailed per-action mapping is tracked in `docs/UI_ACTION_REGISTRY.md` and will be expanded in follow-up PRs to include dialogs, context menus, and mode-level surfaces.
+
+## Compatibility constraints captured
+- Preserve action handlers/signals and existing shortcuts.
+- Preserve existing menu layout/labels in this milestone.
+- Preserve omni-search behavior while sourcing command entries from registry.

--- a/docs/UI_REWORK_IMPLEMENTATION_PROMPT.md
+++ b/docs/UI_REWORK_IMPLEMENTATION_PROMPT.md
@@ -1,0 +1,358 @@
+# UI/UX rework implementation prompt
+
+You are working in BallonsTranslator-Pro, a Python/PyQt fork of dmMaze/BallonsTranslator.
+
+The goal is to complete a workflow-centered UI/UX rework while preserving every existing feature, project format, config field, model-manager flow, startup script, local API route, and advanced scanlation workflow.
+
+Use the competitor visual research in `docs/UI_COMPETITOR_VISUAL_RESEARCH.md` as the product-design reference.
+
+## Design targets
+
+Emulate the good parts of these tools:
+
+- ImageTrans: professional editor layout, selected text block inspector, Translation Assist pane, text-area tables, CAT-tool workflow.
+- Dango Translator: friendly mode launcher, live translation flow, soft modern visual hierarchy, right-side style inspector, always-visible job/status progress.
+- manga-image-translator: clear automation pipeline, headless/API mental model, stage presets.
+- Project Naptha-style browser OCR: low-friction selected-region/live translation interaction.
+- Manga reader apps: left library/page/chapter navigation and resumable source/downloader workflows.
+
+Do not clone any competitor UI directly. Adapt the patterns to Pro's existing PyQt architecture.
+
+## Non-negotiable rules
+
+1. Do not remove features.
+2. Do not break existing menus until replacements are proven.
+3. Do not break existing shortcuts.
+4. Do not break config loading/saving.
+5. Do not break startup scripts.
+6. Do not break first-run model picker or model manager.
+7. Do not break local API route discovery.
+8. Keep Windows compatibility.
+9. Keep README.md and README_zh_CN.md parity for user-facing changes.
+10. Make changes in small reviewable PR-sized phases.
+
+## Target app shell
+
+Create a consistent shell with:
+
+- Left mode rail
+- Top command/status bar
+- Center workspace
+- Right inspector
+- Bottom job/status drawer
+- Command palette
+- Legacy menus available during migration
+
+Top-level modes:
+
+1. Home
+2. Editor
+3. Live Translation
+4. Quick Image
+5. Raw Downloader
+6. Batch Queue
+7. Assist / QA
+8. Models / Providers
+9. Settings
+10. Diagnostics / Help
+
+## Phase 1: Action registry and command palette
+
+Status: initial implementation exists on this branch.
+
+Continue improving:
+
+- Register every menu action.
+- Add stable action IDs.
+- Add category, workflow mode, simple/advanced visibility, shortcut, tooltip, and danger level.
+- Build command palette from the registry.
+- Add command result badges: Command, Setting, Page, Text block, Recent, Help.
+- Add disabled-action reasons.
+- Add duplicate shortcut detection.
+- Add JSON export for action inventory.
+
+Acceptance:
+
+- No action is lost.
+- Omni-search/command palette uses the registry.
+- Tests cover duplicate IDs, duplicate shortcuts, and command discovery.
+
+## Phase 2: Menu cleanup
+
+Reorganize menus into:
+
+- File
+- Edit
+- View
+- Pipeline
+- Tools
+- Translation
+- Export
+- Models
+- Diagnostics
+- Help
+
+Rules:
+
+- Tools must not be a dumping ground.
+- Translation Assist, TM, glossary, concordance, SFX, prompt profiles, and translation QA belong under Translation.
+- Proof packs, CBZ/ZIP/PDF, SVG/PSD handoff, XLIFF, Excel, Word, LabelPlus, OCR JSON belong under Export.
+- Model/provider/cache/setup actions belong under Models.
+- Logs, doctors, startup reports, action-registry validation, safe mode, and API route discovery belong under Diagnostics.
+
+Acceptance:
+
+- Existing handlers are reused.
+- Legacy menu locations remain reachable through command palette and optionally legacy menus.
+
+## Phase 3: Home / Launcher
+
+Build a new Home mode inspired by Dango's workflow cards.
+
+Cards:
+
+- Open Project
+- Open Folder / Images
+- Open CBZ/ZIP/CBR
+- Continue Recent Project
+- Manga & Comic Editor
+- Chrome Manhua Live Translation
+- Image Quick Translation
+- Raw Downloader
+- Batch Queue
+- Translation Assist / QA
+- Models / Provider Setup
+- Diagnostics
+
+Each card should show:
+
+- short description
+- recommended user/task
+- setup health/warnings
+- last-used state where relevant
+
+Config:
+
+- startup_mode: home | editor | last_used | live | downloader
+- show_home_on_startup
+- recent_workflows
+
+Acceptance:
+
+- New users know where to start.
+- Existing power users can bypass Home.
+
+## Phase 4: Editor workspace
+
+Rework Editor mode around:
+
+- Left page thumbnails/project navigation
+- Center canvas
+- Right inspector
+- Bottom job/status bar
+
+Right inspector tabs:
+
+- Text
+- Style
+- Layout
+- Assist
+- OCR
+- QA
+- Metadata
+
+Emulate ImageTrans' professional workspace: source/target text and Translation Assist should be visible near the selected block, not hidden in menus.
+
+Acceptance:
+
+- Selecting a text block updates the inspector.
+- Common text/style/layout actions require fewer clicks.
+- Translation Assist is a dock/tab, not just a menu action.
+
+## Phase 5: Settings rework
+
+Reorganize settings into searchable groups:
+
+- General
+- Appearance
+- Startup
+- Editor
+- Canvas
+- Text & Typesetting
+- Auto Layout
+- OCR
+- Translation
+- Translation Assist
+- Glossary / TM / SFX
+- Inpaint / Cleanup
+- Raw Downloader
+- Live Translation
+- Models
+- Providers
+- Performance
+- Storage / Data Paths
+- Shortcuts
+- Integrations
+- Advanced
+- Developer
+
+Requirements:
+
+- Search at top.
+- Breadcrumbs.
+- Simple/advanced/developer filter.
+- Reset-to-default per setting.
+- Inline validation.
+- Requires-restart badges.
+- Requires-model/provider badges.
+- Setup wizard links.
+
+Acceptance:
+
+- Existing config keys still load/save.
+- Settings are easier to scan and search.
+
+## Phase 6: Workflow-specific modes
+
+### Live Translation
+
+Dango-inspired, low-friction UI:
+
+- region/window picker
+- Chrome Manhua Reader preset
+- profile selector
+- OCR/translation provider status
+- overlay controls
+- history panel
+- privacy status
+- high-quality/slower options such as SAM-assisted region refinement
+
+### Quick Image
+
+- drag/drop images
+- run default OCR/translate/inpaint/render
+- before/after preview
+- promote to full project
+
+### Raw Downloader
+
+- source browser
+- search/results
+- chapters queue
+- output/import controls
+- source health/status badges
+
+### Batch Queue
+
+- parent/child CBZ/folder processing
+- resumable queue
+- progress/cancel
+- export manifests
+
+### Assist / QA
+
+ImageTrans-inspired professional area:
+
+- candidate comparison
+- TM fuzzy matches
+- glossary hits/violations
+- concordance
+- SFX dictionary
+- QA warnings
+
+Acceptance:
+
+- Each major workflow has a clear home instead of being buried in Tools.
+
+## Phase 7: Visual design system
+
+Create or continue:
+
+- design tokens
+- spacing scale
+- typography scale
+- icon sizes
+- panel padding
+- cards
+- badges
+- warning banners
+- empty states
+- job status pills
+- provider status chips
+- inspector sections
+
+Files may include:
+
+- `ui/design_tokens.py`
+- `ui/ui_components/`
+- `docs/UI_DESIGN_SYSTEM.md`
+
+Acceptance:
+
+- New UI surfaces look consistent.
+- Styling is not duplicated randomly.
+
+## Phase 8: Notifications and jobs
+
+Create a unified job/status drawer:
+
+- OCR
+- translation
+- inpaint
+- render
+- export
+- raw download
+- live translation
+- model download
+- batch queue
+- Translation Assist provider calls
+
+Requirements:
+
+- progress
+- cancel/pause where supported
+- warnings
+- copy error details
+- avoid modal spam for non-critical errors
+
+Acceptance:
+
+- Users always know what is running and why.
+
+## Phase 9: Migration safety
+
+Add:
+
+- legacy menu layout option
+- UI reset/troubleshooting docs
+- config migration tests
+- action registry inventory tests
+- startup mode tests
+- manual QA checklist
+
+Acceptance:
+
+- Existing users keep their workflows.
+- New users get a cleaner app.
+
+## Minimum next implementation milestone
+
+1. Keep the existing ActionRegistry work.
+2. Add competitor visual research document.
+3. Add this implementation prompt.
+4. Add a lightweight design-token module.
+5. Add a Home/Launcher skeleton or improve existing welcome screen with workflow cards.
+6. Add tests for mode/action visibility if possible.
+7. Update PR body with research-driven design direction.
+
+## Final acceptance
+
+- Pro has a workflow-centered app shell.
+- Menus are logical and no longer overloaded.
+- Home/Launcher makes the app approachable.
+- Editor mode feels like a professional scanlation workspace.
+- Live mode feels like a lightweight reader/overlay tool.
+- Translation Assist is visible and useful.
+- Settings are searchable and organized.
+- Power users have command palette access.
+- All existing functionality remains accessible.

--- a/docs/UI_REWORK_MIGRATION_PLAN.md
+++ b/docs/UI_REWORK_MIGRATION_PLAN.md
@@ -1,0 +1,61 @@
+# UI Rework Migration Plan
+
+## Compatibility-first sequence
+1. Build complete action inventory (menus + shortcuts + handlers + context menus).
+2. Centralize actions in registry and keep legacy menu wiring intact.
+3. Switch command palette + shortcuts diagnostics to registry source.
+4. Add simple/advanced/developer visibility metadata and filtering.
+5. Add launcher/startup flow settings + migration-safe defaults.
+6. Reorganize menus and navigation only after parity checks pass.
+
+## This iteration
+- Extended registry-backed discoverability through titlebar menu trees.
+- Added startup/UI mode config defaults and load-time migration guards.
+- Added tests for config migration defaults and registry behaviors.
+
+## Backward compatibility contract
+- Existing project files remain unchanged.
+- Existing shortcut strings are preserved.
+- Legacy menu layout remains active while `show_legacy_menus=True`.
+- New config keys have safe defaults when loading older config files.
+
+## Newly implemented in this pass
+- Theme customizer now persists `ui_mode` and `show_legacy_menus`.
+- MainWindow applies UI mode changes immediately via TitleBar action visibility filtering.
+- Simple mode now reduces menu noise without removing underlying functionality or shortcuts.
+
+## Startup mode behavior now wired
+- `startup_mode` is now consumed at startup (`home|editor|last_used|settings|live|downloader|batch|models|diagnostics`).
+- `recent_workflows` is now updated at runtime when entering editor/settings/live/downloader/batch/home surfaces.
+- `show_home_on_startup` now participates in last-used fallback routing.
+- Config-load startup-mode validation now explicitly accepts all routed modes (`settings|batch|models|diagnostics`) instead of collapsing them back to `last_used`.
+- Live Translator now persists and restores runtime profile/capture/debounce/follow-window preferences through config-backed defaults.
+- Realtime API `translate_now` now performs an immediate watcher tick for a target region and returns OCR/translation/status payload (instead of a placeholder queued response).
+- Realtime service now applies config-backed defaults (profile/follow-window/region rect) when initialized and when live mode is enabled, improving startup consistency between Settings and live runtime behavior.
+
+## Live settings propagation improvements
+- ConfigPanel now emits `ui_mode_changed` and MainWindow applies mode visibility immediately.
+- ConfigPanel now emits omni option changes so command search cache refreshes without restart.
+- Startup-dependent settings UI now validates fallback option relevance by selected startup mode.
+
+- Continued phased menu split: introduced top-level Translation/Diagnostics/Export/Models while retaining legacy Tools to preserve workflow compatibility.
+
+- Added persistent omni result-type filtering to reduce result noise and support simple-vs-power-user navigation styles.
+
+- Simple/Advanced visibility now prefers ActionRegistry metadata when available, reducing heuristic-only filtering.
+
+- Added registry validation loop (in-app + export payload summary) to support parity checks during phased menu remapping.
+
+- Added Home workflow launch shortcuts wired to existing handlers to improve first-run discoverability without breaking legacy flows.
+
+- `show_legacy_menus` now actively toggles legacy Tools visibility at runtime (non-destructive; new top-level menus remain).
+
+- Theme customizer now controls startup target directly, complementing ConfigPanel startup settings.
+
+- Registry enrichment pass now tags actions with top-level/category/workflow metadata to support deterministic menu-to-mode migration.
+
+## Completion status snapshot
+- Foundation (registry/config/startup/menu split/launcher): largely implemented.
+- Context-menu taxonomy rewrite: substantially implemented (canvas action categories now aligned to Text box/OCR/Translation/Style/Layout/QA/Export; lightweight debug grouping remains mode-aware in editor list context menus).
+- Context-menu quick profiles now persist last-applied preset (`editing|pipeline|layout|custom`) for clearer recoverability across restarts.
+- Full end-state rework (workspace redesign, full settings IA, all wizard flows): still in progress.

--- a/docs/UI_SHELL_COMPONENTS.md
+++ b/docs/UI_SHELL_COMPONENTS.md
@@ -1,0 +1,90 @@
+# UI shell components
+
+This document tracks reusable UI pieces added during the BallonsTranslator-Pro UI/UX rework.
+
+## WorkflowHomeWidget
+
+File: `ui/workflow_home.py`
+
+Purpose:
+
+- Dango-style workflow-card launcher.
+- Can live inside the existing `WelcomeWidget` now.
+- Can become the Home mode of the final app shell later.
+
+Workflow cards:
+
+- Editor
+- Live Translation
+- Quick Image
+- Raw Downloader
+- Batch Queue
+- Translation Assist / QA
+- Models / Providers
+- Diagnostics / Help
+
+Current integration:
+
+- Embedded in `ui/welcome_widget.py`.
+- Emits `workflow_requested(str)`.
+- `WelcomeWidget` maps workflow keys to existing signals where possible.
+
+Next integration step:
+
+- Connect `WelcomeWidget.open_assist_requested` in `MainWindow` once a stable Translation Assist panel entry point is chosen.
+- Consider adding a first-run setup-health row above the workflow cards.
+
+## ModeRail
+
+File: `ui/mode_rail.py`
+
+Purpose:
+
+- Reusable left navigation rail for the final app shell.
+- Independent from `MainWindow`, so it can be tested and iterated before replacing or sitting beside the legacy `LeftBar`.
+
+Modes:
+
+- Home
+- Editor
+- Live
+- Quick Image
+- Raws
+- Batch
+- Assist
+- Models
+- Settings
+- Help / Diagnostics
+
+Current integration:
+
+- Component exists, but is not yet embedded into `MainWindow`.
+
+Next integration step:
+
+- Add `ModeRail` beside the existing `LeftBar` behind a config flag, for example `enable_experimental_mode_rail`.
+- Route `mode_requested(str)` to existing handlers:
+  - `home` -> `_show_welcome_screen()`
+  - `editor` -> `setupImgTransUI()`
+  - `live` -> `on_open_realtime_translator()`
+  - `quick_image` -> `leftBar.onOpenImages()`
+  - `downloader` -> `on_open_manga_source()`
+  - `batch` -> `on_open_batch_queue()`
+  - `assist` -> Translation Assist dock entry point
+  - `models` -> `on_open_manage_models()`
+  - `settings` -> `setupConfigUI()`
+  - `diagnostics` -> `on_environment_doctor()`
+
+## Design tokens
+
+File: `ui/design_tokens.py`
+
+Purpose:
+
+- Shared spacing, radius, typography, color, badge, card, and inspector-section styling helpers.
+- Prevents every new UI widget from inventing a different style.
+
+Next integration step:
+
+- Use tokens in the future right inspector and job drawer components.
+- Add `docs/UI_DESIGN_SYSTEM.md` once more components use the tokens.

--- a/docs/USER_WORKFLOWS.md
+++ b/docs/USER_WORKFLOWS.md
@@ -1,0 +1,34 @@
+# User Workflows (Current Increment)
+
+## Home / Launcher workflows
+From the Welcome screen users can now start directly from workflow shortcuts:
+- Manga Editor
+- Live Translator
+- Raw Downloader
+- Batch Queue
+- Models
+- Diagnostics
+
+These shortcuts route to existing handlers and preserve current behavior.
+
+## Compatibility
+- Legacy menu paths remain available.
+- Existing project open flows and startup behavior are unchanged aside from the added launcher shortcuts.
+
+## Startup preference
+Theme & UI Customizer and Settings now include startup target selection (Home/Editor/Last-used/Settings/Live/Downloader/Batch/Models/Diagnostics).
+
+## Help & diagnostics access
+A dedicated top-level Help menu now provides Documentation, About, Update, Keyboard Shortcuts, Context Menu Options, and a Feature Matrix / Model Coverage summary.
+
+## Current limitation note
+Some project-dependent commands appear as unavailable until a project is opened; omni-search now explains this state explicitly.
+
+## Live Translator setup status
+- Live Translator now initializes with real screenshot backend selection (`auto` backend), persists capture/debounce/follow-window preferences, and restores them on next launch.
+- Settings → General now exposes Live Translator defaults (profile/capture interval/min OCR interval/follow-window), and automation API supports `realtime_regions` update payloads.
+- Live Translator also remembers the last region rectangle (x/y/width/height) to speed up repeated session startup.
+
+## Community model bundle coverage
+- Model packages now include an optional **Community showcase models** bundle with entries for YSG comic segmenters, MangaLens bubble segmentation, SAM2/3 segmentation variants, Flux inpaint variants, PaddleOCR-VL-1.5, and Real-CUGAN/AnimeSharp upscaling metadata.
+- A dedicated detector key `mangalens_bubble_segmentation` is now registered, using YOLO-backed bubble-seg defaults and a default checkpoint path `data/models/mangalens_bubble_segmentation.pt`.

--- a/modules/ocr/ocr_windows.py
+++ b/modules/ocr/ocr_windows.py
@@ -1,18 +1,44 @@
 # https://learn.microsoft.com/en-us/windows/powertoys/text-extractor#how-to-query-for-ocr-language-packs
-import platform
+from __future__ import annotations
 
-if platform.system() == 'Windows' and platform.version() >= '10.0.10240.0':
+import logging
+import platform
+from typing import TYPE_CHECKING
+
+try:
+    from .base import LOGGER
+except Exception:  # pragma: no cover - fallback for very early optional-module import failures
+    LOGGER = logging.getLogger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    import numpy as np
+    from typing import List
+    from .base import TextBlock
+
+
+def _is_supported_windows_version() -> bool:
+    if platform.system() != 'Windows':
+        return False
+    try:
+        parts = tuple(int(part) for part in platform.version().split('.')[:3])
+    except Exception:
+        return False
+    return parts >= (10, 0, 10240)
+
+
+if _is_supported_windows_version():
 
     try:
         from winsdk.windows.media.ocr import OcrEngine
         from winsdk.windows.globalization import Language
         from winsdk.windows.storage.streams import DataWriter
         from winsdk.windows.graphics.imaging import SoftwareBitmap, BitmapPixelFormat
+        import asyncio
+        import cv2
         import numpy as np
-        import cv2, asyncio
         from typing import List
 
-        from .base import register_OCR, OCRBase, LOGGER, TextBlock
+        from .base import register_OCR, OCRBase, TextBlock
 
         def get_supported_language_packs():
             return list(OcrEngine.available_recognizer_languages)
@@ -21,17 +47,20 @@ if platform.system() == 'Windows' and platform.version() >= '10.0.10240.0':
             writer = DataWriter()
             writer.write_bytes(byte)
             sb = SoftwareBitmap.create_copy_from_buffer(writer.detach_buffer(), BitmapPixelFormat.RGBA8, width, height)
-            return OcrEngine.try_create_from_language(Language(lang)).recognize_async(sb)
+            engine = OcrEngine.try_create_from_language(Language(lang))
+            if engine is None:
+                raise RuntimeError(f"Windows OCR engine is unavailable for language: {lang}")
+            return engine.recognize_async(sb)
 
         async def coroutine(awaitable):
-            return await awaitable 
+            return await awaitable
 
         winocr_available_recognizer_languages = get_supported_language_packs()
 
         if len(winocr_available_recognizer_languages) > 0:
             class WindowsOCR:
                 lang = winocr_available_recognizer_languages[0].language_tag
-                
+
                 def __call__(self, img: np.ndarray) -> str:
                     img = cv2.cvtColor(img, cv2.COLOR_RGB2RGBA)
                     w, h = img.shape[1], img.shape[0]
@@ -39,11 +68,12 @@ if platform.system() == 'Windows' and platform.version() >= '10.0.10240.0':
 
             languages_display_name = [lang.display_name for lang in winocr_available_recognizer_languages]
             languages_tag = [lang.language_tag for lang in winocr_available_recognizer_languages]
+
             @register_OCR('windows_ocr')
             class OCRWindows(OCRBase):
                 params = {
                     'language': {
-                        'type':'selector',
+                        'type': 'selector',
                         'options': languages_display_name,
                         'value': languages_display_name[0],
                     }
@@ -56,12 +86,12 @@ if platform.system() == 'Windows' and platform.version() >= '10.0.10240.0':
                     self.engine.lang = self.get_engine_lang()
 
                 def get_engine_lang(self) -> str:
-                    language = self.params['language']['value'] 
+                    language = self.params['language']['value']
                     tag_name = languages_tag[languages_display_name.index(language)]
                     return tag_name
 
                 def ocr_img(self, img: np.ndarray) -> str:
-                    self.engine(img)
+                    return self.engine(img)
 
                 def _ocr_blk_list(self, img: np.ndarray, blk_list: List[TextBlock], *args, **kwargs) -> None:
                     im_h, im_w = img.shape[:2]
@@ -76,14 +106,12 @@ if platform.system() == 'Windows' and platform.version() >= '10.0.10240.0':
                         else:
                             self.logger.warning('invalid textbbox to target img')
                             blk.text = ['']
-                
+
                 def updateParam(self, param_key: str, param_content):
                     super().updateParam(param_key, param_content)
                     self.engine.lang = self.get_engine_lang()
 
         else:
-            LOGGER.warning(f'No supported language packs found for windows, Windows OCR will be unavailable.')
+            LOGGER.warning('No supported language packs found for Windows; Windows OCR will be unavailable.')
     except Exception as e:
-        LOGGER.error(f'Failed to initialize windows OCR:')
-        LOGGER.error(e)
-
+        LOGGER.warning('Failed to initialize Windows OCR; it will be unavailable.', exc_info=True)

--- a/modules/textdetector/detector_mangalens.py
+++ b/modules/textdetector/detector_mangalens.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from .base import register_textdetectors
+from .detector_ysg import YSGYoloDetector
+
+
+@register_textdetectors('mangalens_bubble_segmentation')
+class MangaLensBubbleSegmentationDetector(YSGYoloDetector):
+    """MangaLens bubble segmentation detector profile.
+
+    Compatibility-first wrapper over ysgyolo backend with defaults tuned for
+    speech-bubble segmentation style workflows.
+    """
+
+    params = dict(YSGYoloDetector.params)
+    params['model path'] = dict(YSGYoloDetector.params['model path'])
+    params['model path']['value'] = 'data/models/mangalens_bubble_segmentation.pt'
+
+    params['label'] = dict(YSGYoloDetector.params['label'])
+    params['label']['value'] = {
+        'balloon': True,
+        'bubble': True,
+        'speech_bubble': True,
+        'text_bubble': True,
+        'other': False,
+    }
+
+    params['merge text lines'] = dict(YSGYoloDetector.params['merge text lines'])
+    params['merge text lines']['value'] = False
+
+    params['confidence threshold'] = dict(YSGYoloDetector.params['confidence threshold'])
+    params['confidence threshold']['value'] = 0.25
+
+    params['IoU threshold'] = dict(YSGYoloDetector.params['IoU threshold'])
+    params['IoU threshold']['value'] = 0.5

--- a/modules/textdetector/detector_sam3_refiner.py
+++ b/modules/textdetector/detector_sam3_refiner.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+
+from .base import TEXTDETECTORS, register_textdetectors, TextDetectorBase, TextBlock, DEVICE_SELECTOR
+from utils.sam3_refinement import (
+    SAM3_REFINEMENT_MODEL_CUSTOM,
+    all_base_detector_options,
+    curated_refiner_detector_options,
+    curated_sam3_refinement_models,
+    resolve_refinement_model_id,
+    SAM3RefinementOptions,
+    refine_mask_with_sam3,
+)
+
+
+def _registered_detector_names() -> list[str]:
+    return [k for k in TEXTDETECTORS.module_dict.keys() if k != "sam3_refiner"]
+
+
+@register_textdetectors("sam3_refiner")
+class SAM3RefinerDetector(TextDetectorBase):
+    """Detector wrapper: run any base detector, then a curated mask refiner."""
+
+    params = {
+        "base_detector": {
+            "type": "selector",
+            "options": list(all_base_detector_options()),
+            "value": "ctd",
+            "description": "First-pass detector. The UI refreshes this to all registered detectors except sam3_refiner.",
+        },
+        "refiner_detector": {
+            "type": "selector",
+            "options": list(curated_refiner_detector_options()),
+            "value": "sam_text_det",
+            "description": "Second-pass detector used only for mask refinement. Curated to detectors likely to improve bubble/text masks.",
+        },
+        "refinement_model": {
+            "type": "selector",
+            "options": list(curated_sam3_refinement_models()),
+            "value": "facebook/sam3",
+            "description": "SAM 3 model for sam_text_det. Use Custom only for SAM 3-compatible models.",
+        },
+        "custom_model_id": {
+            "type": "line_editor",
+            "value": "",
+            "description": "Used only when refinement_model is Custom SAM 3 model id.",
+        },
+        "prompt": {
+            "type": "selector",
+            "options": ["speech bubble", "text", "caption", "sound effect", "panel"],
+            "value": "speech bubble",
+            "description": "Prompt for SAM-style refiners. speech bubble is best for bubble safe areas; text is stricter for text masks.",
+        },
+        "fallback_prompt": {
+            "type": "selector",
+            "options": ["text", "speech bubble", "caption", "sound effect", ""],
+            "value": "text",
+            "description": "Prompt used if the primary prompt returns no usable candidate.",
+        },
+        "merge_mode": {
+            "type": "selector",
+            "options": ["union", "intersect", "replace_if_nonempty"],
+            "value": "union",
+            "description": "How to combine base and refiner masks. union = coverage; intersect = strict; replace_if_nonempty = whole refiner mask.",
+        },
+        "min_iou_with_initial": {
+            "type": "line_editor",
+            "value": 0.02,
+            "description": "Reject refiner candidates with IoU below this against the base detector mask.",
+        },
+        "min_mask_area": {"type": "line_editor", "value": 64, "description": "Reject candidates smaller than this area in pixels."},
+        "max_mask_area_ratio": {"type": "line_editor", "value": 0.75, "description": "Reject candidates larger than this fraction of the page."},
+        "expand_px": {"type": "line_editor", "value": 0, "description": "Optional final mask dilation in pixels after merging."},
+        "safe_rect_min_coverage": {"type": "line_editor", "value": 0.88, "description": "Minimum mask coverage used when deriving auto-layout safe rectangles."},
+        "attach_safe_areas": {"type": "checkbox", "value": True, "description": "Attach refinement safe-area metadata to detected blocks."},
+        "device": DEVICE_SELECTOR(),
+        "description": "Run a selected base detector first, then refine the mask with a curated second detector such as SAM 3.",
+    }
+    _load_model_keys = {"_base_detector", "_refiner_detector"}
+
+    def __init__(self, **params) -> None:
+        super().__init__(**params)
+        self._refresh_selector_options()
+        self._base_detector = None
+        self._base_detector_key = None
+        self._refiner_detector = None
+        self._refiner_detector_key = None
+        self._refiner_model_id = None
+        self._refiner_device = None
+
+    @classmethod
+    def _refresh_class_selector_options(cls):
+        names = _registered_detector_names()
+        if "base_detector" in cls.params:
+            opts = list(all_base_detector_options(names)) or list(all_base_detector_options())
+            cls.params["base_detector"]["options"] = opts
+            if cls.params["base_detector"].get("value") not in opts:
+                cls.params["base_detector"]["value"] = "ctd" if "ctd" in opts else (opts[0] if opts else "")
+        if "refiner_detector" in cls.params:
+            opts = list(curated_refiner_detector_options(names)) or list(curated_refiner_detector_options())
+            cls.params["refiner_detector"]["options"] = opts
+            if cls.params["refiner_detector"].get("value") not in opts:
+                cls.params["refiner_detector"]["value"] = opts[0] if opts else "sam_text_det"
+
+    def _refresh_selector_options(self):
+        self.__class__._refresh_class_selector_options()
+        if self.params:
+            for key in ("base_detector", "refiner_detector"):
+                if key in self.__class__.params and key in self.params:
+                    try:
+                        self.params[key]["options"] = list(self.__class__.params[key].get("options", []))
+                    except Exception:
+                        pass
+
+    def _param(self, key: str, default=None):
+        try:
+            return self.get_param_value(key)
+        except Exception:
+            return default
+
+    def _saved_params_for(self, detector_key: str) -> dict:
+        try:
+            from utils.config import pcfg
+            return (getattr(pcfg.module, "textdetector_params", {}) or {}).get(detector_key, {}) or {}
+        except Exception:
+            return {}
+
+    def _make_detector(self, detector_key: str, params: dict | None = None):
+        if detector_key not in TEXTDETECTORS.module_dict:
+            raise KeyError(detector_key)
+        return TEXTDETECTORS.module_dict[detector_key](**(params or {}))
+
+    def _load_base_detector(self):
+        self._refresh_selector_options()
+        detector_key = str(self._param("base_detector", "ctd") or "ctd").strip()
+        if detector_key == "sam3_refiner":
+            detector_key = "ctd"
+        if detector_key not in TEXTDETECTORS.module_dict:
+            fallback = "ctd" if "ctd" in TEXTDETECTORS.module_dict else next(iter(TEXTDETECTORS.module_dict.keys()))
+            if fallback == "sam3_refiner":
+                raise RuntimeError("No usable base detector is registered for sam3_refiner.")
+            self.logger.warning("SAM3 refiner base detector %s unavailable; using %s", detector_key, fallback)
+            detector_key = fallback
+        if self._base_detector is not None and self._base_detector_key == detector_key:
+            return
+        self._base_detector_key = detector_key
+        self._base_detector = self._make_detector(detector_key, self._saved_params_for(detector_key))
+        self._base_detector.load_model()
+
+    def _refiner_params(self, detector_key: str) -> dict:
+        params = self._saved_params_for(detector_key)
+        if detector_key == "sam_text_det":
+            choice = str(self._param("refinement_model", "facebook/sam3") or "facebook/sam3")
+            custom = str(self._param("custom_model_id", "") or "")
+            model_id = resolve_refinement_model_id(choice, custom)
+            params = dict(params)
+            params.update({
+                "model_id": model_id,
+                "text_prompt": str(self._param("prompt", "speech bubble") or "speech bubble"),
+                "device": str(self._param("device", "cpu") or "cpu"),
+                "box_padding": 0,
+                "min_area_px": int(float(self._param("min_mask_area", 64) or 64)),
+                "max_area_ratio": float(self._param("max_mask_area_ratio", 0.75) or 0.75),
+            })
+        return params
+
+    def _load_refiner_detector(self):
+        self._refresh_selector_options()
+        detector_key = str(self._param("refiner_detector", "sam_text_det") or "sam_text_det").strip()
+        allowed = set(curated_refiner_detector_options(_registered_detector_names()))
+        if detector_key not in allowed:
+            fallback = "sam_text_det" if "sam_text_det" in allowed else (next(iter(allowed)) if allowed else "")
+            if not fallback:
+                raise RuntimeError("No supported mask refiner detector is registered.")
+            self.logger.warning("SAM3 refiner rejected unsupported refiner %s; using %s", detector_key, fallback)
+            detector_key = fallback
+        marker_model = resolve_refinement_model_id(str(self._param("refinement_model", "facebook/sam3") or "facebook/sam3"), str(self._param("custom_model_id", "") or ""))
+        marker_device = str(self._param("device", "cpu") or "cpu")
+        if self._refiner_detector is not None and self._refiner_detector_key == detector_key and self._refiner_model_id == marker_model and self._refiner_device == marker_device:
+            return
+        self._refiner_detector_key = detector_key
+        self._refiner_model_id = marker_model
+        self._refiner_device = marker_device
+        self._refiner_detector = self._make_detector(detector_key, self._refiner_params(detector_key))
+        self._refiner_detector.load_model()
+
+    def _load_model(self):
+        self._load_base_detector()
+        self._load_refiner_detector()
+
+    def _refiner_box_runner(self, image: np.ndarray, prompt: str):
+        self._load_refiner_detector()
+        if self._refiner_detector is None:
+            return []
+        if hasattr(self._refiner_detector, "set_param_value") and self._refiner_detector_key == "sam_text_det":
+            self._refiner_detector.set_param_value("text_prompt", prompt)
+        _mask, blocks = self._refiner_detector.detect(image, None)
+        return [getattr(blk, "xyxy", []) for blk in (blocks or [])]
+
+    def _opts(self) -> SAM3RefinementOptions:
+        return SAM3RefinementOptions(
+            enabled=True,
+            prompt=str(self._param("prompt", "speech bubble") or "speech bubble"),
+            fallback_prompt=str(self._param("fallback_prompt", "text") or "text"),
+            merge_mode=str(self._param("merge_mode", "union") or "union"),
+            min_mask_area=int(float(self._param("min_mask_area", 64) or 64)),
+            max_mask_area_ratio=float(self._param("max_mask_area_ratio", 0.75) or 0.75),
+            min_iou_with_initial=float(self._param("min_iou_with_initial", 0.02) or 0.02),
+            expand_px=int(float(self._param("expand_px", 0) or 0)),
+            safe_rect_min_coverage=float(self._param("safe_rect_min_coverage", 0.88) or 0.88),
+        )
+
+    def _detect(self, img: np.ndarray, proj=None) -> Tuple[np.ndarray, List[TextBlock]]:
+        self._load_base_detector()
+        mask, blocks = self._base_detector.detect(img, proj)
+        result = refine_mask_with_sam3(img, mask, self._opts(), box_runner=self._refiner_box_runner)
+        if bool(self._param("attach_safe_areas", True)) and blocks and result.safe_areas:
+            meta = result.to_dict()
+            meta["base_detector"] = self._base_detector_key
+            meta["refiner_detector"] = self._refiner_detector_key
+            for blk in blocks:
+                try:
+                    rid = getattr(blk, "region_inpaint_dict", None) or {}
+                    rid["sam3_refinement"] = meta
+                    blk.region_inpaint_dict = rid
+                except Exception:
+                    pass
+        for blk in blocks or []:
+            try:
+                blk.det_model = f"{self.name}:{self._base_detector_key}+{self._refiner_detector_key}"
+            except Exception:
+                pass
+        return result.mask, blocks or []
+
+    def updateParam(self, param_key: str, param_content):
+        super().updateParam(param_key, param_content)
+        if param_key == "base_detector":
+            self._base_detector = None
+            self._base_detector_key = None
+        if param_key in {"refiner_detector", "refinement_model", "custom_model_id", "device"}:
+            self._refiner_detector = None
+            self._refiner_detector_key = None
+            self._refiner_model_id = None
+            self._refiner_device = None

--- a/modules/translators/base.py
+++ b/modules/translators/base.py
@@ -12,6 +12,7 @@ from utils.io_utils import text_is_empty, normalize_line_breaks
 from utils.logger import logger as LOGGER
 from utils.translation_cache import TranslationCache
 from utils.config import pcfg
+from utils.line_breaking import normalize_artificial_hyphenation
 
 TRANSLATORS = Registry('translators')
 register_translator = TRANSLATORS.register_module
@@ -20,12 +21,16 @@ PROXY = urllib.request.getproxies()
 
 
 def sanitize_translation_text(text: str) -> str:
-    """Normalize HTML line breaks and trim excessive trailing repetition from LLM/API output."""
+    """Normalize translator output before assigning it to text blocks."""
     if not text or not isinstance(text, str):
         return text
     # Unescape literal \n and \r\n from API (e.g. "Mortal\nworld" as two chars -> real newline)
     text = text.replace("\\n", "\n").replace("\\r\\n", "\n").replace("\\r", "\n")
     text = normalize_line_breaks(text)
+    # Some web translators/layout passes can return artificial visible word
+    # fragments such as "NE‐ VER" / "MI‐ ND‐...".  Clean those here so every
+    # translator and cache path benefits before rendering.
+    text = normalize_artificial_hyphenation(text)
     # Trim excessive trailing repetition (e.g. "one one one one one" or "一个一个..." from stuck generation)
     text = text.rstrip()
     if len(text) < 4:
@@ -91,6 +96,7 @@ LANG_LATIN_DISPLAY = {
     'Polski': 'Polish',
     'Português': 'Portuguese',
     'Brazilian Portuguese': 'Brazilian Portuguese',
+    'limba romana': 'Romanian',
     'limba română': 'Romanian',
     'русский язык': 'Russian',
     'Español': 'Spanish',

--- a/tests/test_action_registry.py
+++ b/tests/test_action_registry.py
@@ -1,0 +1,114 @@
+from ui.action_registry import ActionRegistry
+
+
+class _DummyShortcut:
+    def __init__(self, value: str):
+        self._v = value
+
+    def toString(self):
+        return self._v
+
+
+class _DummyIcon:
+    def __init__(self, null=True):
+        self._null = null
+
+    def isNull(self):
+        return self._null
+
+
+class _DummyAction:
+    def __init__(self, text: str, shortcut: str = "", tooltip: str = ""):
+        self._text = text
+        self._shortcut = _DummyShortcut(shortcut)
+        self._tooltip = tooltip
+
+    def text(self):
+        return self._text
+
+    def shortcut(self):
+        return self._shortcut
+
+    def toolTip(self):
+        return self._tooltip
+
+    def icon(self):
+        return _DummyIcon(True)
+
+
+def test_action_registry_unique_ids_and_discoverability():
+    reg = ActionRegistry()
+    a1 = _DummyAction("Open Project", "Ctrl+O")
+    a2 = _DummyAction("Export All")
+    reg.register_qaction(top_level="File", menu_path="File", qaction=a1)
+    reg.register_qaction(top_level="File", menu_path="File > Export", qaction=a2)
+
+    assert len(reg.all_records()) == 2
+    assert not reg.has_duplicate_ids()
+    labels = [label for label, _, _ in reg.discoverable_actions()]
+    assert any("Open Project" in x for x in labels)
+    assert any("Export All" in x for x in labels)
+
+
+def test_action_registry_detects_shortcut_conflicts():
+    reg = ActionRegistry()
+    reg.register_qaction(top_level="Edit", menu_path="Edit", qaction=_DummyAction("Undo", "Ctrl+Z"))
+    reg.register_qaction(top_level="Edit", menu_path="Edit", qaction=_DummyAction("Also Undo", "Ctrl+Z"))
+
+    conflicts = reg.duplicate_shortcuts()
+    assert "Ctrl+Z" in conflicts
+    assert len(conflicts["Ctrl+Z"]) == 2
+
+
+def test_action_registry_hides_unavailable_by_default_and_includes_when_requested():
+    class _DisabledDummy(_DummyAction):
+        def __init__(self, text: str, enabled: bool):
+            super().__init__(text)
+            self._enabled = enabled
+
+        def isEnabled(self):
+            return self._enabled
+
+    reg = ActionRegistry()
+    reg.register_qaction(top_level="Tools", menu_path="Tools", qaction=_DisabledDummy("Enabled action", True))
+    reg.register_qaction(top_level="Tools", menu_path="Tools", qaction=_DisabledDummy("Disabled action", False))
+
+    visible_default = [x[0] for x in reg.discoverable_actions()]
+    visible_all = [x[0] for x in reg.discoverable_actions(show_unavailable=True)]
+
+    assert any("Enabled action" in t for t in visible_default)
+    assert not any("Disabled action" in t for t in visible_default)
+    assert any("Disabled action" in t for t in visible_all)
+
+
+def test_action_registry_to_rows_contains_expected_fields():
+    reg = ActionRegistry()
+    reg.register_qaction(top_level="View", menu_path="View", qaction=_DummyAction("Toggle Panel", "Ctrl+1", "Toggle panel visibility"))
+    rows = reg.to_rows()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["action_id"].startswith("view.")
+    assert row["top_level"] == "View"
+    assert row["label"] == "Toggle Panel"
+    assert row["shortcut"] == "Ctrl+1"
+    assert row["tooltip"] == "Toggle panel visibility"
+
+
+def test_action_registry_record_for_action_lookup():
+    a = _DummyAction("Find Me", "Ctrl+F")
+    reg = ActionRegistry()
+    rec = reg.register_qaction(top_level="Edit", menu_path="Edit", qaction=a)
+    got = reg.record_for_action(a)
+    assert got is not None
+    assert got.action_id == rec.action_id
+
+
+def test_action_registry_summary_stats_reports_counts():
+    reg = ActionRegistry()
+    reg.register_qaction(top_level="File", menu_path="File", qaction=_DummyAction("Open", "Ctrl+O"))
+    reg.register_qaction(top_level="Edit", menu_path="Edit", qaction=_DummyAction("Copy", "Ctrl+C"))
+    stats = reg.summary_stats()
+    assert stats["total_actions"] == 2
+    assert stats["enabled_actions"] == 2
+    assert stats["disabled_actions"] == 0
+    assert isinstance(stats["categories"], dict)

--- a/tests/test_context_menu_taxonomy.py
+++ b/tests/test_context_menu_taxonomy.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+
+def _load_context_menu_items():
+    src = Path("ui/context_menu_config_dialog.py").read_text(encoding="utf-8")
+    mod = ast.parse(src)
+    for node in mod.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "CONTEXT_MENU_ITEMS":
+                    return ast.literal_eval(node.value)
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == "CONTEXT_MENU_ITEMS":
+            return ast.literal_eval(node.value)
+    raise AssertionError("CONTEXT_MENU_ITEMS not found")
+
+
+def test_context_menu_taxonomy_categories_present():
+    CONTEXT_MENU_ITEMS = _load_context_menu_items()
+    categories = [cat for cat, _items in CONTEXT_MENU_ITEMS]
+    expected = {"Text box", "OCR", "Translation", "Style", "Layout", "QA", "Export"}
+    assert expected.issubset(set(categories))
+
+
+def test_context_menu_keys_unique_across_taxonomy():
+    CONTEXT_MENU_ITEMS = _load_context_menu_items()
+    keys = []
+    for _cat, items in CONTEXT_MENU_ITEMS:
+        for key, _label in items:
+            keys.append(key)
+    assert len(keys) == len(set(keys))

--- a/tests/test_dashboard_action_dispatcher.py
+++ b/tests/test_dashboard_action_dispatcher.py
@@ -24,6 +24,14 @@ class FakeRegistry:
         return list(self._records)
 
 
+class FakeLeftBar:
+    def __init__(self):
+        self.opened_images = False
+
+    def onOpenImages(self):
+        self.opened_images = True
+
+
 class FakeOwner:
     pass
 
@@ -55,6 +63,18 @@ def test_dispatch_falls_back_to_handler_name():
     assert result.handled is True
     assert result.invoked == "handler:on_open_realtime_translator"
     assert owner.called is True
+
+
+def test_dispatch_supports_dotted_handler_paths():
+    owner = FakeOwner()
+    owner.leftBar = FakeLeftBar()
+
+    result = dispatch_dashboard_action(owner, "quick_image", "primary")
+
+    assert result.handled is True
+    assert result.route_found is True
+    assert result.invoked == "handler:leftBar.onOpenImages"
+    assert owner.leftBar.opened_images is True
 
 
 def test_dispatch_reports_missing_route():
@@ -89,3 +109,4 @@ def test_router_has_safe_routes_and_known_action_ids():
     assert ("editor", "layout_review") in routes
     assert dashboard_action_id_for("assist", "primary") == "translation.assist"
     assert dashboard_handler_for("assist", "primary") == "on_open_translation_assist_dock"
+    assert dashboard_handler_for("quick_image", "primary") == "leftBar.onOpenImages"

--- a/tests/test_dashboard_action_dispatcher.py
+++ b/tests/test_dashboard_action_dispatcher.py
@@ -1,0 +1,81 @@
+from ui.dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
+from ui.dashboard_action_router import dashboard_action_id_for, safe_dashboard_routes
+
+
+class FakeAction:
+    def __init__(self):
+        self.triggered = False
+
+    def trigger(self):
+        self.triggered = True
+
+
+class FakeRecord:
+    def __init__(self, action_id, action):
+        self.action_id = action_id
+        self.action = action
+
+
+class FakeRegistry:
+    def __init__(self, records):
+        self._records = records
+
+    def all_records(self):
+        return list(self._records)
+
+
+class FakeOwner:
+    pass
+
+
+def test_dispatch_uses_action_registry_first():
+    owner = FakeOwner()
+    action = FakeAction()
+    owner._action_registry = FakeRegistry([FakeRecord("live.open", action)])
+
+    result = dispatch_dashboard_action(owner, "live", "primary")
+
+    assert result.handled is True
+    assert result.route_found is True
+    assert result.invoked == "action:live.open"
+    assert action.triggered is True
+
+
+def test_dispatch_falls_back_to_handler_name():
+    owner = FakeOwner()
+    owner.called = False
+
+    def handler():
+        owner.called = True
+
+    owner.on_open_realtime_translator = handler
+
+    result = dispatch_dashboard_action(owner, "live", "primary")
+
+    assert result.handled is True
+    assert result.invoked == "handler:on_open_realtime_translator"
+    assert owner.called is True
+
+
+def test_dispatch_reports_missing_route():
+    owner = FakeOwner()
+    result = dispatch_dashboard_action(owner, "missing", "action")
+
+    assert result.handled is False
+    assert result.route_found is False
+    assert "No route" in dispatch_message_for_result(result)
+
+
+def test_dispatch_reports_intentionally_unwired_action():
+    owner = FakeOwner()
+    result = dispatch_dashboard_action(owner, "editor", "layout_review")
+
+    assert result.handled is False
+    assert result.route_found is True
+    assert "not wired yet" in dispatch_message_for_result(result)
+
+
+def test_router_has_safe_routes_and_known_action_ids():
+    routes = safe_dashboard_routes()
+    assert ("live", "primary") in routes
+    assert dashboard_action_id_for("assist", "primary") == "translation.assist"

--- a/tests/test_dashboard_action_dispatcher.py
+++ b/tests/test_dashboard_action_dispatcher.py
@@ -1,5 +1,5 @@
 from ui.dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
-from ui.dashboard_action_router import dashboard_action_id_for, safe_dashboard_routes
+from ui.dashboard_action_router import dashboard_action_id_for, dashboard_handler_for, safe_dashboard_routes
 
 
 class FakeAction:
@@ -66,16 +66,26 @@ def test_dispatch_reports_missing_route():
     assert "No route" in dispatch_message_for_result(result)
 
 
-def test_dispatch_reports_intentionally_unwired_action():
+def test_editor_layout_review_route_uses_current_handler():
     owner = FakeOwner()
+    owner.called = False
+
+    def handler():
+        owner.called = True
+
+    owner.shortcutLayoutReviewSelected = handler
+
     result = dispatch_dashboard_action(owner, "editor", "layout_review")
 
-    assert result.handled is False
+    assert result.handled is True
     assert result.route_found is True
-    assert "not wired yet" in dispatch_message_for_result(result)
+    assert result.invoked == "handler:shortcutLayoutReviewSelected"
+    assert owner.called is True
 
 
 def test_router_has_safe_routes_and_known_action_ids():
     routes = safe_dashboard_routes()
     assert ("live", "primary") in routes
+    assert ("editor", "layout_review") in routes
     assert dashboard_action_id_for("assist", "primary") == "translation.assist"
+    assert dashboard_handler_for("assist", "primary") == "on_open_translation_assist_dock"

--- a/tests/test_dashboard_status_provider.py
+++ b/tests/test_dashboard_status_provider.py
@@ -14,6 +14,24 @@ class FakeManager:
         self.is_busy = busy
 
 
+class FakeBlock:
+    def __init__(self, translation=""):
+        self.translation = translation
+
+
+class FakeProject:
+    def __init__(self, pages=None):
+        self.pages = pages or {}
+
+
+class FakeCanvas:
+    def __init__(self, selected=None):
+        self._selected = selected if selected is not None else []
+
+    def selected_text_items(self):
+        return self._selected
+
+
 class FakeCentralStack:
     def __init__(self):
         self._widgets = []
@@ -31,9 +49,19 @@ class FakeMainWindow:
         self.page_list = []
         self.module_manager = FakeManager()
         self.jobStatusDrawer = FakeDrawer()
+        self.imgtrans_proj = FakeProject()
+        self.canvas = FakeCanvas()
 
     def _has_open_project(self):
-        return bool(self.page_list)
+        return bool(self.page_list) or bool(self.imgtrans_proj.pages)
+
+
+class FakeDock:
+    def __init__(self, visible=False):
+        self._visible = visible
+
+    def isVisible(self):
+        return self._visible
 
 
 def metric_by_key(metrics, key):
@@ -58,6 +86,49 @@ def test_editor_metrics_reflect_project_pages_and_warnings():
     assert metric_by_key(metrics, "warnings").status == "warning"
 
 
+def test_editor_metrics_show_translation_progress_and_selected_blocks():
+    win = FakeMainWindow()
+    win.imgtrans_proj = FakeProject({
+        "001.png": [FakeBlock("Hello"), FakeBlock("World")],
+        "002.png": [FakeBlock("Only one"), FakeBlock("")],
+        "003.png": [],
+    })
+    win.canvas = FakeCanvas(selected=[object(), object()])
+
+    metrics = metrics_for_mode(win, "editor")
+
+    pages = metric_by_key(metrics, "pages")
+    assert pages.value == "1/3"
+    assert pages.status == "running"
+    assert "4 text blocks" in pages.description
+    assert metric_by_key(metrics, "selected").value == "2"
+    assert metric_by_key(metrics, "selected").status == "success"
+
+
+def test_editor_metrics_mark_all_pages_complete_when_all_blocks_translated():
+    win = FakeMainWindow()
+    win.imgtrans_proj = FakeProject({
+        "001.png": [FakeBlock("A")],
+        "002.png": [FakeBlock("B"), FakeBlock("C")],
+    })
+
+    metrics = metrics_for_mode(win, "editor")
+
+    pages = metric_by_key(metrics, "pages")
+    assert pages.value == "2/2"
+    assert pages.status == "success"
+
+
+def test_selected_metric_handles_no_selection():
+    win = FakeMainWindow()
+    win.canvas = FakeCanvas(selected=[])
+
+    metrics = metrics_for_mode(win, "quick_image")
+
+    assert metric_by_key(metrics, "selected").value == "0"
+    assert metric_by_key(metrics, "selected").status == "idle"
+
+
 def test_model_metric_reports_missing_models():
     win = FakeMainWindow()
     win.module_manager = FakeManager(missing=["ocr", "detector"])
@@ -80,9 +151,19 @@ def test_job_summary_reports_running_jobs():
     assert metric_by_key(metrics, "jobs").status == "running"
 
 
+def test_assist_metric_reflects_open_translation_assist_dock():
+    win = FakeMainWindow()
+    win.translationAssistDock = FakeDock(visible=True)
+
+    metrics = metrics_for_mode(win, "assist")
+
+    assert metric_by_key(metrics, "candidates").value == "Open"
+    assert metric_by_key(metrics, "candidates").status == "success"
+
+
 def test_refresh_default_dashboard_metrics_updates_installed_dashboards():
     win = FakeMainWindow()
-    win.page_list = ["001.png"]
+    win.imgtrans_proj = FakeProject({"001.png": [FakeBlock("Done")]})
     win.centralStackWidget = FakeCentralStack()
     dashboard = ModeDashboard(dashboard_for_mode("quick_image", "Quick", "Quick images"))
     idx = win.centralStackWidget.addWidget(dashboard)
@@ -91,5 +172,6 @@ def test_refresh_default_dashboard_metrics_updates_installed_dashboards():
     assert refresh_default_dashboard_metrics(win) == 1
 
     snapshot = dashboard.metric_snapshot()
-    assert snapshot["pages"].value == "1"
+    assert snapshot["pages"].value == "1/1"
     assert snapshot["pages"].status == "success"
+    assert snapshot["selected"].value == "0"

--- a/tests/test_dashboard_status_provider.py
+++ b/tests/test_dashboard_status_provider.py
@@ -1,0 +1,95 @@
+from ui.dashboard_status_provider import metrics_for_mode, refresh_default_dashboard_metrics
+from ui.job_status_drawer import JobStatusSpec
+from ui.mode_dashboard import ModeDashboard, dashboard_for_mode
+
+
+class FakeDrawer:
+    def __init__(self, jobs=None):
+        self._jobs = jobs or {}
+
+
+class FakeManager:
+    def __init__(self, missing=None, busy=False):
+        self.missing_models = missing or []
+        self.is_busy = busy
+
+
+class FakeCentralStack:
+    def __init__(self):
+        self._widgets = []
+
+    def addWidget(self, widget):
+        self._widgets.append(widget)
+        return len(self._widgets) - 1
+
+    def widget(self, index):
+        return self._widgets[index]
+
+
+class FakeMainWindow:
+    def __init__(self):
+        self.page_list = []
+        self.module_manager = FakeManager()
+        self.jobStatusDrawer = FakeDrawer()
+
+    def _has_open_project(self):
+        return bool(self.page_list)
+
+
+def metric_by_key(metrics, key):
+    for metric in metrics:
+        if metric.key == key:
+            return metric
+    raise AssertionError(f"missing metric {key}")
+
+
+def test_editor_metrics_reflect_project_pages_and_warnings():
+    win = FakeMainWindow()
+    win.page_list = ["001.png", "002.png"]
+    win.jobStatusDrawer = FakeDrawer({
+        "pipeline": JobStatusSpec(job_id="pipeline", title="Pipeline", status="warning", warnings=["overflow"])
+    })
+
+    metrics = metrics_for_mode(win, "editor")
+
+    assert metric_by_key(metrics, "pages").value == "2"
+    assert metric_by_key(metrics, "pages").status == "success"
+    assert metric_by_key(metrics, "warnings").value == "1"
+    assert metric_by_key(metrics, "warnings").status == "warning"
+
+
+def test_model_metric_reports_missing_models():
+    win = FakeMainWindow()
+    win.module_manager = FakeManager(missing=["ocr", "detector"])
+
+    metrics = metrics_for_mode(win, "models")
+
+    assert metric_by_key(metrics, "models").value == "2 missing"
+    assert metric_by_key(metrics, "models").status == "warning"
+
+
+def test_job_summary_reports_running_jobs():
+    win = FakeMainWindow()
+    win.jobStatusDrawer = FakeDrawer({
+        "pipeline": JobStatusSpec(job_id="pipeline", title="Pipeline", status="running", progress=50)
+    })
+
+    metrics = metrics_for_mode(win, "batch")
+
+    assert metric_by_key(metrics, "jobs").value == "1 running"
+    assert metric_by_key(metrics, "jobs").status == "running"
+
+
+def test_refresh_default_dashboard_metrics_updates_installed_dashboards():
+    win = FakeMainWindow()
+    win.page_list = ["001.png"]
+    win.centralStackWidget = FakeCentralStack()
+    dashboard = ModeDashboard(dashboard_for_mode("quick_image", "Quick", "Quick images"))
+    idx = win.centralStackWidget.addWidget(dashboard)
+    win._modern_dashboard_indexes = {"quick_image": idx}
+
+    assert refresh_default_dashboard_metrics(win) == 1
+
+    snapshot = dashboard.metric_snapshot()
+    assert snapshot["pages"].value == "1"
+    assert snapshot["pages"].status == "success"

--- a/tests/test_default_mode_dashboards.py
+++ b/tests/test_default_mode_dashboards.py
@@ -1,0 +1,177 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+try:
+    from qtpy.QtWidgets import QApplication, QStackedWidget, QWidget
+except Exception as exc:  # pragma: no cover - optional Qt test environment
+    pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
+
+from ui.default_mode_dashboards import (
+    DEFAULT_DASHBOARD_MODES,
+    dispatch_default_dashboard_action,
+    install_default_mode_dashboards,
+    route_default_dashboard_mode,
+    show_default_mode_dashboard,
+)
+from ui.mode_rail import ModeRail
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class FakeLeftBar(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.open_images_called = 0
+
+    def onOpenImages(self):
+        self.open_images_called += 1
+
+
+class FakePipelinePanel:
+    def __init__(self):
+        self.events = []
+        self.warnings = []
+
+    def add_event(self, kind, message):
+        self.events.append((kind, message))
+
+    def add_warning(self, kind, message):
+        self.warnings.append((kind, message))
+
+
+class FakeTitleBar:
+    def __init__(self):
+        self.workflow_hints = []
+
+    def set_workflow_hint(self, mode):
+        self.workflow_hints.append(mode)
+
+
+class DummyMainWindow(QWidget):
+    def __init__(self, *, with_stack: bool = True, with_rail: bool = False):
+        super().__init__()
+        self.calls = []
+        self.leftBar = FakeLeftBar(self)
+        self.pipelineInsightsPanel = FakePipelinePanel()
+        self.titleBar = FakeTitleBar()
+        self.project_open = False
+        if with_stack:
+            self.centralStackWidget = QStackedWidget(self)
+            # Existing default pages: welcome, editor, settings.
+            self.centralStackWidget.addWidget(QWidget(self))
+            self.centralStackWidget.addWidget(QWidget(self))
+            self.centralStackWidget.addWidget(QWidget(self))
+        if with_rail:
+            self.modeRail = ModeRail(parent=self)
+
+    def _show_welcome_screen(self):
+        self.calls.append("home")
+
+    def _has_open_project(self):
+        return self.project_open
+
+    def setupImgTransUI(self):
+        self.calls.append("editor")
+
+    def setupConfigUI(self):
+        self.calls.append("settings")
+
+    def on_open_realtime_translator(self):
+        self.calls.append("live")
+
+    def on_open_manga_source(self):
+        self.calls.append("downloader")
+
+    def on_open_batch_queue(self):
+        self.calls.append("batch")
+
+    def on_open_translation_assist_dock(self):
+        self.calls.append("assist")
+
+    def on_open_manage_models(self):
+        self.calls.append("models")
+
+    def on_environment_doctor(self):
+        self.calls.append("diagnostics")
+
+
+def test_install_default_mode_dashboards_appends_pages(qapp):
+    win = DummyMainWindow(with_stack=True)
+    before = win.centralStackWidget.count()
+
+    assert install_default_mode_dashboards(win) is True
+
+    indexes = win._modern_dashboard_indexes
+    assert set(indexes) == {key for key, _title, _description in DEFAULT_DASHBOARD_MODES}
+    assert win.centralStackWidget.count() == before + len(DEFAULT_DASHBOARD_MODES)
+
+
+def test_install_default_mode_dashboards_is_idempotent(qapp):
+    win = DummyMainWindow(with_stack=True)
+
+    assert install_default_mode_dashboards(win) is True
+    first_indexes = dict(win._modern_dashboard_indexes)
+    first_count = win.centralStackWidget.count()
+    assert install_default_mode_dashboards(win) is True
+
+    assert win._modern_dashboard_indexes == first_indexes
+    assert win.centralStackWidget.count() == first_count
+
+
+def test_show_default_mode_dashboard_switches_central_stack(qapp):
+    win = DummyMainWindow(with_stack=True)
+    install_default_mode_dashboards(win)
+
+    assert show_default_mode_dashboard(win, "live") is True
+    assert win.centralStackWidget.currentIndex() == win._modern_dashboard_indexes["live"]
+    assert show_default_mode_dashboard(win, "missing") is False
+
+
+def test_route_default_dashboard_mode_prefers_dashboard_page(qapp):
+    win = DummyMainWindow(with_stack=True)
+    install_default_mode_dashboards(win)
+
+    assert route_default_dashboard_mode(win, "downloader") is True
+
+    assert win.calls == []
+    assert win.centralStackWidget.currentIndex() == win._modern_dashboard_indexes["downloader"]
+    assert win.titleBar.workflow_hints[-1] == "downloader"
+
+
+def test_route_default_dashboard_mode_falls_back_without_dashboards(qapp):
+    win = DummyMainWindow(with_stack=False)
+
+    assert route_default_dashboard_mode(win, "live") is True
+
+    assert win.calls == ["live"]
+
+
+def test_installed_mode_rail_routes_to_dashboard_page(qapp):
+    win = DummyMainWindow(with_stack=True, with_rail=True)
+    install_default_mode_dashboards(win)
+
+    win.modeRail.mode_requested.emit("assist")
+
+    assert win.centralStackWidget.currentIndex() == win._modern_dashboard_indexes["assist"]
+    assert win.modeRail.current_mode() == "assist"
+    assert win.calls == []
+
+
+def test_dashboard_action_dispatch_uses_existing_child_handler_and_logs(qapp):
+    win = DummyMainWindow(with_stack=True)
+
+    result = dispatch_default_dashboard_action(win, "quick_image", "primary")
+
+    assert result.handled is True
+    assert result.invoked == "handler:leftBar.onOpenImages"
+    assert win.leftBar.open_images_called == 1
+    assert win.pipelineInsightsPanel.events[-1][0] == "DASHBOARD"

--- a/tests/test_default_mode_dashboards.py
+++ b/tests/test_default_mode_dashboards.py
@@ -16,6 +16,7 @@ from ui.default_mode_dashboards import (
     route_default_dashboard_mode,
     show_default_mode_dashboard,
 )
+from ui.job_status_drawer import JobStatusSpec
 from ui.mode_rail import ModeRail
 
 
@@ -56,6 +57,14 @@ class FakeTitleBar:
         self.workflow_hints.append(mode)
 
 
+class FakeDrawer:
+    def __init__(self):
+        self._jobs = {}
+
+    def upsert_job(self, job: JobStatusSpec):
+        self._jobs[job.job_id] = job
+
+
 class DummyMainWindow(QWidget):
     def __init__(self, *, with_stack: bool = True, with_rail: bool = False):
         super().__init__()
@@ -63,6 +72,7 @@ class DummyMainWindow(QWidget):
         self.leftBar = FakeLeftBar(self)
         self.pipelineInsightsPanel = FakePipelinePanel()
         self.titleBar = FakeTitleBar()
+        self.jobStatusDrawer = FakeDrawer()
         self.project_open = False
         if with_stack:
             self.centralStackWidget = QStackedWidget(self)
@@ -175,3 +185,16 @@ def test_dashboard_action_dispatch_uses_existing_child_handler_and_logs(qapp):
     assert result.invoked == "handler:leftBar.onOpenImages"
     assert win.leftBar.open_images_called == 1
     assert win.pipelineInsightsPanel.events[-1][0] == "DASHBOARD"
+
+
+def test_dashboard_action_dispatch_mirrors_task_jobs_to_drawer(qapp):
+    win = DummyMainWindow(with_stack=True)
+
+    result = dispatch_default_dashboard_action(win, "models", "primary")
+
+    assert result.handled is True
+    assert win.calls == ["models"]
+    job = win.jobStatusDrawer._jobs["model-manager"]
+    assert job.title == "Models & providers"
+    assert job.kind == "Models"
+    assert job.status == "running"

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -11,6 +11,7 @@ except Exception as exc:  # pragma: no cover - optional Qt test environment
     pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
 
 from ui.default_modern_shell import (
+    PIPELINE_JOB_ID,
     install_default_job_drawer,
     install_default_modern_navigation,
     install_default_welcome_signal_fallbacks,
@@ -95,6 +96,12 @@ class DummyMainWindow(QWidget):
     def on_environment_doctor(self):
         self.calls.append("diagnostics")
 
+    def on_pipeline_stage_event(self, stage_name: str, progress: int, page_name: str):
+        self.calls.append(f"stage:{stage_name}:{progress}:{page_name}")
+
+    def on_imgtrans_pipeline_finished(self):
+        self.calls.append("pipeline_finished")
+
 
 def test_install_default_modern_navigation_adds_mode_rail_before_leftbar(qapp):
     win = DummyMainWindow()
@@ -138,6 +145,36 @@ def test_upsert_default_job_populates_installed_drawer(qapp):
     assert upsert_default_job(win, JobStatusSpec(job_id="pipeline-1", title="Pipeline", status="running", progress=25)) is True
 
     assert win.jobStatusDrawer.job_ids() == ["pipeline-1"]
+
+
+def test_pipeline_stage_events_are_mirrored_to_default_job_drawer(qapp):
+    win = DummyMainWindow(include_bottom_bar=True)
+    install_default_job_drawer(win)
+
+    win.on_pipeline_stage_event("OCR", 42, "001.png")
+
+    assert win.calls == ["stage:OCR:42:001.png"]
+    assert win.jobStatusDrawer.job_ids() == [PIPELINE_JOB_ID]
+    job = win.jobStatusDrawer._jobs[PIPELINE_JOB_ID]
+    assert job.status == "running"
+    assert job.progress == 42
+    assert job.detail == "OCR · 001.png"
+    assert job.can_cancel is True
+
+
+def test_pipeline_finish_event_marks_default_job_complete(qapp):
+    win = DummyMainWindow(include_bottom_bar=True)
+    install_default_job_drawer(win)
+
+    win.on_pipeline_stage_event("Translate", 65, "002.png")
+    win.on_imgtrans_pipeline_finished()
+
+    assert win.calls == ["stage:Translate:65:002.png", "pipeline_finished"]
+    job = win.jobStatusDrawer._jobs[PIPELINE_JOB_ID]
+    assert job.status == "succeeded"
+    assert job.progress == 100
+    assert job.detail == "Pipeline finished"
+    assert job.can_cancel is False
 
 
 def test_route_modern_mode_request_reuses_existing_handlers(qapp):

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -138,11 +138,12 @@ def test_legacy_navigation_handlers_keep_mode_rail_selection_synced(qapp):
 def test_mode_sync_wrappers_are_not_installed_twice(qapp):
     win = DummyMainWindow()
     install_default_modern_navigation(win)
-    first_setup_settings = win.setupConfigUI
+    first_setup_settings_func = getattr(win.setupConfigUI, "__func__", None)
 
     install_default_modern_navigation(win)
+    second_setup_settings_func = getattr(win.setupConfigUI, "__func__", None)
     win.setupConfigUI()
 
-    assert win.setupConfigUI is first_setup_settings
+    assert second_setup_settings_func is first_setup_settings_func
     assert win.calls == ["settings"]
     assert win.modeRail.current_mode() == "settings"

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -46,6 +46,9 @@ class DummyMainWindow(QWidget):
     def _show_welcome_screen(self):
         self.calls.append("home")
 
+    def _show_main_content(self):
+        self.calls.append("main")
+
     def _has_open_project(self):
         return self.project_open
 
@@ -109,3 +112,37 @@ def test_route_modern_mode_request_reuses_existing_handlers(qapp):
 
     assert win.calls == ["home", "home", "editor", "assist", "diagnostics"]
     assert win.leftBar.open_images_called == 1
+
+
+def test_legacy_navigation_handlers_keep_mode_rail_selection_synced(qapp):
+    win = DummyMainWindow()
+    install_default_modern_navigation(win)
+
+    win.setupConfigUI()
+    assert win.modeRail.current_mode() == "settings"
+
+    win.on_open_manga_source()
+    assert win.modeRail.current_mode() == "downloader"
+
+    win.on_open_translation_assist_dock()
+    assert win.modeRail.current_mode() == "assist"
+
+    win.project_open = True
+    win.setupImgTransUI()
+    assert win.modeRail.current_mode() == "editor"
+
+    win._show_welcome_screen()
+    assert win.modeRail.current_mode() == "home"
+
+
+def test_mode_sync_wrappers_are_not_installed_twice(qapp):
+    win = DummyMainWindow()
+    install_default_modern_navigation(win)
+    first_setup_settings = win.setupConfigUI
+
+    install_default_modern_navigation(win)
+    win.setupConfigUI()
+
+    assert win.setupConfigUI is first_setup_settings
+    assert win.calls == ["settings"]
+    assert win.modeRail.current_mode() == "settings"

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -11,10 +11,13 @@ except Exception as exc:  # pragma: no cover - optional Qt test environment
     pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
 
 from ui.default_modern_shell import (
+    install_default_job_drawer,
     install_default_modern_navigation,
     install_default_welcome_signal_fallbacks,
     route_modern_mode_request,
+    upsert_default_job,
 )
+from ui.job_status_drawer import JobStatusDrawer, JobStatusSpec
 from ui.mode_rail import ModeRail
 
 
@@ -35,12 +38,16 @@ class DummyLeftBar(QWidget):
         self.open_images_called += 1
 
 
+class DummyBottomBar(QWidget):
+    pass
+
+
 class DummyWelcomeWidget(QWidget):
     open_assist_requested = Signal()
 
 
 class DummyMainWindow(QWidget):
-    def __init__(self):
+    def __init__(self, include_bottom_bar: bool = False):
         super().__init__()
         self.calls = []
         self.leftBar = DummyLeftBar(self)
@@ -50,6 +57,9 @@ class DummyMainWindow(QWidget):
         self.main_hlayout.addWidget(self.leftBar)
         self.main_hlayout.addWidget(self.content)
         self.mainvlayout.addLayout(self.main_hlayout)
+        self.bottomBar = DummyBottomBar(self) if include_bottom_bar else None
+        if self.bottomBar is not None:
+            self.mainvlayout.addWidget(self.bottomBar)
         self.project_open = False
 
     def _show_welcome_screen(self):
@@ -102,10 +112,32 @@ def test_install_default_modern_navigation_is_idempotent(qapp):
 
     assert install_default_modern_navigation(win) is True
     first = win.modeRail
+    first_drawer = win.jobStatusDrawer
     assert install_default_modern_navigation(win) is True
 
     assert win.modeRail is first
+    assert win.jobStatusDrawer is first_drawer
     assert sum(1 for i in range(win.main_hlayout.count()) if win.main_hlayout.itemAt(i).widget() is first) == 1
+    assert sum(1 for i in range(win.mainvlayout.count()) if win.mainvlayout.itemAt(i).widget() is first_drawer) == 1
+
+
+def test_install_default_job_drawer_adds_collapsed_drawer_before_bottom_bar(qapp):
+    win = DummyMainWindow(include_bottom_bar=True)
+
+    assert install_default_job_drawer(win) is True
+
+    assert isinstance(win.jobStatusDrawer, JobStatusDrawer)
+    assert win.mainvlayout.indexOf(win.jobStatusDrawer) == win.mainvlayout.indexOf(win.bottomBar) - 1
+    assert win.jobStatusDrawer.list_widget.isVisible() is False
+
+
+def test_upsert_default_job_populates_installed_drawer(qapp):
+    win = DummyMainWindow(include_bottom_bar=True)
+    install_default_job_drawer(win)
+
+    assert upsert_default_job(win, JobStatusSpec(job_id="pipeline-1", title="Pipeline", status="running", progress=25)) is True
+
+    assert win.jobStatusDrawer.job_ids() == ["pipeline-1"]
 
 
 def test_route_modern_mode_request_reuses_existing_handlers(qapp):

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -6,18 +6,20 @@ import pytest
 
 try:
     from qtpy.QtCore import Signal
-    from qtpy.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget
+    from qtpy.QtWidgets import QApplication, QHBoxLayout, QStackedWidget, QVBoxLayout, QWidget
 except Exception as exc:  # pragma: no cover - optional Qt test environment
     pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
 
 from ui.default_modern_shell import (
     PIPELINE_JOB_ID,
+    install_default_editor_inspector,
     install_default_job_drawer,
     install_default_modern_navigation,
     install_default_welcome_signal_fallbacks,
     route_modern_mode_request,
     upsert_default_job,
 )
+from ui.editor_inspector import EditorInspector
 from ui.job_status_drawer import JobStatusDrawer, JobStatusSpec
 from ui.mode_rail import ModeRail
 
@@ -48,7 +50,7 @@ class DummyWelcomeWidget(QWidget):
 
 
 class DummyMainWindow(QWidget):
-    def __init__(self, include_bottom_bar: bool = False):
+    def __init__(self, include_bottom_bar: bool = False, include_right_stack: bool = False):
         super().__init__()
         self.calls = []
         self.leftBar = DummyLeftBar(self)
@@ -61,6 +63,9 @@ class DummyMainWindow(QWidget):
         self.bottomBar = DummyBottomBar(self) if include_bottom_bar else None
         if self.bottomBar is not None:
             self.mainvlayout.addWidget(self.bottomBar)
+        self.rightComicTransStackPanel = QStackedWidget(self) if include_right_stack else None
+        if self.rightComicTransStackPanel is not None:
+            self.rightComicTransStackPanel.addWidget(QWidget(self))
         self.project_open = False
 
     def _show_welcome_screen(self):
@@ -95,6 +100,15 @@ class DummyMainWindow(QWidget):
 
     def on_environment_doctor(self):
         self.calls.append("diagnostics")
+
+    def on_open_ocr_crop_inspector_requested(self):
+        self.calls.append("ocr_crop")
+
+    def on_run_layout_review_requested(self):
+        self.calls.append("layout_review")
+
+    def on_open_typography_qa_report(self):
+        self.calls.append("typography_qa")
 
     def on_pipeline_stage_event(self, stage_name: str, progress: int, page_name: str):
         self.calls.append(f"stage:{stage_name}:{progress}:{page_name}")
@@ -175,6 +189,29 @@ def test_pipeline_finish_event_marks_default_job_complete(qapp):
     assert job.progress == 100
     assert job.detail == "Pipeline finished"
     assert job.can_cancel is False
+
+
+def test_install_default_editor_inspector_adds_shell_to_right_stack(qapp):
+    win = DummyMainWindow(include_right_stack=True)
+    before = win.rightComicTransStackPanel.count()
+
+    assert install_default_editor_inspector(win) is True
+
+    assert isinstance(win.editorInspector, EditorInspector)
+    assert win.rightComicTransStackPanel.count() == before + 1
+    assert win.rightComicTransStackPanel.indexOf(win.editorInspector) == before
+
+
+def test_default_editor_inspector_buttons_reuse_existing_handlers(qapp):
+    win = DummyMainWindow(include_right_stack=True)
+    install_default_editor_inspector(win)
+
+    win.editorInspector.request_translation_assist.emit()
+    win.editorInspector.request_ocr_rerun.emit()
+    win.editorInspector.request_layout_review.emit()
+    win.editorInspector.request_typography_qa.emit()
+
+    assert win.calls == ["assist", "ocr_crop", "layout_review", "typography_qa"]
 
 
 def test_route_modern_mode_request_reuses_existing_handlers(qapp):

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -5,11 +5,16 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 import pytest
 
 try:
+    from qtpy.QtCore import Signal
     from qtpy.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget
 except Exception as exc:  # pragma: no cover - optional Qt test environment
     pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
 
-from ui.default_modern_shell import install_default_modern_navigation, route_modern_mode_request
+from ui.default_modern_shell import (
+    install_default_modern_navigation,
+    install_default_welcome_signal_fallbacks,
+    route_modern_mode_request,
+)
 from ui.mode_rail import ModeRail
 
 
@@ -28,6 +33,10 @@ class DummyLeftBar(QWidget):
 
     def onOpenImages(self):
         self.open_images_called += 1
+
+
+class DummyWelcomeWidget(QWidget):
+    open_assist_requested = Signal()
 
 
 class DummyMainWindow(QWidget):
@@ -147,3 +156,14 @@ def test_mode_sync_wrappers_are_not_installed_twice(qapp):
     assert second_setup_settings_func is first_setup_settings_func
     assert win.calls == ["settings"]
     assert win.modeRail.current_mode() == "settings"
+
+
+def test_welcome_assist_fallback_connects_once(qapp):
+    win = DummyMainWindow()
+    welcome = DummyWelcomeWidget()
+
+    assert install_default_welcome_signal_fallbacks(welcome, win) is True
+    assert install_default_welcome_signal_fallbacks(welcome, win) is True
+    welcome.open_assist_requested.emit()
+
+    assert win.calls == ["assist"]

--- a/tests/test_default_modern_shell.py
+++ b/tests/test_default_modern_shell.py
@@ -1,0 +1,111 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+
+try:
+    from qtpy.QtWidgets import QApplication, QHBoxLayout, QVBoxLayout, QWidget
+except Exception as exc:  # pragma: no cover - optional Qt test environment
+    pytest.skip(f"Qt is not available: {exc}", allow_module_level=True)
+
+from ui.default_modern_shell import install_default_modern_navigation, route_modern_mode_request
+from ui.mode_rail import ModeRail
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    return app
+
+
+class DummyLeftBar(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.open_images_called = 0
+
+    def onOpenImages(self):
+        self.open_images_called += 1
+
+
+class DummyMainWindow(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+        self.leftBar = DummyLeftBar(self)
+        self.content = QWidget(self)
+        self.mainvlayout = QVBoxLayout(self)
+        self.main_hlayout = QHBoxLayout()
+        self.main_hlayout.addWidget(self.leftBar)
+        self.main_hlayout.addWidget(self.content)
+        self.mainvlayout.addLayout(self.main_hlayout)
+        self.project_open = False
+
+    def _show_welcome_screen(self):
+        self.calls.append("home")
+
+    def _has_open_project(self):
+        return self.project_open
+
+    def setupImgTransUI(self):
+        self.calls.append("editor")
+
+    def on_open_realtime_translator(self):
+        self.calls.append("live")
+
+    def on_open_manga_source(self):
+        self.calls.append("downloader")
+
+    def on_open_batch_queue(self):
+        self.calls.append("batch")
+
+    def on_open_translation_assist_dock(self):
+        self.calls.append("assist")
+
+    def on_open_manage_models(self):
+        self.calls.append("models")
+
+    def setupConfigUI(self):
+        self.calls.append("settings")
+
+    def on_environment_doctor(self):
+        self.calls.append("diagnostics")
+
+
+def test_install_default_modern_navigation_adds_mode_rail_before_leftbar(qapp):
+    win = DummyMainWindow()
+
+    assert install_default_modern_navigation(win) is True
+
+    assert isinstance(win.modeRail, ModeRail)
+    assert win.main_hlayout.indexOf(win.modeRail) == 0
+    assert win.main_hlayout.indexOf(win.leftBar) == 1
+    assert win.modeRail.current_mode() == "home"
+
+
+def test_install_default_modern_navigation_is_idempotent(qapp):
+    win = DummyMainWindow()
+
+    assert install_default_modern_navigation(win) is True
+    first = win.modeRail
+    assert install_default_modern_navigation(win) is True
+
+    assert win.modeRail is first
+    assert sum(1 for i in range(win.main_hlayout.count()) if win.main_hlayout.itemAt(i).widget() is first) == 1
+
+
+def test_route_modern_mode_request_reuses_existing_handlers(qapp):
+    win = DummyMainWindow()
+
+    route_modern_mode_request(win, "home")
+    route_modern_mode_request(win, "editor")
+    win.project_open = True
+    route_modern_mode_request(win, "editor")
+    route_modern_mode_request(win, "quick_image")
+    route_modern_mode_request(win, "assist")
+    route_modern_mode_request(win, "diagnostics")
+
+    assert win.calls == ["home", "home", "editor", "assist", "diagnostics"]
+    assert win.leftBar.open_images_called == 1

--- a/tests/test_experimental_app_shell_ast.py
+++ b/tests/test_experimental_app_shell_ast.py
@@ -1,0 +1,60 @@
+import ast
+from pathlib import Path
+
+
+def test_experimental_app_shell_defines_expected_shell_pieces_without_importing_qt():
+    path = Path("ui/experimental_app_shell.py")
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+
+    class_names = {node.name for node in tree.body if isinstance(node, ast.ClassDef)}
+    assert "ShellPageSpec" in class_names
+    assert "PlaceholderShellPage" in class_names
+    assert "ExperimentalAppShell" in class_names
+
+    for key in [
+        "home",
+        "editor",
+        "live",
+        "quick_image",
+        "downloader",
+        "batch",
+        "assist",
+        "models",
+        "settings",
+        "diagnostics",
+    ]:
+        assert f'ShellPageSpec("{key}"' in text
+
+
+def test_experimental_app_shell_uses_expected_layout_components():
+    text = Path("ui/experimental_app_shell.py").read_text(encoding="utf-8")
+    expected = [
+        "QSplitter",
+        "QStackedWidget",
+        "ModeRail",
+        "WorkflowHomeWidget",
+        "EditorInspector",
+        "JobStatusDrawer",
+        "save_splitter_state",
+        "restore_splitter_state",
+    ]
+    for snippet in expected:
+        assert snippet in text
+
+
+def test_experimental_app_shell_exposes_routing_signals():
+    text = Path("ui/experimental_app_shell.py").read_text(encoding="utf-8")
+    expected = [
+        "mode_changed = Signal(str)",
+        "workflow_requested = Signal(str)",
+        "translation_assist_requested = Signal()",
+        "ocr_rerun_requested = Signal()",
+        "layout_review_requested = Signal()",
+        "typography_qa_requested = Signal()",
+        "job_cancel_requested = Signal(str)",
+        "job_pause_requested = Signal(str)",
+        "job_details_requested = Signal(str)",
+    ]
+    for snippet in expected:
+        assert snippet in text

--- a/tests/test_experimental_shell_preview_ast.py
+++ b/tests/test_experimental_shell_preview_ast.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+
+def test_experimental_shell_preview_dialog_exists_without_importing_qt():
+    path = Path("ui/experimental_shell_preview_dialog.py")
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    class_names = {node.name for node in tree.body if isinstance(node, ast.ClassDef)}
+    assert "ExperimentalShellPreviewDialog" in class_names
+    assert "open_experimental_shell_preview" in text
+
+
+def test_experimental_shell_preview_wires_shell_signals():
+    text = Path("ui/experimental_shell_preview_dialog.py").read_text(encoding="utf-8")
+    expected = [
+        "dashboard_action_requested",
+        "workflow_requested",
+        "mode_changed",
+        "translation_assist_requested",
+        "ocr_rerun_requested",
+        "layout_review_requested",
+        "typography_qa_requested",
+        "job_cancel_requested",
+        "job_pause_requested",
+        "job_details_requested",
+    ]
+    for snippet in expected:
+        assert snippet in text
+
+
+def test_experimental_shell_preview_has_sample_jobs_button():
+    text = Path("ui/experimental_shell_preview_dialog.py").read_text(encoding="utf-8")
+    assert "Add sample jobs" in text
+    assert "sample-ocr" in text
+    assert "sample-export" in text
+    assert "JobStatusSpec" in text

--- a/tests/test_feature_matrix.py
+++ b/tests/test_feature_matrix.py
@@ -1,0 +1,14 @@
+from utils.feature_matrix import build_feature_matrix, feature_matrix_text
+
+
+def test_feature_matrix_has_expected_rows():
+    rows = build_feature_matrix()
+    names = {r['feature'] for r in rows}
+    assert 'Detection' in names
+    assert 'Models: Segmentation' in names
+
+
+def test_feature_matrix_text_format():
+    txt = feature_matrix_text()
+    assert 'Feature Matrix' in txt
+    assert '- Detection:' in txt

--- a/tests/test_job_status_drawer_ast.py
+++ b/tests/test_job_status_drawer_ast.py
@@ -1,0 +1,35 @@
+import ast
+from pathlib import Path
+
+
+def test_job_status_drawer_defines_shell_classes_without_importing_qt():
+    path = Path("ui/job_status_drawer.py")
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+    class_names = {node.name for node in tree.body if isinstance(node, ast.ClassDef)}
+    assert "JobStatusSpec" in class_names
+    assert "JobStatusRow" in class_names
+    assert "JobStatusDrawer" in class_names
+
+
+def test_job_status_drawer_has_required_signals_and_methods():
+    text = Path("ui/job_status_drawer.py").read_text(encoding="utf-8")
+    required = [
+        "cancel_requested = Signal(str)",
+        "pause_requested = Signal(str)",
+        "details_requested = Signal(str)",
+        "clear_completed_requested = Signal()",
+        "def refresh_jobs",
+        "def upsert_job",
+        "def remove_job",
+        "def set_expanded",
+    ]
+    for snippet in required:
+        assert snippet in text
+
+
+def test_job_status_drawer_mentions_core_job_types():
+    text = Path("ui/job_status_drawer.py").read_text(encoding="utf-8")
+    expected = ["OCR", "translation", "inpaint", "render", "export", "raw download", "live translation", "model download", "batch queue", "Translation"]
+    for word in expected:
+        assert word in text

--- a/tests/test_line_breaking_hyphenation.py
+++ b/tests/test_line_breaking_hyphenation.py
@@ -1,0 +1,34 @@
+from utils.line_breaking import normalize_artificial_hyphenation, split_long_token_with_hyphenation
+
+
+def measure(text: str) -> int:
+    return len(text) * 10
+
+
+def test_normalize_artificial_hyphenation_issue_137_google_translate_fragments():
+    text = "AH‐... NE‐ VER MI‐ ND‐..."
+
+    assert normalize_artificial_hyphenation(text) == "AH... NEVER MIND..."
+
+
+def test_normalize_artificial_hyphenation_handles_newline_splits():
+    text = "NE-\nVER\nMI-\nND"
+
+    assert normalize_artificial_hyphenation(text) == "NEVER\nMIND"
+
+
+def test_normalize_artificial_hyphenation_preserves_real_hyphenated_words():
+    text = "well-being and twenty-one should remain hyphenated"
+
+    assert normalize_artificial_hyphenation(text) == text
+
+
+def test_short_translated_words_are_not_hyphenated_even_when_enabled():
+    assert split_long_token_with_hyphenation("NEVER", measure, 10, hyphenate=True) == [("NEVER", 50)]
+    assert split_long_token_with_hyphenation("MIND", measure, 10, hyphenate=True) == [("MIND", 40)]
+
+
+def test_hyphenation_is_opt_in_by_default():
+    token = "extraordinarilylongword"
+
+    assert split_long_token_with_hyphenation(token, measure, 30) == [(token, measure(token))]

--- a/tests/test_mangalens_detector_registration.py
+++ b/tests/test_mangalens_detector_registration.py
@@ -1,0 +1,15 @@
+import ast
+from pathlib import Path
+
+
+def test_mangalens_detector_module_exists_and_registers_key():
+    p = Path('modules/textdetector/detector_mangalens.py')
+    assert p.exists()
+    tree = ast.parse(p.read_text(encoding='utf-8'))
+    found = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == 'register_textdetectors':
+            if node.args and isinstance(node.args[0], ast.Constant) and node.args[0].value == 'mangalens_bubble_segmentation':
+                found = True
+                break
+    assert found

--- a/tests/test_model_showcase_manifest.py
+++ b/tests/test_model_showcase_manifest.py
@@ -1,0 +1,22 @@
+import json
+from pathlib import Path
+
+
+def test_manifest_contains_showcase_package_and_models():
+    manifest = json.loads(Path('data/model_manifest.json').read_text(encoding='utf-8'))
+    packages = {p.get('id'): p for p in manifest.get('packages', [])}
+    assert 'community_showcase' in packages
+    module_keys = {m.get('module_key') for m in manifest.get('modules', [])}
+    expected = {
+        'ysg_comic_text_segmenter_v8m',
+        'ysg_comic_speech_bubble_v8m',
+        'mangalens_bubble_segmentation',
+        'sam2_1_hiera_large',
+        'sam3_hiera_large',
+        'flux1_kontext_inpaint',
+        'flux2_klein_inpaint',
+        'paddleocr_vl_1_5',
+        'realcugan_upscaler',
+        'anime_sharp_v4_x2',
+    }
+    assert expected.issubset(module_keys)

--- a/tests/test_ocr_windows_import_safety.py
+++ b/tests/test_ocr_windows_import_safety.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class _FakePlatform(types.ModuleType):
+    def system(self):
+        return "Windows"
+
+    def version(self):
+        return "10.0.22631"
+
+
+class _BlockWinsdkFinder:
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "winsdk" or fullname.startswith("winsdk."):
+            raise ImportError("winsdk intentionally unavailable for test")
+        return None
+
+
+def test_ocr_windows_import_without_winsdk_does_not_raise_nameerror(monkeypatch):
+    """Windows OCR is optional; missing winsdk must not crash module discovery.
+
+    Regression coverage for issue #136: `LOGGER` used to be imported inside the
+    same try block as winsdk, so missing winsdk caused the except block itself to
+    raise `NameError: LOGGER is not defined`.
+    """
+    module_path = Path("modules/ocr/ocr_windows.py")
+    spec = importlib.util.spec_from_file_location("_test_ocr_windows_missing_winsdk", module_path)
+    module = importlib.util.module_from_spec(spec)
+    finder = _BlockWinsdkFinder()
+    monkeypatch.setitem(sys.modules, "platform", _FakePlatform("platform"))
+    sys.meta_path.insert(0, finder)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        try:
+            sys.meta_path.remove(finder)
+        except ValueError:
+            pass

--- a/tests/test_realtime_service.py
+++ b/tests/test_realtime_service.py
@@ -1,0 +1,31 @@
+import pytest
+pytest.importorskip("cv2", exc_type=ImportError, reason="OpenCV runtime unavailable in test env")
+
+from utils.realtime_mode import RealtimeService, NumpyFrameBackend, RealtimeWatcher
+import numpy as np
+
+
+def test_realtime_service_manual_tick_updates_state():
+    svc = RealtimeService()
+    frames = [np.ones((2, 2, 3), dtype=np.uint8) * 255]
+    svc.watcher = RealtimeWatcher(NumpyFrameBackend(frames), lambda _im: 'src', lambda t: f'tr:{t}')
+    out = svc.tick_region('r1')
+    assert out['region_id'] == 'r1'
+    assert out['status'] in {'translated', 'skipped_unchanged_text'}
+    assert 'r1' in svc.states
+
+
+def test_realtime_status_contains_states_map():
+    svc = RealtimeService()
+    st = svc.status()
+    assert 'states' in st
+    assert isinstance(st['states'], dict)
+
+
+def test_realtime_apply_defaults_sets_default_region():
+    svc = RealtimeService()
+    region = svc.apply_defaults(rect=(11, 22, 333, 444), profile='manga_reader', follow_window=True)
+    assert region.region_id == 'default'
+    assert tuple(region.rect) == (11, 22, 333, 444)
+    assert region.profile == 'manga_reader'
+    assert region.follow_window is True

--- a/tests/test_startup_mode_allowlist_ast.py
+++ b/tests/test_startup_mode_allowlist_ast.py
@@ -1,0 +1,19 @@
+import ast
+from pathlib import Path
+
+
+def test_startup_mode_allowlist_includes_all_routed_modes():
+    src = Path('utils/config.py').read_text(encoding='utf-8')
+    mod = ast.parse(src)
+    target = None
+    for node in ast.walk(mod):
+        if isinstance(node, ast.Compare) and isinstance(node.left, ast.Call):
+            fn = node.left.func
+            if isinstance(fn, ast.Attribute) and fn.attr == 'get':
+                if node.left.args and isinstance(node.left.args[0], ast.Constant) and node.left.args[0].value == 'startup_mode':
+                    if node.comparators and isinstance(node.comparators[0], ast.Set):
+                        target = {elt.value for elt in node.comparators[0].elts if isinstance(elt, ast.Constant)}
+                        break
+    assert target is not None
+    expected = {'home', 'editor', 'last_used', 'settings', 'live', 'downloader', 'batch', 'models', 'diagnostics'}
+    assert expected.issubset(target)

--- a/tests/test_task_job_bridge.py
+++ b/tests/test_task_job_bridge.py
@@ -1,0 +1,71 @@
+from ui.job_status_drawer import JobStatusSpec
+from ui.task_job_bridge import (
+    complete_task_job,
+    dashboard_task_job_for,
+    mirror_dashboard_task_job,
+    upsert_task_job,
+)
+
+
+class FakeDrawer:
+    def __init__(self):
+        self._jobs = {}
+
+    def upsert_job(self, job: JobStatusSpec):
+        self._jobs[job.job_id] = job
+
+
+class FakeMainWindow:
+    def __init__(self):
+        self.jobStatusDrawer = FakeDrawer()
+
+
+def test_dashboard_task_job_for_known_export_action():
+    spec = dashboard_task_job_for("editor", "export_proof")
+
+    assert spec is not None
+    assert spec.job_id == "export-proof-pack"
+    assert spec.kind == "Export"
+
+
+def test_mirror_dashboard_task_job_upserts_handled_job():
+    win = FakeMainWindow()
+
+    assert mirror_dashboard_task_job(win, "models", "primary", handled=True) is True
+
+    job = win.jobStatusDrawer._jobs["model-manager"]
+    assert job.title == "Models & providers"
+    assert job.status == "running"
+    assert job.progress == 5
+    assert job.warnings == []
+
+
+def test_mirror_dashboard_task_job_marks_unhandled_as_warning():
+    win = FakeMainWindow()
+
+    assert mirror_dashboard_task_job(win, "assist", "compare", handled=False) is True
+
+    job = win.jobStatusDrawer._jobs["translation-assist-compare"]
+    assert job.status == "warning"
+    assert job.warnings == ["Dashboard action was not handled by the existing UI."]
+
+
+def test_mirror_dashboard_task_job_ignores_unknown_action():
+    win = FakeMainWindow()
+
+    assert mirror_dashboard_task_job(win, "missing", "action", handled=True) is False
+    assert win.jobStatusDrawer._jobs == {}
+
+
+def test_complete_task_job_marks_existing_job_success():
+    win = FakeMainWindow()
+    spec = dashboard_task_job_for("batch", "primary")
+    assert upsert_task_job(win, spec, handled=True) is True
+
+    assert complete_task_job(win, "batch-queue", detail="Batch queue finished") is True
+
+    job = win.jobStatusDrawer._jobs["batch-queue"]
+    assert job.status == "success"
+    assert job.progress == 100
+    assert job.detail == "Batch queue finished"
+    assert job.can_cancel is False

--- a/tests/test_text_layout_auto_formatting.py
+++ b/tests/test_text_layout_auto_formatting.py
@@ -36,6 +36,29 @@ def test_candidate_layout_widths_include_balanced_shape_specific_widths():
     assert any(145 <= width <= 175 for width in widths)
 
 
+def test_rectangle_alias_uses_simple_box_width_candidates():
+    square = candidate_layout_widths(
+        max_width=240,
+        min_width=60,
+        words_width=520,
+        delimiter_total_width=40,
+        line_height=24,
+        target_box_height=120,
+        balloon_shape="square",
+    )
+    rectangle = candidate_layout_widths(
+        max_width=240,
+        min_width=60,
+        words_width=520,
+        delimiter_total_width=40,
+        line_height=24,
+        target_box_height=120,
+        balloon_shape="rectangle",
+    )
+
+    assert rectangle == square
+
+
 def test_target_line_count_responds_to_tall_narrow_bubbles():
     wide = estimate_target_line_count(480, 24, 240, 80, "elongated")
     narrow = estimate_target_line_count(480, 24, 120, 240, "narrow")
@@ -96,23 +119,28 @@ def test_auto_layout_profile_defaults_cover_advanced_knobs():
         "layout_stub_penalty_1word",
     }
     assert expected <= set(balanced)
+    assert balanced["layout_balloon_shape"] == "square"
+    assert fit["layout_balloon_shape"] == "square"
+    assert readable["layout_balloon_shape"] == "square"
     assert balanced["layout_balloon_shape_auto_method"] == "contour_ratio"
     assert balanced["layout_balloon_shape_model_id"] == ""
     assert fit["layout_height_overflow_penalty"] > balanced["layout_height_overflow_penalty"]
     assert readable["layout_font_size_min"] > balanced["layout_font_size_min"]
-    assert "Balanced" in auto_layout_profile_summary("balanced")
+    assert "rectangular text boxes" in auto_layout_profile_summary("balanced")
 
 
 def test_apply_auto_layout_profile_updates_config_like_object():
     class Cfg:
         layout_auto_preset = "balanced"
         layout_font_size_min = 1.0
+        layout_balloon_shape = "auto"
         layout_balloon_shape_model_id = "old/model"
 
     cfg = Cfg()
     applied = apply_auto_layout_profile(cfg, "fit inside")
     assert cfg.layout_auto_preset == "fit"
     assert cfg.layout_font_size_min == applied["layout_font_size_min"] == 6.0
+    assert cfg.layout_balloon_shape == "square"
     assert cfg.layout_balloon_shape_model_id == ""
     assert cfg.layout_constrain_to_bubble is True
 
@@ -128,6 +156,7 @@ def test_auto_layout_setting_hints_explain_numeric_values():
         "layout_max_line_width_frac_no_bubble": 0.9,
         "layout_center_in_bubble_min_gap_px": 0,
         "layout_box_size_check_model_id": "builtin",
+        "layout_balloon_shape": "auto",
         "layout_balloon_shape_auto_method": "model_contour",
         "layout_balloon_shape_model_id": "shape/model",
     })
@@ -143,6 +172,16 @@ def test_auto_layout_setting_hints_explain_numeric_values():
         "layout_font_size_min": 6,
         "layout_font_size_max": 64,
     })
+
+
+def test_auto_layout_setting_hints_identify_simple_rectangle_shape():
+    hints = auto_layout_setting_hints({
+        "layout_balloon_shape": "square",
+        "layout_balloon_shape_auto_method": "model_contour",
+        "layout_balloon_shape_model_id": "shape/model",
+    })
+
+    assert hints["shape_detection"] == "simple rectangle"
 
 
 def test_auto_layout_presets_normalize_and_shift_behavior():

--- a/tests/test_translation_sanitize_hyphenation.py
+++ b/tests/test_translation_sanitize_hyphenation.py
@@ -1,0 +1,18 @@
+from modules.translators.base import sanitize_translation_text
+
+
+UNICODE_HYPHEN = chr(0x2010)
+
+
+def test_sanitize_translation_text_removes_issue_137_artificial_hyphen_fragments():
+    text = f"AH{UNICODE_HYPHEN}... NE{UNICODE_HYPHEN} VER MI{UNICODE_HYPHEN} ND{UNICODE_HYPHEN}..."
+    assert sanitize_translation_text(text) == "AH... NEVER MIND..."
+
+
+def test_sanitize_translation_text_handles_newline_word_fragments():
+    assert sanitize_translation_text("NE-\nVER\nMI-\nND") == "NEVER\nMIND"
+
+
+def test_sanitize_translation_text_preserves_real_hyphenated_words():
+    text = "well-being and twenty-one should remain hyphenated"
+    assert sanitize_translation_text(text) == text

--- a/tests/test_ui_config_migration.py
+++ b/tests/test_ui_config_migration.py
@@ -1,0 +1,135 @@
+import json
+
+import pytest
+
+pytest.importorskip("cv2", exc_type=ImportError, reason="OpenCV runtime unavailable in test env")
+
+from utils.config import ProgramConfig
+
+
+def test_ui_config_migration_defaults(tmp_path):
+    cfg = {
+        "module": {
+            "translator": "google",
+            "translator_params": {},
+        },
+        "show_welcome_screen": False,
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+
+    loaded = ProgramConfig.load(str(p))
+
+    assert loaded.ui_mode == "advanced"
+    assert loaded.show_experimental_features is False
+    assert loaded.show_legacy_menus is True
+    assert loaded.startup_mode == "last_used"
+    assert loaded.show_home_on_startup is False
+    assert loaded.recent_workflows == []
+    assert loaded.omni_show_unavailable is False
+    assert loaded.omni_result_type_filter == "all"
+    assert loaded.omni_result_type_filter == "all"
+
+
+def test_ui_config_migration_invalid_values_reset(tmp_path):
+    cfg = {
+        "module": {
+            "translator": "google",
+            "translator_params": {},
+        },
+        "ui_mode": "nope",
+        "startup_mode": "???",
+        "recent_workflows": "bad",
+        "omni_result_type_filter": "bad_type",
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+
+    loaded = ProgramConfig.load(str(p))
+
+    assert loaded.ui_mode == "advanced"
+    assert loaded.startup_mode == "last_used"
+    assert loaded.recent_workflows == []
+    assert loaded.omni_show_unavailable is False
+    assert loaded.omni_result_type_filter == "all"
+
+
+def test_invalid_recent_workflows_are_cleaned(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "recent_workflows": ["editor", "bad", "models", "", "EDITOR", "diag"],
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.recent_workflows == ["editor", "models"]
+
+
+def test_context_menu_profile_migration_defaults_and_invalid(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "context_menu_profile": "invalid_profile",
+    }
+    p = tmp_path / "cfg.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.context_menu_profile == "custom"
+
+
+def test_startup_mode_models_and_diagnostics_are_preserved(tmp_path):
+    for mode in ("settings", "batch", "models", "diagnostics"):
+        cfg = {"module": {"translator": "google", "translator_params": {}}, "startup_mode": mode}
+        p = tmp_path / f"cfg_{mode}.json"
+        p.write_text(json.dumps(cfg), encoding="utf-8")
+        loaded = ProgramConfig.load(str(p))
+        assert loaded.startup_mode == mode
+
+
+def test_realtime_defaults_and_invalid_values(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "realtime_profile_id": "bad",
+        "realtime_capture_interval_ms": -1,
+        "realtime_min_ocr_interval_ms": "x",
+    }
+    p = tmp_path / "cfg_rt.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.realtime_profile_id == "generic_screen_ocr"
+    assert loaded.realtime_capture_interval_ms == 100
+    assert loaded.realtime_min_ocr_interval_ms == 0
+
+
+def test_realtime_profile_valid_value_preserved(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "realtime_profile_id": "chrome_manhua_reader",
+    }
+    p = tmp_path / "cfg_rt_valid.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.realtime_profile_id == "chrome_manhua_reader"
+
+
+def test_realtime_interval_clamps_upper_bound(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "realtime_capture_interval_ms": 999999,
+        "realtime_min_ocr_interval_ms": 999999,
+    }
+    p = tmp_path / "cfg_rt_clamp.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.realtime_capture_interval_ms == 5000
+    assert loaded.realtime_min_ocr_interval_ms == 5000
+
+
+def test_realtime_region_rect_normalization(tmp_path):
+    cfg = {
+        "module": {"translator": "google", "translator_params": {}},
+        "realtime_region_rect": [-10, "bad", 0, 200000],
+    }
+    p = tmp_path / "cfg_rt_rect.json"
+    p.write_text(json.dumps(cfg), encoding="utf-8")
+    loaded = ProgramConfig.load(str(p))
+    assert loaded.realtime_region_rect == [0, 0, 100, 100]

--- a/tests/test_welcome_workflow_home_ast.py
+++ b/tests/test_welcome_workflow_home_ast.py
@@ -1,0 +1,37 @@
+import ast
+from pathlib import Path
+
+
+def test_welcome_widget_embeds_workflow_home_without_importing_qt():
+    path = Path("ui/welcome_widget.py")
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text)
+
+    assert "from .workflow_home import WorkflowHomeWidget" in text
+    assert "self._workflow_home = WorkflowHomeWidget(parent=self)" in text
+    assert "self._workflow_home.workflow_requested.connect(self._on_workflow_requested)" in text
+    assert "open_assist_requested = Signal()" in text
+
+    method_names = {
+        node.name
+        for cls in tree.body
+        if isinstance(cls, ast.ClassDef) and cls.name == "WelcomeWidget"
+        for node in cls.body
+        if isinstance(node, ast.FunctionDef)
+    }
+    assert "_on_workflow_requested" in method_names
+
+
+def test_welcome_workflow_dispatches_expected_signal_names():
+    text = Path("ui/welcome_widget.py").read_text(encoding="utf-8")
+    expected = [
+        "open_live_requested.emit()",
+        "open_images_requested.emit()",
+        "open_downloader_requested.emit()",
+        "open_batch_requested.emit()",
+        "open_assist_requested.emit()",
+        "open_models_requested.emit()",
+        "open_diagnostics_requested.emit()",
+    ]
+    for snippet in expected:
+        assert snippet in text

--- a/tests/test_workflow_home_ast.py
+++ b/tests/test_workflow_home_ast.py
@@ -1,0 +1,34 @@
+import ast
+from pathlib import Path
+
+
+def test_workflow_home_defines_expected_cards_without_importing_qt():
+    path = Path("ui/workflow_home.py")
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    text = path.read_text(encoding="utf-8")
+
+    expected_keys = [
+        "editor",
+        "live",
+        "quick_image",
+        "downloader",
+        "batch",
+        "assist",
+        "models",
+        "diagnostics",
+    ]
+    for key in expected_keys:
+        assert f'key="{key}"' in text
+
+    class_names = {node.name for node in tree.body if isinstance(node, ast.ClassDef)}
+    assert "WorkflowCardSpec" in class_names
+    assert "WorkflowCard" in class_names
+    assert "WorkflowHomeWidget" in class_names
+
+
+def test_workflow_home_uses_design_tokens():
+    text = Path("ui/workflow_home.py").read_text(encoding="utf-8")
+    assert "from .design_tokens import" in text
+    assert "card_style" in text
+    assert "badge_style" in text
+    assert "WORKFLOW_ACCENTS" in text

--- a/ui/action_registry.py
+++ b/ui/action_registry.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from qtpy.QtCore import QObject
+
+
+@dataclass
+class ActionRecord:
+    action_id: str
+    top_level: str
+    label: str
+    menu_path: str
+    category: str
+    workflow_mode: str
+    simple_mode_visible: bool
+    advanced_mode_visible: bool
+    command_palette_visible: bool
+    shortcut: str
+    tooltip: str
+    icon_name: str = ""
+    context_menu_category: str = ""
+    danger_level: str = "normal"
+    enabled: bool = True
+    disabled_reason: str = ""
+    action: object = None
+
+
+class ActionRegistry(QObject):
+    """Central registry for discoverable UI actions.
+
+    First milestone scope: register existing menu actions without behavior changes.
+    """
+
+    def __init__(self, parent: Optional[QObject] = None) -> None:
+        super().__init__(parent)
+        self._records: Dict[str, ActionRecord] = {}
+        self._action_to_id: Dict[int, str] = {}
+
+    @staticmethod
+    def _slug(text: str) -> str:
+        out = []
+        for ch in (text or "").lower():
+            if ch.isalnum():
+                out.append(ch)
+            elif ch in (" ", "-", "/", ":", ".", "(", ")"):
+                out.append("_")
+        return "_".join(part for part in "".join(out).split("_") if part)
+
+    def _build_id(self, top_level: str, path: str, label: str) -> str:
+        return f"{self._slug(top_level)}.{self._slug(path)}.{self._slug(label)}"
+
+    def register_qaction(
+        self,
+        *,
+        top_level: str,
+        menu_path: str,
+        qaction,
+        category: Optional[str] = None,
+        workflow_mode: str = "editor",
+        simple_mode_visible: bool = True,
+        advanced_mode_visible: bool = True,
+        command_palette_visible: bool = True,
+    ) -> ActionRecord:
+        text = (qaction.text() or "").replace("&", "").strip()
+        aid = self._build_id(top_level, menu_path, text)
+        shortcut = qaction.shortcut().toString() if hasattr(qaction, "shortcut") else ""
+        tooltip = qaction.toolTip() if hasattr(qaction, "toolTip") else ""
+        icon_name = ""
+        if hasattr(qaction, "icon") and not qaction.icon().isNull():
+            icon_name = "icon"
+        enabled = True
+        if hasattr(qaction, "isEnabled"):
+            try:
+                enabled = bool(qaction.isEnabled())
+            except Exception:
+                enabled = True
+
+        rec = ActionRecord(
+            action_id=aid,
+            top_level=str(top_level or ""),
+            label=text,
+            menu_path=menu_path,
+            category=category or top_level,
+            workflow_mode=workflow_mode,
+            simple_mode_visible=simple_mode_visible,
+            advanced_mode_visible=advanced_mode_visible,
+            command_palette_visible=command_palette_visible,
+            shortcut=shortcut,
+            tooltip=tooltip,
+            icon_name=icon_name,
+            enabled=enabled,
+            disabled_reason="Action is currently unavailable." if not enabled else "",
+            action=qaction,
+        )
+        self._records[aid] = rec
+        self._action_to_id[id(qaction)] = aid
+        return rec
+
+    def register_menu_tree(self, top_level: str, menu, *, menu_path_prefix: str = "") -> None:
+        if menu is None:
+            return
+        for act in menu.actions():
+            if act.isSeparator():
+                continue
+            sub = act.menu()
+            if sub is not None:
+                title = (sub.title() or act.text() or "").replace("&", "").strip()
+                next_path = f"{menu_path_prefix}{title}"
+                self.register_menu_tree(top_level, sub, menu_path_prefix=f"{next_path} > ")
+                continue
+            self.register_qaction(
+                top_level=top_level,
+                menu_path=(menu_path_prefix[:-3] if menu_path_prefix.endswith(" > ") else menu_path_prefix) or top_level,
+                qaction=act,
+            )
+
+    def clear(self) -> None:
+        self._records.clear()
+        self._action_to_id.clear()
+
+    def record_for_action(self, action) -> Optional[ActionRecord]:
+        aid = self._action_to_id.get(id(action))
+        if not aid:
+            return None
+        return self._records.get(aid)
+
+    def all_records(self) -> List[ActionRecord]:
+        return list(self._records.values())
+
+    def discoverable_actions(self, show_unavailable: bool = False) -> Iterable[Tuple[str, object, dict]]:
+        for rec in self._records.values():
+            if not rec.command_palette_visible or rec.action is None:
+                continue
+            if (not show_unavailable) and (not rec.enabled):
+                continue
+            label = f"[Command] Menu > {rec.menu_path} > {rec.label}" if rec.menu_path else f"[Command] Menu > {rec.label}"
+            extra = ""
+            if rec.tooltip:
+                extra += f" ({rec.tooltip})"
+            if rec.shortcut:
+                extra += f" [{rec.shortcut}]"
+            if not rec.enabled:
+                extra += f" [Unavailable: {rec.disabled_reason}]"
+            yield (label + extra, rec.action, {"enabled": rec.enabled, "reason": rec.disabled_reason})
+
+    def has_duplicate_ids(self) -> bool:
+        return len(self._records) != len(set(self._records.keys()))
+
+    def to_rows(self) -> List[dict]:
+        rows = []
+        for rec in self._records.values():
+            rows.append({
+                "action_id": rec.action_id,
+                "top_level": rec.top_level,
+                "label": rec.label,
+                "menu_path": rec.menu_path,
+                "category": rec.category,
+                "workflow_mode": rec.workflow_mode,
+                "simple_mode_visible": rec.simple_mode_visible,
+                "advanced_mode_visible": rec.advanced_mode_visible,
+                "command_palette_visible": rec.command_palette_visible,
+                "shortcut": rec.shortcut,
+                "tooltip": rec.tooltip,
+                "enabled": rec.enabled,
+                "disabled_reason": rec.disabled_reason,
+                "danger_level": rec.danger_level,
+            })
+        return rows
+
+    def summary_stats(self) -> dict:
+        rows = self.to_rows()
+        total = len(rows)
+        enabled = sum(1 for r in rows if r.get("enabled"))
+        simple_visible = sum(1 for r in rows if r.get("simple_mode_visible"))
+        advanced_visible = sum(1 for r in rows if r.get("advanced_mode_visible"))
+        by_category: Dict[str, int] = {}
+        for r in rows:
+            c = str(r.get("category") or "Uncategorized")
+            by_category[c] = by_category.get(c, 0) + 1
+        return {
+            "total_actions": total,
+            "enabled_actions": enabled,
+            "disabled_actions": max(0, total - enabled),
+            "simple_visible_actions": simple_visible,
+            "advanced_visible_actions": advanced_visible,
+            "categories": by_category,
+            "duplicate_shortcuts": self.duplicate_shortcuts(),
+        }
+
+    def duplicate_shortcuts(self) -> Dict[str, List[str]]:
+        by_shortcut: Dict[str, List[str]] = {}
+        for rec in self._records.values():
+            if not rec.shortcut:
+                continue
+            by_shortcut.setdefault(rec.shortcut, []).append(rec.action_id)
+        return {k: v for k, v in by_shortcut.items() if len(v) > 1}

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -410,6 +410,9 @@ class ConfigPanel(Widget):
     display_lang_changed = Signal(str)
     dev_mode_changed = Signal()
     manual_mode_changed = Signal()
+    ui_mode_changed = Signal(str)
+    legacy_menu_layout_changed = Signal(bool)
+    omni_options_changed = Signal()
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -675,6 +675,104 @@ class ConfigPanel(Widget):
         )
         self.show_welcome_screen_checker.stateChanged.connect(self.on_show_welcome_screen_changed)
 
+        self.startup_mode_combo = QComboBox(self)
+        self.startup_mode_combo.addItem(self.tr('Home / Launcher'), 'home')
+        self.startup_mode_combo.addItem(self.tr('Editor'), 'editor')
+        self.startup_mode_combo.addItem(self.tr('Last used workflow'), 'last_used')
+        self.startup_mode_combo.addItem(self.tr('Settings'), 'settings')
+        self.startup_mode_combo.addItem(self.tr('Live translator'), 'live')
+        self.startup_mode_combo.addItem(self.tr('Raw downloader'), 'downloader')
+        self.startup_mode_combo.addItem(self.tr('Batch queue'), 'batch')
+        self.startup_mode_combo.addItem(self.tr('Models hub'), 'models')
+        self.startup_mode_combo.addItem(self.tr('Diagnostics'), 'diagnostics')
+        self.startup_mode_combo.currentIndexChanged.connect(self.on_startup_mode_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.startup_mode_combo,
+            self.tr('Startup mode'),
+            discription=self.tr('Choose which surface opens at startup when no explicit file/path argument is provided.')
+        ))
+
+        self.show_home_on_startup_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Fallback to Home when startup target is unavailable'),
+            discription=self.tr('If last-used/startup target cannot be opened, return to Home instead of staying in an empty editor state.')
+        )
+        self.show_home_on_startup_checker.stateChanged.connect(self.on_show_home_on_startup_changed)
+
+        self.ui_mode_combo = QComboBox(self)
+        self.ui_mode_combo.addItem(self.tr('Simple'), 'simple')
+        self.ui_mode_combo.addItem(self.tr('Advanced'), 'advanced')
+        self.ui_mode_combo.addItem(self.tr('Developer'), 'developer')
+        self.ui_mode_combo.currentIndexChanged.connect(self.on_ui_mode_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.ui_mode_combo,
+            self.tr('UI complexity mode'),
+            discription=self.tr('Simple mode hides advanced/diagnostic-heavy menu actions. Advanced keeps full standard menus. Developer keeps all actions.')
+        ))
+
+        self.show_legacy_menus_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Show legacy menu layout'),
+            discription=self.tr('Keep the existing menu structure visible while workflow-centered navigation is rolled out.')
+        )
+        self.show_legacy_menus_checker.stateChanged.connect(self.on_show_legacy_menus_changed)
+
+        self.omni_show_unavailable_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Omni-search: show unavailable commands'),
+            discription=self.tr('Include disabled commands in command search results with a reason why they are unavailable.')
+        )
+        self.omni_show_unavailable_checker.stateChanged.connect(self.on_omni_show_unavailable_changed)
+
+        self.omni_type_filter_combo = QComboBox(self)
+        self.omni_type_filter_combo.addItem(self.tr('All'), 'all')
+        self.omni_type_filter_combo.addItem(self.tr('Commands'), 'command')
+        self.omni_type_filter_combo.addItem(self.tr('Settings'), 'setting')
+        self.omni_type_filter_combo.addItem(self.tr('Text blocks'), 'text_block')
+        self.omni_type_filter_combo.addItem(self.tr('Page'), 'page')
+        self.omni_type_filter_combo.addItem(self.tr('Recent'), 'recent')
+        self.omni_type_filter_combo.addItem(self.tr('Help'), 'help')
+        self.omni_type_filter_combo.currentIndexChanged.connect(self.on_omni_result_type_filter_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.omni_type_filter_combo,
+            self.tr('Omni-search default result filter'),
+            discription=self.tr('Choose the default result type shown in omni-search.')
+        ))
+
+        self.realtime_profile_combo = QComboBox(self)
+        self.realtime_profile_combo.addItem(self.tr('Chrome Manhua Reader'), 'chrome_manhua_reader')
+        self.realtime_profile_combo.addItem(self.tr('Manga Reader'), 'manga_reader')
+        self.realtime_profile_combo.addItem(self.tr('Generic Screen OCR'), 'generic_screen_ocr')
+        self.realtime_profile_combo.currentIndexChanged.connect(self.on_realtime_profile_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.realtime_profile_combo,
+            self.tr('Live Translator profile'),
+            discription=self.tr('Default profile for Realtime Screen Translator startup behavior.')
+        ))
+
+        self.realtime_capture_interval_spin = QSpinBox(self)
+        self.realtime_capture_interval_spin.setRange(100, 5000)
+        self.realtime_capture_interval_spin.setSingleStep(50)
+        self.realtime_capture_interval_spin.valueChanged.connect(self.on_realtime_capture_interval_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.realtime_capture_interval_spin,
+            self.tr('Live capture interval (ms)'),
+            discription=self.tr('Default screenshot capture interval for Live Translator.')
+        ))
+
+        self.realtime_min_ocr_interval_spin = QSpinBox(self)
+        self.realtime_min_ocr_interval_spin.setRange(0, 5000)
+        self.realtime_min_ocr_interval_spin.setSingleStep(50)
+        self.realtime_min_ocr_interval_spin.valueChanged.connect(self.on_realtime_min_ocr_interval_changed)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            self.realtime_min_ocr_interval_spin,
+            self.tr('Live min OCR interval (ms)'),
+            discription=self.tr('Debounce OCR runs in Live Translator to reduce repeated OCR calls.')
+        ))
+
+        self.realtime_follow_window_checker, _ = generalConfigPanel.addCheckBox(
+            self.tr('Live Translator: follow selected window by default'),
+            discription=self.tr('When enabled, Live Translator follows selected window position when backend support is available.')
+        )
+        self.realtime_follow_window_checker.stateChanged.connect(self.on_realtime_follow_window_changed)
+
         self.auto_update_from_github_checker, _ = generalConfigPanel.addCheckBox(
             self.tr('Auto update from GitHub on startup'),
             discription=self.tr('Check for updates and pull from GitHub when the app starts. Can cause issues or bad results (e.g. merge conflicts, broken code, unexpected behavior). Use only if you understand the risks. Your config and local files are not overwritten.')
@@ -1670,6 +1768,46 @@ class ConfigPanel(Widget):
     def on_open_onstartup_changed(self):
         pcfg.open_recent_on_startup = self.open_on_startup_checker.isChecked()
 
+    def on_startup_mode_changed(self):
+        pcfg.startup_mode = str(self.startup_mode_combo.currentData() or 'last_used')
+        self._refresh_startup_mode_dependent_ui()
+
+    def on_show_home_on_startup_changed(self):
+        pcfg.show_home_on_startup = self.show_home_on_startup_checker.isChecked()
+
+    def on_ui_mode_changed(self):
+        pcfg.ui_mode = str(self.ui_mode_combo.currentData() or 'advanced')
+        self.ui_mode_changed.emit(pcfg.ui_mode)
+
+    def on_show_legacy_menus_changed(self):
+        pcfg.show_legacy_menus = self.show_legacy_menus_checker.isChecked()
+        self.legacy_menu_layout_changed.emit(bool(pcfg.show_legacy_menus))
+
+    def on_omni_show_unavailable_changed(self):
+        pcfg.omni_show_unavailable = self.omni_show_unavailable_checker.isChecked()
+        self.omni_options_changed.emit()
+
+    def on_omni_result_type_filter_changed(self):
+        pcfg.omni_result_type_filter = str(self.omni_type_filter_combo.currentData() or "all")
+        self.omni_options_changed.emit()
+
+    def on_realtime_profile_changed(self):
+        pcfg.realtime_profile_id = str(self.realtime_profile_combo.currentData() or "generic_screen_ocr")
+
+    def on_realtime_capture_interval_changed(self):
+        pcfg.realtime_capture_interval_ms = int(self.realtime_capture_interval_spin.value())
+
+    def on_realtime_min_ocr_interval_changed(self):
+        pcfg.realtime_min_ocr_interval_ms = int(self.realtime_min_ocr_interval_spin.value())
+
+    def on_realtime_follow_window_changed(self):
+        pcfg.realtime_follow_window = bool(self.realtime_follow_window_checker.isChecked())
+
+    def _refresh_startup_mode_dependent_ui(self):
+        mode = str(getattr(pcfg, 'startup_mode', 'last_used') or 'last_used')
+        # Fallback toggle is only meaningful when startup target may be unavailable.
+        self.show_home_on_startup_checker.setEnabled(mode in ('last_used', 'editor', 'settings', 'live', 'downloader', 'batch', 'models', 'diagnostics'))
+
     def on_show_welcome_screen_changed(self):
         pcfg.show_welcome_screen = self.show_welcome_screen_checker.isChecked()
 
@@ -2616,6 +2754,29 @@ class ConfigPanel(Widget):
         self.let_show_only_custom_fonts.setChecked(pcfg.let_show_only_custom_fonts_flag)
         self.recent_proj_list_max_spin.setValue(getattr(pcfg, 'recent_proj_list_max', 14))
         self.show_welcome_screen_checker.setChecked(getattr(pcfg, 'show_welcome_screen', True))
+        startup_mode = str(getattr(pcfg, 'startup_mode', 'last_used') or 'last_used')
+        sm_idx = self.startup_mode_combo.findData(startup_mode)
+        if sm_idx < 0:
+            sm_idx = self.startup_mode_combo.findData('last_used')
+        self.startup_mode_combo.setCurrentIndex(max(0, sm_idx))
+        self.show_home_on_startup_checker.setChecked(bool(getattr(pcfg, 'show_home_on_startup', True)))
+        ui_mode = str(getattr(pcfg, 'ui_mode', 'advanced') or 'advanced')
+        ui_idx = self.ui_mode_combo.findData(ui_mode)
+        if ui_idx < 0:
+            ui_idx = self.ui_mode_combo.findData('advanced')
+        self.ui_mode_combo.setCurrentIndex(max(0, ui_idx))
+        self.show_legacy_menus_checker.setChecked(bool(getattr(pcfg, 'show_legacy_menus', True)))
+        self.omni_show_unavailable_checker.setChecked(bool(getattr(pcfg, 'omni_show_unavailable', False)))
+        _ot = str(getattr(pcfg, 'omni_result_type_filter', 'all') or 'all')
+        _ot_idx = self.omni_type_filter_combo.findData(_ot)
+        self.omni_type_filter_combo.setCurrentIndex(_ot_idx if _ot_idx >= 0 else 0)
+        _rtp = str(getattr(pcfg, 'realtime_profile_id', 'generic_screen_ocr') or 'generic_screen_ocr')
+        _rtp_idx = self.realtime_profile_combo.findData(_rtp)
+        self.realtime_profile_combo.setCurrentIndex(_rtp_idx if _rtp_idx >= 0 else self.realtime_profile_combo.findData('generic_screen_ocr'))
+        self.realtime_capture_interval_spin.setValue(int(getattr(pcfg, 'realtime_capture_interval_ms', 700) or 700))
+        self.realtime_min_ocr_interval_spin.setValue(int(getattr(pcfg, 'realtime_min_ocr_interval_ms', 0) or 0))
+        self.realtime_follow_window_checker.setChecked(bool(getattr(pcfg, 'realtime_follow_window', False)))
+        self._refresh_startup_mode_dependent_ui()
         self.show_model_download_result_dialog_checker.setChecked(getattr(pcfg, 'show_model_download_result_dialog', True))
         self.show_startup_health_dialog_checker.setChecked(getattr(pcfg, 'show_startup_health_dialog', True))
         self.dev_mode_checker.setChecked(getattr(pcfg, 'dev_mode', False))

--- a/ui/context_menu_config_dialog.py
+++ b/ui/context_menu_config_dialog.py
@@ -94,7 +94,7 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("format_re_auto_fit_selected", "Re-auto-fit selected text box(es)"),
         ("format_re_auto_fit_page", "Re-auto-fit current page"),
         ("format_re_auto_fit_all", "Re-auto-fit all pages"),
-        ("format_balloon_shape", "Balloon shape (submenu)"),
+        ("format_balloon_shape", "Text box shape: Rectangle / Auto (submenu)"),
         ("format_resize_to_fit_content", "Resize to fit content"),
         ("format_fit_to_mask_safe_box", "Fit box to visible mask area"),
         ("format_center_in_bubble", "Center in bubble"),

--- a/ui/context_menu_config_dialog.py
+++ b/ui/context_menu_config_dialog.py
@@ -38,7 +38,7 @@ def _all_keys_with_labels() -> List[Tuple[str, str]]:
 
 # (category_title, items: [(key, label), ...])
 CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
-    ("Edit", [
+    ("Text box", [
         ("edit_copy", "Copy"),
         ("edit_paste", "Paste"),
         ("edit_copy_trans", "Copy translation"),
@@ -51,7 +51,7 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("edit_clear_trans", "Clear translation"),
         ("edit_select_all", "Select all"),
     ]),
-    ("Text", [
+    ("Style", [
         ("text_spell_src", "Spell check source text"),
         ("text_spell_trans", "Spell check translation"),
         ("text_trim", "Trim whitespace"),
@@ -61,7 +61,7 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("text_gradient", "Gradient type (submenu)"),
         ("text_on_path", "Text on path (submenu)"),
     ]),
-    ("Block", [
+    ("Layout", [
         ("block_merge", "Merge selected blocks"),
         ("block_split", "Split selected region(s)"),
         ("block_move_up", "Move block(s) up"),
@@ -70,20 +70,20 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("block_triage_mark_reviewed", "Mark selected as reviewed"),
         ("create_textbox", "Create text box"),
     ]),
-    ("Image / Overlay", [
+    ("Export", [
         ("overlay_import", "Import Image"),
         ("overlay_clear", "Clear overlay image"),
     ]),
-    ("Transform", [
+    ("Layout", [
         ("transform_free", "Free Transform"),
         ("transform_reset_warp", "Reset warp"),
         ("transform_warp_preset", "Warp preset (submenu)"),
     ]),
-    ("Order", [
+    ("Layout", [
         ("order_bring_front", "Bring to front"),
         ("order_send_back", "Send to back"),
     ]),
-    ("Format", [
+    ("Style", [
         ("format_apply", "Apply font formatting"),
         ("format_layout", "Auto layout"),
         ("format_fit_to_bubble", "Fit to bubble"),
@@ -107,19 +107,25 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("format_layout_review_config", "Layout review settings"),
         ("review_export_lettering_proof", "Export lettering proof pack"),
     ]),
-    ("Run", [
+    ("OCR", [
         ("run_detect_region", "Detect text in region"),
         ("run_detect_page", "Detect text on page"),
-        ("run_translate", "Translate"),
         ("run_ocr", "OCR"),
+    ]),
+    ("Translation", [
+        ("run_translate", "Translate"),
         ("run_ocr_translate", "OCR and translate"),
         ("run_ocr_translate_inpaint", "OCR, translate and inpaint"),
+    ]),
+    ("Layout", [
         ("run_inpaint", "Inpaint"),
+    ]),
+    ("QA", [
         ("review_ocr_triage_page", "OCR triage worklist (current page)"),
         ("review_translation_qa_page", "Translation QA report (current page)"),
         ("review_auto_extract_glossary_page", "Auto-extract glossary (current page)"),
     ]),
-    ("Download image", [
+    ("Export", [
         ("download_image", "Download image (submenu)"),
     ]),
 ]
@@ -178,6 +184,11 @@ class ContextMenuConfigDialog(QDialog):
 
         preset_row = QHBoxLayout()
         preset_row.addWidget(QLabel(self.tr("Quick profiles:")))
+        self._profile_combo = QLineEdit(self)
+        self._profile_combo.setReadOnly(True)
+        self._profile_combo.setMaximumWidth(190)
+        self._profile_combo.setToolTip(self.tr("Shows the last-applied quick profile. Manual checkbox edits set this to Custom."))
+        preset_row.addWidget(self._profile_combo)
         btn_edit = QPushButton(self.tr("Editing-focused"))
         btn_edit.clicked.connect(lambda: self._apply_profile("editing"))
         preset_row.addWidget(btn_edit)
@@ -210,6 +221,7 @@ class ContextMenuConfigDialog(QDialog):
                 cb = QCheckBox(self.tr(label))
                 cb.setToolTip(self.tr(f"Canvas context menu action: {label} ({key})"))
                 cb.setChecked(pcfg.context_menu.get(key, True))
+                cb.stateChanged.connect(self._mark_custom_profile)
                 self._checkboxes[key] = cb
                 row.addWidget(cb, 1)
                 pin_btn = QPushButton(self.tr("Pin to top"))
@@ -253,6 +265,7 @@ class ContextMenuConfigDialog(QDialog):
         layout.addLayout(btn_layout)
 
         self._refresh_pinned_list()
+        self._set_profile_label(str(getattr(pcfg, "context_menu_profile", "custom") or "custom"))
 
     def _apply_filter(self, text: str = None):
         needle = (text if text is not None else self._filter_edit.text()).strip().lower()
@@ -292,6 +305,22 @@ class ContextMenuConfigDialog(QDialog):
         chosen = editing_keys if profile == 'editing' else pipeline_keys if profile == 'pipeline' else layout_keys
         for key, cb in self._checkboxes.items():
             cb.setChecked(key in chosen)
+        self._set_profile_label(profile)
+
+    def _set_profile_label(self, profile: str):
+        p = str(profile or "custom").lower()
+        labels = {
+            "editing": self.tr("Profile: Editing-focused"),
+            "pipeline": self.tr("Profile: Pipeline-focused"),
+            "layout": self.tr("Profile: Layout-focused"),
+            "custom": self.tr("Profile: Custom"),
+        }
+        self._profile_combo.setText(labels.get(p, labels["custom"]))
+        self._current_profile = p if p in labels else "custom"
+
+    def _mark_custom_profile(self, *_args):
+        if getattr(self, "_current_profile", "custom") != "custom":
+            self._set_profile_label("custom")
 
     def _refresh_pinned_list(self):
         self._pinned_list.clear()
@@ -343,6 +372,7 @@ class ContextMenuConfigDialog(QDialog):
             if k and k not in self._pinned_keys:
                 self._pinned_keys.append(k)
         pcfg.context_menu_pinned = self._pinned_keys
+        pcfg.context_menu_profile = str(getattr(self, "_current_profile", "custom") or "custom")
         try:
             pcfg.context_run_macros = parse_context_run_macros(self._macros_edit.toPlainText())
         except Exception as e:

--- a/ui/dashboard_action_dispatcher.py
+++ b/ui/dashboard_action_dispatcher.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from .dashboard_action_router import DashboardActionRoute, dashboard_route_for
+
+
+@dataclass(frozen=True)
+class DashboardDispatchResult:
+    mode: str
+    action: str
+    handled: bool
+    route_found: bool
+    invoked: str = ""
+    message: str = ""
+
+
+def _find_action_registry(owner: Any):
+    """Best-effort lookup for the action registry without depending on MainWindow."""
+    for attr in ("action_registry", "_action_registry"):
+        reg = getattr(owner, attr, None)
+        if reg is not None:
+            return reg
+    for holder_name in ("titleBar", "titlebar", "title_bar"):
+        holder = getattr(owner, holder_name, None)
+        if holder is None:
+            continue
+        for attr in ("action_registry", "_action_registry"):
+            reg = getattr(holder, attr, None)
+            if reg is not None:
+                return reg
+    return None
+
+
+def _trigger_action_by_id(owner: Any, action_id: str) -> bool:
+    if not action_id:
+        return False
+    registry = _find_action_registry(owner)
+    if registry is None or not hasattr(registry, "all_records"):
+        return False
+    try:
+        for record in registry.all_records():
+            if getattr(record, "action_id", "") == action_id:
+                action_obj = getattr(record, "action", None)
+                if action_obj is not None and hasattr(action_obj, "trigger"):
+                    action_obj.trigger()
+                    return True
+    except Exception:
+        return False
+    return False
+
+
+def _invoke_handler(owner: Any, handler_name: str) -> bool:
+    if not handler_name:
+        return False
+    handler = getattr(owner, handler_name, None)
+    if handler is None or not callable(handler):
+        return False
+    handler()
+    return True
+
+
+def dispatch_dashboard_action(owner: Any, mode: str, action: str) -> DashboardDispatchResult:
+    """Safely dispatch a dashboard action to the existing app when possible.
+
+    Resolution order:
+    1. Action registry ID, if present and registered.
+    2. Existing handler method name on the owner.
+    3. Structured unhandled result for future wiring.
+
+    This lets the modern dashboards become useful incrementally without forcing
+    a risky all-at-once MainWindow rewrite.
+    """
+    route: Optional[DashboardActionRoute] = dashboard_route_for(mode, action)
+    if route is None:
+        return DashboardDispatchResult(mode, action, False, False, message="No route is registered for this dashboard action.")
+
+    if route.action_id and _trigger_action_by_id(owner, route.action_id):
+        return DashboardDispatchResult(mode, action, True, True, invoked=f"action:{route.action_id}", message=route.title)
+
+    try:
+        if route.handler_name and _invoke_handler(owner, route.handler_name):
+            return DashboardDispatchResult(mode, action, True, True, invoked=f"handler:{route.handler_name}", message=route.title)
+    except Exception as exc:
+        return DashboardDispatchResult(mode, action, False, True, invoked=f"handler:{route.handler_name}", message=f"Dashboard action failed: {exc}")
+
+    if not route.safe_to_wire:
+        return DashboardDispatchResult(
+            mode,
+            action,
+            False,
+            True,
+            message=f"{route.title or action} is intentionally marked as not wired yet.",
+        )
+    return DashboardDispatchResult(
+        mode,
+        action,
+        False,
+        True,
+        message=f"{route.title or action} has a route but no matching handler/action was found.",
+    )
+
+
+def dispatch_message_for_result(result: DashboardDispatchResult) -> str:
+    if result.handled:
+        return result.message or f"Handled {result.mode}:{result.action}"
+    if result.message:
+        return result.message
+    return f"Dashboard action is not wired yet: {result.mode}:{result.action}"

--- a/ui/dashboard_action_dispatcher.py
+++ b/ui/dashboard_action_dispatcher.py
@@ -51,10 +51,23 @@ def _trigger_action_by_id(owner: Any, action_id: str) -> bool:
     return False
 
 
+def _resolve_attr_path(owner: Any, attr_path: str):
+    """Resolve handler paths such as 'leftBar.onOpenImages'."""
+    target = owner
+    for part in str(attr_path or "").split("."):
+        part = part.strip()
+        if not part:
+            return None
+        target = getattr(target, part, None)
+        if target is None:
+            return None
+    return target
+
+
 def _invoke_handler(owner: Any, handler_name: str) -> bool:
     if not handler_name:
         return False
-    handler = getattr(owner, handler_name, None)
+    handler = _resolve_attr_path(owner, handler_name)
     if handler is None or not callable(handler):
         return False
     handler()
@@ -66,7 +79,7 @@ def dispatch_dashboard_action(owner: Any, mode: str, action: str) -> DashboardDi
 
     Resolution order:
     1. Action registry ID, if present and registered.
-    2. Existing handler method name on the owner.
+    2. Existing handler method/path on the owner.
     3. Structured unhandled result for future wiring.
 
     This lets the modern dashboards become useful incrementally without forcing

--- a/ui/dashboard_action_router.py
+++ b/ui/dashboard_action_router.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class DashboardActionRoute:
+    mode: str
+    action: str
+    action_id: str = ""
+    handler_name: str = ""
+    title: str = ""
+    description: str = ""
+    safe_to_wire: bool = True
+
+    def route_key(self) -> Tuple[str, str]:
+        return (self.mode, self.action)
+
+
+DASHBOARD_ACTION_ROUTES: Dict[Tuple[str, str], DashboardActionRoute] = {
+    ("editor", "primary"): DashboardActionRoute("editor", "primary", "file.open_folder", "openFolder", "Open project/folder"),
+    ("editor", "run_pipeline"): DashboardActionRoute("editor", "run_pipeline", "pipeline.run", "onRun", "Run full pipeline"),
+    ("editor", "selected_ocr"): DashboardActionRoute("editor", "selected_ocr", "ocr.rerun_selected", "onOCRSelectedBlocks", "OCR selected blocks", safe_to_wire=False),
+    ("editor", "layout_review"): DashboardActionRoute("editor", "layout_review", "qa.layout_review", "onLayoutReviewSelected", "Review layout", safe_to_wire=False),
+    ("editor", "export_proof"): DashboardActionRoute("editor", "export_proof", "export.proof_pack", "onExportProofPack", "Export proof pack", safe_to_wire=False),
+
+    ("live", "primary"): DashboardActionRoute("live", "primary", "live.open", "on_open_realtime_translator", "Start live region picker"),
+    ("live", "pick_region"): DashboardActionRoute("live", "pick_region", "live.pick_region", "on_open_realtime_translator", "Select live region"),
+    ("live", "chrome_profile"): DashboardActionRoute("live", "chrome_profile", "live.chrome_profile", "on_open_realtime_translator", "Chrome Manhua preset"),
+    ("live", "overlay"): DashboardActionRoute("live", "overlay", "live.overlay_settings", "on_open_realtime_translator", "Overlay settings"),
+    ("live", "privacy"): DashboardActionRoute("live", "privacy", "live.privacy", "on_open_realtime_translator", "Live privacy controls"),
+
+    ("assist", "primary"): DashboardActionRoute("assist", "primary", "translation.assist", "on_open_translation_assist", "Open Translation Assist"),
+    ("assist", "compare"): DashboardActionRoute("assist", "compare", "translation.compare_providers", "on_open_translation_assist", "Compare providers"),
+    ("assist", "tm"): DashboardActionRoute("assist", "tm", "translation.memory", "on_open_translation_assist", "Translation memory"),
+    ("assist", "glossary"): DashboardActionRoute("assist", "glossary", "translation.glossary", "on_open_translation_assist", "Glossary violations"),
+    ("assist", "sfx"): DashboardActionRoute("assist", "sfx", "translation.sfx_dictionary", "on_open_translation_assist", "SFX dictionary"),
+
+    ("downloader", "primary"): DashboardActionRoute("downloader", "primary", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
+    ("downloader", "search"): DashboardActionRoute("downloader", "search", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
+    ("downloader", "queue"): DashboardActionRoute("downloader", "queue", "batch.queue", "on_open_batch_queue", "Chapter queue"),
+    ("downloader", "health"): DashboardActionRoute("downloader", "health", "diagnostics.source_health", "on_environment_doctor", "Source health", safe_to_wire=False),
+    ("downloader", "import"): DashboardActionRoute("downloader", "import", "file.open_folder", "openFolder", "Import to project"),
+
+    ("models", "primary"): DashboardActionRoute("models", "primary", "models.manage", "on_open_manage_models", "Manage models"),
+    ("settings", "primary"): DashboardActionRoute("settings", "primary", "settings.open", "setupConfigUI", "Open settings"),
+    ("diagnostics", "primary"): DashboardActionRoute("diagnostics", "primary", "diagnostics.environment_doctor", "on_environment_doctor", "Environment doctor"),
+}
+
+
+def dashboard_route_for(mode: str, action: str) -> Optional[DashboardActionRoute]:
+    return DASHBOARD_ACTION_ROUTES.get((str(mode or ""), str(action or "")))
+
+
+def dashboard_action_id_for(mode: str, action: str) -> str:
+    route = dashboard_route_for(mode, action)
+    return route.action_id if route else ""
+
+
+def dashboard_handler_for(mode: str, action: str) -> str:
+    route = dashboard_route_for(mode, action)
+    return route.handler_name if route else ""
+
+
+def safe_dashboard_routes() -> Dict[Tuple[str, str], DashboardActionRoute]:
+    return {key: route for key, route in DASHBOARD_ACTION_ROUTES.items() if route.safe_to_wire}

--- a/ui/dashboard_action_router.py
+++ b/ui/dashboard_action_router.py
@@ -19,11 +19,13 @@ class DashboardActionRoute:
 
 
 DASHBOARD_ACTION_ROUTES: Dict[Tuple[str, str], DashboardActionRoute] = {
-    ("editor", "primary"): DashboardActionRoute("editor", "primary", "file.open_folder", "openFolder", "Open project/folder"),
-    ("editor", "run_pipeline"): DashboardActionRoute("editor", "run_pipeline", "pipeline.run", "onRun", "Run full pipeline"),
-    ("editor", "selected_ocr"): DashboardActionRoute("editor", "selected_ocr", "ocr.rerun_selected", "onOCRSelectedBlocks", "OCR selected blocks", safe_to_wire=False),
-    ("editor", "layout_review"): DashboardActionRoute("editor", "layout_review", "qa.layout_review", "onLayoutReviewSelected", "Review layout", safe_to_wire=False),
-    ("editor", "export_proof"): DashboardActionRoute("editor", "export_proof", "export.proof_pack", "onExportProofPack", "Export proof pack", safe_to_wire=False),
+    # Editor / project workflow.  These handler names intentionally match the
+    # existing MainWindow methods used by the legacy left bar and menus.
+    ("editor", "primary"): DashboardActionRoute("editor", "primary", "file.open_folder", "_welcome_open_folder", "Open project/folder"),
+    ("editor", "run_pipeline"): DashboardActionRoute("editor", "run_pipeline", "pipeline.run", "run_imgtrans", "Run full pipeline"),
+    ("editor", "selected_ocr"): DashboardActionRoute("editor", "selected_ocr", "ocr.rerun_selected", "on_open_ocr_crop_inspector_requested", "OCR selected blocks"),
+    ("editor", "layout_review"): DashboardActionRoute("editor", "layout_review", "qa.layout_review", "shortcutLayoutReviewSelected", "Review layout"),
+    ("editor", "export_proof"): DashboardActionRoute("editor", "export_proof", "export.proof_pack", "on_export_lettering_proof_pack", "Export proof pack"),
 
     ("live", "primary"): DashboardActionRoute("live", "primary", "live.open", "on_open_realtime_translator", "Start live region picker"),
     ("live", "pick_region"): DashboardActionRoute("live", "pick_region", "live.pick_region", "on_open_realtime_translator", "Select live region"),
@@ -31,18 +33,20 @@ DASHBOARD_ACTION_ROUTES: Dict[Tuple[str, str], DashboardActionRoute] = {
     ("live", "overlay"): DashboardActionRoute("live", "overlay", "live.overlay_settings", "on_open_realtime_translator", "Overlay settings"),
     ("live", "privacy"): DashboardActionRoute("live", "privacy", "live.privacy", "on_open_realtime_translator", "Live privacy controls"),
 
-    ("assist", "primary"): DashboardActionRoute("assist", "primary", "translation.assist", "on_open_translation_assist", "Open Translation Assist"),
-    ("assist", "compare"): DashboardActionRoute("assist", "compare", "translation.compare_providers", "on_open_translation_assist", "Compare providers"),
-    ("assist", "tm"): DashboardActionRoute("assist", "tm", "translation.memory", "on_open_translation_assist", "Translation memory"),
-    ("assist", "glossary"): DashboardActionRoute("assist", "glossary", "translation.glossary", "on_open_translation_assist", "Glossary violations"),
-    ("assist", "sfx"): DashboardActionRoute("assist", "sfx", "translation.sfx_dictionary", "on_open_translation_assist", "SFX dictionary"),
+    ("assist", "primary"): DashboardActionRoute("assist", "primary", "translation.assist", "on_open_translation_assist_dock", "Open Translation Assist"),
+    ("assist", "compare"): DashboardActionRoute("assist", "compare", "translation.compare_providers", "on_open_translation_assist_dock", "Compare providers"),
+    ("assist", "tm"): DashboardActionRoute("assist", "tm", "translation.memory", "on_open_translation_assist_dock", "Translation memory"),
+    ("assist", "glossary"): DashboardActionRoute("assist", "glossary", "translation.glossary", "on_open_translation_assist_dock", "Glossary violations"),
+    ("assist", "sfx"): DashboardActionRoute("assist", "sfx", "translation.sfx_dictionary", "on_open_translation_assist_dock", "SFX dictionary"),
 
     ("downloader", "primary"): DashboardActionRoute("downloader", "primary", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
     ("downloader", "search"): DashboardActionRoute("downloader", "search", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
     ("downloader", "queue"): DashboardActionRoute("downloader", "queue", "batch.queue", "on_open_batch_queue", "Chapter queue"),
-    ("downloader", "health"): DashboardActionRoute("downloader", "health", "diagnostics.source_health", "on_environment_doctor", "Source health", safe_to_wire=False),
-    ("downloader", "import"): DashboardActionRoute("downloader", "import", "file.open_folder", "openFolder", "Import to project"),
+    ("downloader", "health"): DashboardActionRoute("downloader", "health", "diagnostics.source_health", "on_environment_doctor", "Source health"),
+    ("downloader", "import"): DashboardActionRoute("downloader", "import", "file.open_folder", "_welcome_open_folder", "Import to project"),
 
+    ("quick_image", "primary"): DashboardActionRoute("quick_image", "primary", "file.open_images", "_welcome_open_folder", "Open images"),
+    ("batch", "primary"): DashboardActionRoute("batch", "primary", "batch.queue", "on_open_batch_queue", "Open batch queue"),
     ("models", "primary"): DashboardActionRoute("models", "primary", "models.manage", "on_open_manage_models", "Manage models"),
     ("settings", "primary"): DashboardActionRoute("settings", "primary", "settings.open", "setupConfigUI", "Open settings"),
     ("diagnostics", "primary"): DashboardActionRoute("diagnostics", "primary", "diagnostics.environment_doctor", "on_environment_doctor", "Environment doctor"),

--- a/ui/dashboard_action_router.py
+++ b/ui/dashboard_action_router.py
@@ -19,33 +19,27 @@ class DashboardActionRoute:
 
 
 DASHBOARD_ACTION_ROUTES: Dict[Tuple[str, str], DashboardActionRoute] = {
-    # Editor / project workflow.  These handler names intentionally match the
-    # existing MainWindow methods used by the legacy left bar and menus.
     ("editor", "primary"): DashboardActionRoute("editor", "primary", "file.open_folder", "_welcome_open_folder", "Open project/folder"),
     ("editor", "run_pipeline"): DashboardActionRoute("editor", "run_pipeline", "pipeline.run", "run_imgtrans", "Run full pipeline"),
     ("editor", "selected_ocr"): DashboardActionRoute("editor", "selected_ocr", "ocr.rerun_selected", "on_open_ocr_crop_inspector_requested", "OCR selected blocks"),
     ("editor", "layout_review"): DashboardActionRoute("editor", "layout_review", "qa.layout_review", "shortcutLayoutReviewSelected", "Review layout"),
     ("editor", "export_proof"): DashboardActionRoute("editor", "export_proof", "export.proof_pack", "on_export_lettering_proof_pack", "Export proof pack"),
-
     ("live", "primary"): DashboardActionRoute("live", "primary", "live.open", "on_open_realtime_translator", "Start live region picker"),
     ("live", "pick_region"): DashboardActionRoute("live", "pick_region", "live.pick_region", "on_open_realtime_translator", "Select live region"),
     ("live", "chrome_profile"): DashboardActionRoute("live", "chrome_profile", "live.chrome_profile", "on_open_realtime_translator", "Chrome Manhua preset"),
     ("live", "overlay"): DashboardActionRoute("live", "overlay", "live.overlay_settings", "on_open_realtime_translator", "Overlay settings"),
     ("live", "privacy"): DashboardActionRoute("live", "privacy", "live.privacy", "on_open_realtime_translator", "Live privacy controls"),
-
     ("assist", "primary"): DashboardActionRoute("assist", "primary", "translation.assist", "on_open_translation_assist_dock", "Open Translation Assist"),
     ("assist", "compare"): DashboardActionRoute("assist", "compare", "translation.compare_providers", "on_open_translation_assist_dock", "Compare providers"),
     ("assist", "tm"): DashboardActionRoute("assist", "tm", "translation.memory", "on_open_translation_assist_dock", "Translation memory"),
     ("assist", "glossary"): DashboardActionRoute("assist", "glossary", "translation.glossary", "on_open_translation_assist_dock", "Glossary violations"),
     ("assist", "sfx"): DashboardActionRoute("assist", "sfx", "translation.sfx_dictionary", "on_open_translation_assist_dock", "SFX dictionary"),
-
     ("downloader", "primary"): DashboardActionRoute("downloader", "primary", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
     ("downloader", "search"): DashboardActionRoute("downloader", "search", "tools.raw_downloader", "on_open_manga_source", "Search sources"),
     ("downloader", "queue"): DashboardActionRoute("downloader", "queue", "batch.queue", "on_open_batch_queue", "Chapter queue"),
     ("downloader", "health"): DashboardActionRoute("downloader", "health", "diagnostics.source_health", "on_environment_doctor", "Source health"),
     ("downloader", "import"): DashboardActionRoute("downloader", "import", "file.open_folder", "_welcome_open_folder", "Import to project"),
-
-    ("quick_image", "primary"): DashboardActionRoute("quick_image", "primary", "file.open_images", "_welcome_open_folder", "Open images"),
+    ("quick_image", "primary"): DashboardActionRoute("quick_image", "primary", "file.open_images", "leftBar.onOpenImages", "Open image files"),
     ("batch", "primary"): DashboardActionRoute("batch", "primary", "batch.queue", "on_open_batch_queue", "Open batch queue"),
     ("models", "primary"): DashboardActionRoute("models", "primary", "models.manage", "on_open_manage_models", "Manage models"),
     ("settings", "primary"): DashboardActionRoute("settings", "primary", "settings.open", "setupConfigUI", "Open settings"),

--- a/ui/dashboard_status_provider.py
+++ b/ui/dashboard_status_provider.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from .job_status_drawer import JobStatusSpec
+from .mode_dashboard import DashboardMetricSpec
+
+
+def _first_attr(obj, names: Sequence[str], default=None):
+    for name in names:
+        try:
+            value = getattr(obj, name, None)
+        except Exception:
+            value = None
+        if value is not None:
+            return value
+    return default
+
+
+def _safe_len(value) -> int | None:
+    if value is None:
+        return None
+    try:
+        return len(value)
+    except Exception:
+        return None
+
+
+def _call_or_value(value):
+    if callable(value):
+        try:
+            return value()
+        except Exception:
+            return None
+    return value
+
+
+def _project_page_count(mainwindow) -> int | None:
+    candidates = (
+        _first_attr(mainwindow, ("page_list", "pageList", "img_list", "imgList", "imgNameList", "pages")),
+        _first_attr(_first_attr(mainwindow, ("proj", "project", "imgtrans_proj", "image_project")), ("pages", "page_list", "img_list")),
+        _first_attr(_first_attr(mainwindow, ("imgtrans_proj", "project")), ("pages", "imgnames", "imgnames_list")),
+    )
+    for candidate in candidates:
+        candidate = _call_or_value(candidate)
+        length = _safe_len(candidate)
+        if length is not None:
+            return length
+    return None
+
+
+def _has_project(mainwindow) -> bool:
+    checker = getattr(mainwindow, "_has_open_project", None)
+    if callable(checker):
+        try:
+            return bool(checker())
+        except Exception:
+            pass
+    if _project_page_count(mainwindow):
+        return True
+    return bool(_first_attr(mainwindow, ("proj", "project", "imgtrans_proj", "proj_path", "project_path")))
+
+
+def _warning_count(mainwindow) -> int:
+    total = 0
+    for owner_name in ("pipelineInsightsPanel", "maskDiagnosticsWidget", "typographyQAReport", "layoutReviewPanel"):
+        owner = getattr(mainwindow, owner_name, None)
+        if owner is None:
+            continue
+        for attr in ("warnings", "warning_items", "issues", "items"):
+            value = _call_or_value(getattr(owner, attr, None))
+            length = _safe_len(value)
+            if length:
+                total += length
+                break
+    drawer = getattr(mainwindow, "jobStatusDrawer", None)
+    jobs = getattr(drawer, "_jobs", {}) if drawer is not None else {}
+    try:
+        total += sum(1 for job in jobs.values() if getattr(job, "warnings", None) or str(getattr(job, "status", "")).lower() in {"warning", "error", "failed"})
+    except Exception:
+        pass
+    return total
+
+
+def _job_summary(mainwindow) -> tuple[str, str, str]:
+    drawer = getattr(mainwindow, "jobStatusDrawer", None)
+    jobs: dict[str, JobStatusSpec] = getattr(drawer, "_jobs", {}) if drawer is not None else {}
+    if not jobs:
+        return "Idle", "idle", "No active jobs."
+    running = [job for job in jobs.values() if str(getattr(job, "status", "")).lower() in {"running", "capturing", "ocr", "translating", "exporting"}]
+    warning = [job for job in jobs.values() if getattr(job, "warnings", None) or str(getattr(job, "status", "")).lower() in {"warning", "error", "failed"}]
+    if warning:
+        return f"{len(warning)} need attention", "warning", f"{len(jobs)} total jobs."
+    if running:
+        return f"{len(running)} running", "running", f"{len(jobs)} total jobs."
+    return f"{len(jobs)} tracked", "success", "All tracked jobs are complete or idle."
+
+
+def _model_status(mainwindow) -> tuple[str, str, str]:
+    manager = _first_attr(mainwindow, ("module_manager", "model_manager", "modelManager"))
+    if manager is None:
+        return "Unknown", "warning", "Model/provider status not available yet."
+    missing = _first_attr(manager, ("missing_models", "missingModelList", "missing_modules"))
+    missing = _call_or_value(missing)
+    missing_count = _safe_len(missing)
+    if missing_count:
+        return f"{missing_count} missing", "warning", "Some optional models/providers may need setup."
+    busy = _first_attr(manager, ("is_busy", "busy", "running"))
+    busy = _call_or_value(busy)
+    if busy:
+        return "Busy", "running", "A model or provider task is currently running."
+    return "Ready", "success", "No missing model/provider status reported."
+
+
+def _source_status(mainwindow) -> tuple[str, str, str]:
+    sources = _first_attr(mainwindow, ("manga_sources", "source_registry", "raw_sources", "mangaSourceList"))
+    sources = _call_or_value(sources)
+    count = _safe_len(sources)
+    if count is not None:
+        return str(count), "success" if count else "warning", "Registered raw/downloader sources."
+    return "Configured", "idle", "Open the downloader to inspect source health."
+
+
+def _translation_assist_status(mainwindow) -> tuple[str, str, str]:
+    dock = _first_attr(mainwindow, ("translationAssistDock", "translation_assist_dock"))
+    if dock is None:
+        return "Available", "idle", "Open Assist to inspect candidates, TM, and glossary."
+    visible = _call_or_value(getattr(dock, "isVisible", None))
+    return ("Open" if visible else "Available", "success" if visible else "idle", "Translation Assist dock status.")
+
+
+def metrics_for_mode(mainwindow, mode: str) -> list[DashboardMetricSpec]:
+    mode = str(mode or "")
+    project_open = _has_project(mainwindow)
+    pages = _project_page_count(mainwindow)
+    warnings = _warning_count(mainwindow)
+    job_value, job_status, job_desc = _job_summary(mainwindow)
+    model_value, model_status, model_desc = _model_status(mainwindow)
+
+    if mode in {"editor", "quick_image"}:
+        return [
+            DashboardMetricSpec("pages", "Pages", str(pages) if pages is not None else ("Loaded" if project_open else "No project"), "success" if project_open else "idle", "Current project/page count."),
+            DashboardMetricSpec("warnings", "Warnings", str(warnings), "warning" if warnings else "success", "Typography, mask, job, and export warnings."),
+            DashboardMetricSpec("models", "Models", model_value, model_status, model_desc),
+        ]
+    if mode == "live":
+        return [
+            DashboardMetricSpec("capture", "Capture", job_value if job_value != "Idle" else "Idle", job_status, job_desc),
+            DashboardMetricSpec("ocr", "OCR", model_value, model_status, model_desc),
+            DashboardMetricSpec("latency", "Latency", "-- ms", "idle", "Realtime latency is shown after live mode starts."),
+        ]
+    if mode == "assist":
+        assist_value, assist_status, assist_desc = _translation_assist_status(mainwindow)
+        return [
+            DashboardMetricSpec("candidates", "Candidates", assist_value, assist_status, assist_desc),
+            DashboardMetricSpec("glossary", "Glossary", "Project", "idle", "Open Assist to load series glossary and TM."),
+            DashboardMetricSpec("qa", "QA", str(warnings), "warning" if warnings else "success", "Project/block QA warning count."),
+        ]
+    if mode == "downloader":
+        source_value, source_status, source_desc = _source_status(mainwindow)
+        return [
+            DashboardMetricSpec("sources", "Sources", source_value, source_status, source_desc),
+            DashboardMetricSpec("queue", "Queue", job_value, job_status, job_desc),
+            DashboardMetricSpec("rate", "Rate limits", "Safe", "success", "Downloader pacing status is conservative by default."),
+        ]
+    if mode in {"batch", "models", "diagnostics"}:
+        return [
+            DashboardMetricSpec("jobs", "Jobs", job_value, job_status, job_desc),
+            DashboardMetricSpec("warnings", "Warnings", str(warnings), "warning" if warnings else "success", "Current warning count."),
+            DashboardMetricSpec("models", "Models", model_value, model_status, model_desc),
+        ]
+    return []
+
+
+def apply_dashboard_metrics(mainwindow, dashboard) -> bool:
+    mode = getattr(getattr(dashboard, "spec", None), "key", "")
+    metrics = metrics_for_mode(mainwindow, mode)
+    if not metrics or not hasattr(dashboard, "update_metrics"):
+        return False
+    dashboard.update_metrics(metrics)
+    return True
+
+
+def refresh_default_dashboard_metrics(mainwindow) -> int:
+    indexes = getattr(mainwindow, "_modern_dashboard_indexes", None) or {}
+    central_stack = getattr(mainwindow, "centralStackWidget", None)
+    if central_stack is None or not hasattr(central_stack, "widget"):
+        return 0
+    count = 0
+    for _mode, index in indexes.items():
+        try:
+            dashboard = central_stack.widget(index)
+        except Exception:
+            dashboard = None
+        if dashboard is not None and apply_dashboard_metrics(mainwindow, dashboard):
+            count += 1
+    return count

--- a/ui/dashboard_status_provider.py
+++ b/ui/dashboard_status_provider.py
@@ -49,6 +49,51 @@ def _project_page_count(mainwindow) -> int | None:
     return None
 
 
+def _project_pages_mapping(mainwindow):
+    project = _first_attr(mainwindow, ("imgtrans_proj", "project", "proj", "image_project"))
+    pages = _call_or_value(_first_attr(project, ("pages", "page_map", "page_blocks")))
+    return pages if isinstance(pages, dict) else None
+
+
+def _block_has_translation(block) -> bool:
+    for attr in ("translation", "rich_text", "translated_text", "target_text"):
+        try:
+            value = getattr(block, attr, None)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value.strip():
+            return True
+    return False
+
+
+def _project_translation_stats(mainwindow) -> tuple[int | None, int | None, int | None]:
+    """Return (translated_pages, total_pages, text_blocks) when project block data is available."""
+    pages = _project_pages_mapping(mainwindow)
+    if not pages:
+        total = _project_page_count(mainwindow)
+        return None, total, None
+    translated_pages = 0
+    text_blocks = 0
+    total_pages = len(pages)
+    for blocks in pages.values():
+        try:
+            block_list = list(blocks or [])
+        except Exception:
+            block_list = []
+        text_blocks += len(block_list)
+        if block_list and all(_block_has_translation(block) for block in block_list):
+            translated_pages += 1
+    return translated_pages, total_pages, text_blocks
+
+
+def _selected_text_count(mainwindow) -> int | None:
+    canvas = _first_attr(mainwindow, ("canvas", "sceneCanvas"))
+    if canvas is None:
+        return None
+    selected = _call_or_value(getattr(canvas, "selected_text_items", None))
+    return _safe_len(selected)
+
+
 def _has_project(mainwindow) -> bool:
     checker = getattr(mainwindow, "_has_open_project", None)
     if callable(checker):
@@ -129,17 +174,35 @@ def _translation_assist_status(mainwindow) -> tuple[str, str, str]:
     return ("Open" if visible else "Available", "success" if visible else "idle", "Translation Assist dock status.")
 
 
+def _project_progress_metric(mainwindow, project_open: bool) -> DashboardMetricSpec:
+    translated_pages, total_pages, text_blocks = _project_translation_stats(mainwindow)
+    if total_pages is None:
+        return DashboardMetricSpec("pages", "Pages", "Loaded" if project_open else "No project", "success" if project_open else "idle", "Current project/page count.")
+    if translated_pages is None:
+        return DashboardMetricSpec("pages", "Pages", str(total_pages), "success" if project_open else "idle", "Current project/page count.")
+    status = "success" if total_pages > 0 and translated_pages == total_pages else "running" if translated_pages else "idle"
+    block_note = f" · {text_blocks} text blocks" if text_blocks is not None else ""
+    return DashboardMetricSpec("pages", "Pages", f"{translated_pages}/{total_pages}", status, f"Translated pages / total pages{block_note}.")
+
+
+def _selected_metric(mainwindow) -> DashboardMetricSpec:
+    selected = _selected_text_count(mainwindow)
+    if selected is None:
+        return DashboardMetricSpec("selected", "Selected", "--", "idle", "Select text boxes to inspect or run targeted actions.")
+    return DashboardMetricSpec("selected", "Selected", str(selected), "success" if selected else "idle", "Currently selected text boxes.")
+
+
 def metrics_for_mode(mainwindow, mode: str) -> list[DashboardMetricSpec]:
     mode = str(mode or "")
     project_open = _has_project(mainwindow)
-    pages = _project_page_count(mainwindow)
     warnings = _warning_count(mainwindow)
     job_value, job_status, job_desc = _job_summary(mainwindow)
     model_value, model_status, model_desc = _model_status(mainwindow)
 
     if mode in {"editor", "quick_image"}:
         return [
-            DashboardMetricSpec("pages", "Pages", str(pages) if pages is not None else ("Loaded" if project_open else "No project"), "success" if project_open else "idle", "Current project/page count."),
+            _project_progress_metric(mainwindow, project_open),
+            _selected_metric(mainwindow),
             DashboardMetricSpec("warnings", "Warnings", str(warnings), "warning" if warnings else "success", "Typography, mask, job, and export warnings."),
             DashboardMetricSpec("models", "Models", model_value, model_status, model_desc),
         ]
@@ -166,6 +229,7 @@ def metrics_for_mode(mainwindow, mode: str) -> list[DashboardMetricSpec]:
     if mode in {"batch", "models", "diagnostics"}:
         return [
             DashboardMetricSpec("jobs", "Jobs", job_value, job_status, job_desc),
+            _project_progress_metric(mainwindow, project_open),
             DashboardMetricSpec("warnings", "Warnings", str(warnings), "warning" if warnings else "success", "Current warning count."),
             DashboardMetricSpec("models", "Models", model_value, model_status, model_desc),
         ]

--- a/ui/default_mode_dashboards.py
+++ b/ui/default_mode_dashboards.py
@@ -6,6 +6,7 @@ from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QWidget
 
 from .dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
+from .dashboard_status_provider import apply_dashboard_metrics, refresh_default_dashboard_metrics
 from .mode_dashboard import ModeDashboard, dashboard_for_mode
 
 DEFAULT_DASHBOARD_MODES: tuple[tuple[str, str, str], ...] = (
@@ -55,6 +56,7 @@ def dispatch_default_dashboard_action(mainwindow: QWidget, mode: str, action: st
     """Dispatch a ModeDashboard action through the existing action/router layer."""
     result = dispatch_dashboard_action(mainwindow, mode, action)
     _log_dashboard_dispatch(mainwindow, result.handled, dispatch_message_for_result(result))
+    refresh_default_dashboard_metrics(mainwindow)
     return result
 
 
@@ -62,12 +64,14 @@ def _legacy_route_for_mode(mainwindow: QWidget, mode: str) -> bool:
     """Fallback to existing handlers if dashboard pages are not installed."""
     if mode == "home" and hasattr(mainwindow, "_show_welcome_screen"):
         mainwindow._show_welcome_screen()
+        refresh_default_dashboard_metrics(mainwindow)
         return True
     if mode == "editor":
         if hasattr(mainwindow, "_has_open_project") and mainwindow._has_open_project() and hasattr(mainwindow, "setupImgTransUI"):
             mainwindow.setupImgTransUI()
         elif hasattr(mainwindow, "_show_welcome_screen"):
             mainwindow._show_welcome_screen()
+        refresh_default_dashboard_metrics(mainwindow)
         return True
     handler_map = {
         "live": "on_open_realtime_translator",
@@ -82,11 +86,13 @@ def _legacy_route_for_mode(mainwindow: QWidget, mode: str) -> bool:
         mainwindow.leftBar.onOpenImages()
         _set_mode_rail(mainwindow, "quick_image")
         _set_workflow_hint(mainwindow, "quick_image")
+        refresh_default_dashboard_metrics(mainwindow)
         return True
     handler_name = handler_map.get(mode)
     handler = getattr(mainwindow, handler_name, None) if handler_name else None
     if callable(handler):
         handler()
+        refresh_default_dashboard_metrics(mainwindow)
         return True
     return False
 
@@ -101,6 +107,7 @@ def route_default_dashboard_mode(mainwindow: QWidget, mode: str) -> bool:
     if mode in DASHBOARD_MODE_KEYS and show_default_mode_dashboard(mainwindow, mode):
         _set_mode_rail(mainwindow, mode)
         _set_workflow_hint(mainwindow, mode)
+        refresh_default_dashboard_metrics(mainwindow)
         return True
     return _legacy_route_for_mode(mainwindow, mode)
 
@@ -132,7 +139,7 @@ def install_default_mode_dashboards(
     """Install mode dashboard landing pages into MainWindow.centralStackWidget.
 
     This is intentionally additive: it appends dashboard pages after the existing
-    welcome/editor/settings pages and records their indexes.  Existing handlers
+    welcome/editor/settings pages and records their indexes. Existing handlers
     remain one click away through dashboard action buttons.
     """
     if mainwindow is None:
@@ -150,8 +157,11 @@ def install_default_mode_dashboards(
             page = ModeDashboard(spec, central_stack)
             page.setObjectName(f"DefaultModeDashboard_{key}")
             page.action_requested.connect(lambda mode, action: dispatch_default_dashboard_action(mainwindow, mode, action))
+            apply_dashboard_metrics(mainwindow, page)
             indexes[key] = central_stack.addWidget(page)
         mainwindow._modern_dashboard_indexes = indexes
+    else:
+        refresh_default_dashboard_metrics(mainwindow)
     _install_dashboard_rail_router(mainwindow)
     return True
 
@@ -166,6 +176,9 @@ def show_default_mode_dashboard(mainwindow: QWidget, mode: str) -> bool:
     if central_stack is None or not hasattr(central_stack, "setCurrentIndex"):
         return False
     try:
+        dashboard = central_stack.widget(idx) if hasattr(central_stack, "widget") else None
+        if dashboard is not None:
+            apply_dashboard_metrics(mainwindow, dashboard)
         central_stack.setCurrentIndex(idx)
         return True
     except Exception:

--- a/ui/default_mode_dashboards.py
+++ b/ui/default_mode_dashboards.py
@@ -8,6 +8,7 @@ from qtpy.QtWidgets import QWidget
 from .dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
 from .dashboard_status_provider import apply_dashboard_metrics, refresh_default_dashboard_metrics
 from .mode_dashboard import ModeDashboard, dashboard_for_mode
+from .task_job_bridge import mirror_dashboard_task_job
 
 DEFAULT_DASHBOARD_MODES: tuple[tuple[str, str, str], ...] = (
     ("live", "Live Translation", "Realtime screen or Chrome manhua translation."),
@@ -53,9 +54,10 @@ def _set_workflow_hint(mainwindow: QWidget, mode: str):
 
 
 def dispatch_default_dashboard_action(mainwindow: QWidget, mode: str, action: str):
-    """Dispatch a ModeDashboard action through the existing action/router layer."""
+    """Dispatch a ModeDashboard action and mirror task-like actions into the drawer."""
     result = dispatch_dashboard_action(mainwindow, mode, action)
     _log_dashboard_dispatch(mainwindow, result.handled, dispatch_message_for_result(result))
+    mirror_dashboard_task_job(mainwindow, mode, action, handled=result.handled)
     refresh_default_dashboard_metrics(mainwindow)
     return result
 

--- a/ui/default_mode_dashboards.py
+++ b/ui/default_mode_dashboards.py
@@ -17,6 +17,7 @@ DEFAULT_DASHBOARD_MODES: tuple[tuple[str, str, str], ...] = (
     ("models", "Models & Providers", "Install models, test providers, and inspect runtime health."),
     ("diagnostics", "Diagnostics / Help", "Logs, doctors, reports, documentation, and support."),
 )
+DASHBOARD_MODE_KEYS = frozenset(key for key, _title, _description in DEFAULT_DASHBOARD_MODES)
 
 
 def _log_dashboard_dispatch(mainwindow: QWidget, handled: bool, message: str):
@@ -32,11 +33,94 @@ def _log_dashboard_dispatch(mainwindow: QWidget, handled: bool, message: str):
         pass
 
 
+def _set_mode_rail(mainwindow: QWidget, mode: str):
+    rail = getattr(mainwindow, "modeRail", None)
+    if rail is not None and hasattr(rail, "set_current_mode"):
+        try:
+            rail.set_current_mode(str(mode or ""))
+        except Exception:
+            pass
+
+
+def _set_workflow_hint(mainwindow: QWidget, mode: str):
+    try:
+        title_bar = getattr(mainwindow, "titleBar", None)
+        if title_bar is not None and hasattr(title_bar, "set_workflow_hint"):
+            title_bar.set_workflow_hint(str(mode or ""))
+    except Exception:
+        pass
+
+
 def dispatch_default_dashboard_action(mainwindow: QWidget, mode: str, action: str):
     """Dispatch a ModeDashboard action through the existing action/router layer."""
     result = dispatch_dashboard_action(mainwindow, mode, action)
     _log_dashboard_dispatch(mainwindow, result.handled, dispatch_message_for_result(result))
     return result
+
+
+def _legacy_route_for_mode(mainwindow: QWidget, mode: str) -> bool:
+    """Fallback to existing handlers if dashboard pages are not installed."""
+    if mode == "home" and hasattr(mainwindow, "_show_welcome_screen"):
+        mainwindow._show_welcome_screen()
+        return True
+    if mode == "editor":
+        if hasattr(mainwindow, "_has_open_project") and mainwindow._has_open_project() and hasattr(mainwindow, "setupImgTransUI"):
+            mainwindow.setupImgTransUI()
+        elif hasattr(mainwindow, "_show_welcome_screen"):
+            mainwindow._show_welcome_screen()
+        return True
+    handler_map = {
+        "live": "on_open_realtime_translator",
+        "downloader": "on_open_manga_source",
+        "batch": "on_open_batch_queue",
+        "assist": "on_open_translation_assist_dock",
+        "models": "on_open_manage_models",
+        "settings": "setupConfigUI",
+        "diagnostics": "on_environment_doctor",
+    }
+    if mode == "quick_image" and hasattr(mainwindow, "leftBar") and hasattr(mainwindow.leftBar, "onOpenImages"):
+        mainwindow.leftBar.onOpenImages()
+        _set_mode_rail(mainwindow, "quick_image")
+        _set_workflow_hint(mainwindow, "quick_image")
+        return True
+    handler_name = handler_map.get(mode)
+    handler = getattr(mainwindow, handler_name, None) if handler_name else None
+    if callable(handler):
+        handler()
+        return True
+    return False
+
+
+def route_default_dashboard_mode(mainwindow: QWidget, mode: str) -> bool:
+    """Route ModeRail requests to dashboard landing pages when available."""
+    mode = str(mode or "").strip().lower()
+    if not mainwindow:
+        return False
+    if mode == "home" or mode == "editor" or mode == "settings":
+        return _legacy_route_for_mode(mainwindow, mode)
+    if mode in DASHBOARD_MODE_KEYS and show_default_mode_dashboard(mainwindow, mode):
+        _set_mode_rail(mainwindow, mode)
+        _set_workflow_hint(mainwindow, mode)
+        return True
+    return _legacy_route_for_mode(mainwindow, mode)
+
+
+def _install_dashboard_rail_router(mainwindow: QWidget) -> bool:
+    rail = getattr(mainwindow, "modeRail", None)
+    if rail is None or not hasattr(rail, "mode_requested"):
+        return False
+    if getattr(mainwindow, "_modern_dashboard_rail_router_installed", False):
+        return True
+    try:
+        rail.mode_requested.disconnect()
+    except Exception:
+        pass
+    try:
+        rail.mode_requested.connect(lambda mode: route_default_dashboard_mode(mainwindow, mode))
+        mainwindow._modern_dashboard_rail_router_installed = True
+        return True
+    except Exception:
+        return False
 
 
 def install_default_mode_dashboards(
@@ -53,22 +137,22 @@ def install_default_mode_dashboards(
     """
     if mainwindow is None:
         return False
-    if getattr(mainwindow, "_modern_dashboard_indexes", None) is not None:
-        return True
     central_stack = getattr(mainwindow, "centralStackWidget", None)
     if central_stack is None or not hasattr(central_stack, "addWidget"):
         if retry:
             QTimer.singleShot(0, lambda: install_default_mode_dashboards(mainwindow, retry=False))
         return False
 
-    indexes: dict[str, int] = {}
-    for key, title, description in modes:
-        spec = dashboard_for_mode(key, title, description)
-        page = ModeDashboard(spec, central_stack)
-        page.setObjectName(f"DefaultModeDashboard_{key}")
-        page.action_requested.connect(lambda mode, action: dispatch_default_dashboard_action(mainwindow, mode, action))
-        indexes[key] = central_stack.addWidget(page)
-    mainwindow._modern_dashboard_indexes = indexes
+    if getattr(mainwindow, "_modern_dashboard_indexes", None) is None:
+        indexes: dict[str, int] = {}
+        for key, title, description in modes:
+            spec = dashboard_for_mode(key, title, description)
+            page = ModeDashboard(spec, central_stack)
+            page.setObjectName(f"DefaultModeDashboard_{key}")
+            page.action_requested.connect(lambda mode, action: dispatch_default_dashboard_action(mainwindow, mode, action))
+            indexes[key] = central_stack.addWidget(page)
+        mainwindow._modern_dashboard_indexes = indexes
+    _install_dashboard_rail_router(mainwindow)
     return True
 
 

--- a/ui/default_mode_dashboards.py
+++ b/ui/default_mode_dashboards.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QWidget
+
+from .dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
+from .mode_dashboard import ModeDashboard, dashboard_for_mode
+
+DEFAULT_DASHBOARD_MODES: tuple[tuple[str, str, str], ...] = (
+    ("live", "Live Translation", "Realtime screen or Chrome manhua translation."),
+    ("quick_image", "Image Quick Translation", "Drop images, translate quickly, and optionally promote to a project."),
+    ("downloader", "Raw Downloader", "Search sources, choose chapters, and import raws."),
+    ("batch", "Batch Queue", "Process many chapters, folders, or archives."),
+    ("assist", "Translation Assist / QA", "Provider comparison, TM, glossary, concordance, SFX, and QA."),
+    ("models", "Models & Providers", "Install models, test providers, and inspect runtime health."),
+    ("diagnostics", "Diagnostics / Help", "Logs, doctors, reports, documentation, and support."),
+)
+
+
+def _log_dashboard_dispatch(mainwindow: QWidget, handled: bool, message: str):
+    panel = getattr(mainwindow, "pipelineInsightsPanel", None)
+    if panel is None:
+        return
+    try:
+        if handled and hasattr(panel, "add_event"):
+            panel.add_event("DASHBOARD", message)
+        elif not handled and hasattr(panel, "add_warning"):
+            panel.add_warning("DASHBOARD", message)
+    except Exception:
+        pass
+
+
+def dispatch_default_dashboard_action(mainwindow: QWidget, mode: str, action: str):
+    """Dispatch a ModeDashboard action through the existing action/router layer."""
+    result = dispatch_dashboard_action(mainwindow, mode, action)
+    _log_dashboard_dispatch(mainwindow, result.handled, dispatch_message_for_result(result))
+    return result
+
+
+def install_default_mode_dashboards(
+    mainwindow: QWidget,
+    *,
+    modes: Iterable[tuple[str, str, str]] = DEFAULT_DASHBOARD_MODES,
+    retry: bool = True,
+) -> bool:
+    """Install mode dashboard landing pages into MainWindow.centralStackWidget.
+
+    This is intentionally additive: it appends dashboard pages after the existing
+    welcome/editor/settings pages and records their indexes.  Existing handlers
+    remain one click away through dashboard action buttons.
+    """
+    if mainwindow is None:
+        return False
+    if getattr(mainwindow, "_modern_dashboard_indexes", None) is not None:
+        return True
+    central_stack = getattr(mainwindow, "centralStackWidget", None)
+    if central_stack is None or not hasattr(central_stack, "addWidget"):
+        if retry:
+            QTimer.singleShot(0, lambda: install_default_mode_dashboards(mainwindow, retry=False))
+        return False
+
+    indexes: dict[str, int] = {}
+    for key, title, description in modes:
+        spec = dashboard_for_mode(key, title, description)
+        page = ModeDashboard(spec, central_stack)
+        page.setObjectName(f"DefaultModeDashboard_{key}")
+        page.action_requested.connect(lambda mode, action: dispatch_default_dashboard_action(mainwindow, mode, action))
+        indexes[key] = central_stack.addWidget(page)
+    mainwindow._modern_dashboard_indexes = indexes
+    return True
+
+
+def show_default_mode_dashboard(mainwindow: QWidget, mode: str) -> bool:
+    """Show an installed dashboard page for a workflow mode."""
+    indexes = getattr(mainwindow, "_modern_dashboard_indexes", None) or {}
+    idx = indexes.get(str(mode or ""))
+    if idx is None:
+        return False
+    central_stack = getattr(mainwindow, "centralStackWidget", None)
+    if central_stack is None or not hasattr(central_stack, "setCurrentIndex"):
+        return False
+    try:
+        central_stack.setCurrentIndex(idx)
+        return True
+    except Exception:
+        return False

--- a/ui/default_modern_shell.py
+++ b/ui/default_modern_shell.py
@@ -9,6 +9,8 @@ from qtpy.QtWidgets import QHBoxLayout, QWidget
 from .job_status_drawer import JobStatusDrawer, JobStatusSpec
 from .mode_rail import ModeRail
 
+PIPELINE_JOB_ID = "pipeline-current"
+
 
 def _find_layout_containing_widget(root_layout, widget: QWidget) -> Optional[QHBoxLayout]:
     """Find the first nested layout that directly contains widget."""
@@ -145,6 +147,82 @@ def _record_job_drawer_event(mainwindow: QWidget, event_type: str, job_id: str):
             pass
 
 
+def upsert_default_job(mainwindow: QWidget, job: JobStatusSpec) -> bool:
+    """Add/update a job in the default drawer when installed."""
+    drawer = getattr(mainwindow, "jobStatusDrawer", None)
+    if drawer is None:
+        return False
+    try:
+        drawer.upsert_job(job)
+        return True
+    except Exception:
+        return False
+
+
+def _install_job_event_wrappers(mainwindow: QWidget):
+    """Mirror legacy pipeline events into JobStatusDrawer without changing pipeline logic."""
+    if mainwindow is None or getattr(mainwindow, "_modern_job_event_wrappers_installed", False):
+        return
+
+    stage_original = getattr(mainwindow, "on_pipeline_stage_event", None)
+    if callable(stage_original):
+        def stage_wrapped(self, stage_name: str, progress: int, page_name: str, __original=stage_original):
+            result = __original(stage_name, progress, page_name)
+            try:
+                stage = str(stage_name or "Pipeline")
+                page = str(page_name or "")
+                detail = f"{stage} · {page}" if page else stage
+                upsert_default_job(
+                    self,
+                    JobStatusSpec(
+                        job_id=PIPELINE_JOB_ID,
+                        title="Pipeline",
+                        kind="pipeline",
+                        status="running",
+                        progress=max(0, min(100, int(progress or 0))),
+                        detail=detail,
+                        can_cancel=True,
+                        can_pause=False,
+                    ),
+                )
+            except Exception:
+                pass
+            return result
+
+        try:
+            setattr(mainwindow, "on_pipeline_stage_event", MethodType(stage_wrapped, mainwindow))
+        except Exception:
+            pass
+
+    finish_original = getattr(mainwindow, "on_imgtrans_pipeline_finished", None)
+    if callable(finish_original):
+        def finish_wrapped(self, *args, __original=finish_original, **kwargs):
+            result = __original(*args, **kwargs)
+            try:
+                upsert_default_job(
+                    self,
+                    JobStatusSpec(
+                        job_id=PIPELINE_JOB_ID,
+                        title="Pipeline",
+                        kind="pipeline",
+                        status="succeeded",
+                        progress=100,
+                        detail="Pipeline finished",
+                        can_cancel=False,
+                    ),
+                )
+            except Exception:
+                pass
+            return result
+
+        try:
+            setattr(mainwindow, "on_imgtrans_pipeline_finished", MethodType(finish_wrapped, mainwindow))
+        except Exception:
+            pass
+
+    mainwindow._modern_job_event_wrappers_installed = True
+
+
 def install_default_job_drawer(mainwindow: QWidget, *, retry: bool = True) -> bool:
     """Install the collapsed bottom Jobs & Status drawer into the default layout.
 
@@ -155,6 +233,7 @@ def install_default_job_drawer(mainwindow: QWidget, *, retry: bool = True) -> bo
     if mainwindow is None:
         return False
     if getattr(mainwindow, "jobStatusDrawer", None) is not None:
+        _install_job_event_wrappers(mainwindow)
         return True
     root_layout = getattr(mainwindow, "mainvlayout", None)
     if root_layout is None:
@@ -183,19 +262,8 @@ def install_default_job_drawer(mainwindow: QWidget, *, retry: bool = True) -> bo
             insert_at = 0
     root_layout.insertWidget(insert_at, drawer)
     mainwindow.jobStatusDrawer = drawer
+    _install_job_event_wrappers(mainwindow)
     return True
-
-
-def upsert_default_job(mainwindow: QWidget, job: JobStatusSpec) -> bool:
-    """Add/update a job in the default drawer when installed."""
-    drawer = getattr(mainwindow, "jobStatusDrawer", None)
-    if drawer is None:
-        return False
-    try:
-        drawer.upsert_job(job)
-        return True
-    except Exception:
-        return False
 
 
 def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True) -> bool:

--- a/ui/default_modern_shell.py
+++ b/ui/default_modern_shell.py
@@ -6,6 +6,7 @@ from typing import Optional
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QHBoxLayout, QWidget
 
+from .editor_inspector import EditorInspector
 from .job_status_drawer import JobStatusDrawer, JobStatusSpec
 from .mode_rail import ModeRail
 
@@ -36,6 +37,16 @@ def _find_layout_containing_widget(root_layout, widget: QWidget) -> Optional[QHB
         if found is not None:
             return found
     return None
+
+
+def _connect_if_present(signal, handler) -> bool:
+    if signal is None or not callable(handler):
+        return False
+    try:
+        signal.connect(handler)
+        return True
+    except Exception:
+        return False
 
 
 def route_modern_mode_request(mainwindow: QWidget, mode: str):
@@ -266,6 +277,47 @@ def install_default_job_drawer(mainwindow: QWidget, *, retry: bool = True) -> bo
     return True
 
 
+def _first_existing_handler(mainwindow: QWidget, *names: str):
+    for name in names:
+        handler = getattr(mainwindow, name, None)
+        if callable(handler):
+            return handler
+    return None
+
+
+def install_default_editor_inspector(mainwindow: QWidget, *, retry: bool = True) -> bool:
+    """Install the modern EditorInspector into the existing right-side editor stack.
+
+    The inspector is added alongside legacy `DrawingPanel`/`TextPanel`/QA panels,
+    not as a replacement yet.  Its action buttons call existing handlers so the
+    new shell advances without duplicating editor logic.
+    """
+    if mainwindow is None:
+        return False
+    if getattr(mainwindow, "editorInspector", None) is not None:
+        return True
+    stack = getattr(mainwindow, "rightComicTransStackPanel", None)
+    if stack is None or not hasattr(stack, "addWidget"):
+        if retry:
+            QTimer.singleShot(0, lambda: install_default_editor_inspector(mainwindow, retry=False))
+        return False
+    inspector = EditorInspector(parent=mainwindow)
+    inspector.setObjectName("DefaultEditorInspector")
+    _connect_if_present(inspector.request_translation_assist, getattr(mainwindow, "on_open_translation_assist_dock", None))
+    _connect_if_present(
+        inspector.request_ocr_rerun,
+        _first_existing_handler(mainwindow, "on_open_ocr_crop_inspector_requested", "on_open_ocr_triage_current_page"),
+    )
+    _connect_if_present(
+        inspector.request_layout_review,
+        _first_existing_handler(mainwindow, "on_run_layout_review_requested", "shortcutLayoutReviewSelected", "shortcutLayoutReviewPage"),
+    )
+    _connect_if_present(inspector.request_typography_qa, getattr(mainwindow, "on_open_typography_qa_report", None))
+    stack.addWidget(inspector)
+    mainwindow.editorInspector = inspector
+    return True
+
+
 def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True) -> bool:
     """Install ModeRail into the existing default MainWindow layout.
 
@@ -278,6 +330,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
     if getattr(mainwindow, "modeRail", None) is not None:
         _install_mode_sync_wrappers(mainwindow)
         install_default_job_drawer(mainwindow, retry=retry)
+        install_default_editor_inspector(mainwindow, retry=retry)
         return True
     left_bar = getattr(mainwindow, "leftBar", None)
     root_layout = getattr(mainwindow, "mainvlayout", None)
@@ -286,6 +339,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
         if retry:
             QTimer.singleShot(0, lambda: install_default_modern_navigation(mainwindow, retry=False))
             QTimer.singleShot(0, lambda: install_default_job_drawer(mainwindow, retry=False))
+            QTimer.singleShot(0, lambda: install_default_editor_inspector(mainwindow, retry=False))
         return False
     rail = ModeRail(parent=mainwindow)
     rail.mode_requested.connect(lambda mode: route_modern_mode_request(mainwindow, mode))
@@ -297,6 +351,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
     mainwindow.modeRail = rail
     _install_mode_sync_wrappers(mainwindow)
     install_default_job_drawer(mainwindow, retry=retry)
+    install_default_editor_inspector(mainwindow, retry=retry)
     set_modern_mode(mainwindow, "home")
     return True
 
@@ -314,11 +369,7 @@ def install_default_welcome_signal_fallbacks(welcome_widget: QWidget, mainwindow
     for signal_name, handler_name in pairs:
         signal = getattr(welcome_widget, signal_name, None)
         handler = getattr(mainwindow, handler_name, None)
-        if signal is not None and callable(handler):
-            try:
-                signal.connect(handler)
-                connected = True
-            except Exception:
-                pass
+        if _connect_if_present(signal, handler):
+            connected = True
     welcome_widget._modern_shell_fallbacks_installed = True
     return connected

--- a/ui/default_modern_shell.py
+++ b/ui/default_modern_shell.py
@@ -6,6 +6,7 @@ from typing import Optional
 from qtpy.QtCore import QTimer
 from qtpy.QtWidgets import QHBoxLayout, QWidget
 
+from .job_status_drawer import JobStatusDrawer, JobStatusSpec
 from .mode_rail import ModeRail
 
 
@@ -123,6 +124,80 @@ def _install_mode_sync_wrappers(mainwindow: QWidget):
     mainwindow._modern_mode_sync_wrappers_installed = True
 
 
+def _record_job_drawer_event(mainwindow: QWidget, event_type: str, job_id: str):
+    """Best-effort bridge from the new drawer buttons to existing status surfaces."""
+    label = f"{event_type}: {job_id}"
+    panel = getattr(mainwindow, "pipelineInsightsPanel", None)
+    if panel is not None:
+        try:
+            if event_type == "cancel" and hasattr(panel, "add_warning"):
+                panel.add_warning("JOB", label)
+            elif hasattr(panel, "add_event"):
+                panel.add_event("JOB", label)
+        except Exception:
+            pass
+    if event_type == "cancel":
+        try:
+            module_manager = getattr(mainwindow, "module_manager", None)
+            if module_manager is not None and hasattr(module_manager, "stopImgtransPipeline"):
+                module_manager.stopImgtransPipeline()
+        except Exception:
+            pass
+
+
+def install_default_job_drawer(mainwindow: QWidget, *, retry: bool = True) -> bool:
+    """Install the collapsed bottom Jobs & Status drawer into the default layout.
+
+    The drawer starts collapsed and does not replace existing progress dialogs.
+    It gives the modern shell a persistent status surface while later PRs wire
+    concrete OCR/translation/inpaint/export/download jobs into it.
+    """
+    if mainwindow is None:
+        return False
+    if getattr(mainwindow, "jobStatusDrawer", None) is not None:
+        return True
+    root_layout = getattr(mainwindow, "mainvlayout", None)
+    if root_layout is None:
+        if retry:
+            QTimer.singleShot(0, lambda: install_default_job_drawer(mainwindow, retry=False))
+        return False
+    drawer = JobStatusDrawer(parent=mainwindow)
+    drawer.setObjectName("DefaultJobStatusDrawer")
+    drawer.set_expanded(False)
+    drawer.cancel_requested.connect(lambda job_id: _record_job_drawer_event(mainwindow, "cancel", job_id))
+    drawer.pause_requested.connect(lambda job_id: _record_job_drawer_event(mainwindow, "pause", job_id))
+    drawer.details_requested.connect(lambda job_id: _record_job_drawer_event(mainwindow, "details", job_id))
+    insert_at = None
+    bottom_bar = getattr(mainwindow, "bottomBar", None)
+    if bottom_bar is not None:
+        try:
+            idx = root_layout.indexOf(bottom_bar)
+            if idx >= 0:
+                insert_at = idx
+        except Exception:
+            insert_at = None
+    if insert_at is None:
+        try:
+            insert_at = max(0, root_layout.count())
+        except Exception:
+            insert_at = 0
+    root_layout.insertWidget(insert_at, drawer)
+    mainwindow.jobStatusDrawer = drawer
+    return True
+
+
+def upsert_default_job(mainwindow: QWidget, job: JobStatusSpec) -> bool:
+    """Add/update a job in the default drawer when installed."""
+    drawer = getattr(mainwindow, "jobStatusDrawer", None)
+    if drawer is None:
+        return False
+    try:
+        drawer.upsert_job(job)
+        return True
+    except Exception:
+        return False
+
+
 def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True) -> bool:
     """Install ModeRail into the existing default MainWindow layout.
 
@@ -134,6 +209,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
         return False
     if getattr(mainwindow, "modeRail", None) is not None:
         _install_mode_sync_wrappers(mainwindow)
+        install_default_job_drawer(mainwindow, retry=retry)
         return True
     left_bar = getattr(mainwindow, "leftBar", None)
     root_layout = getattr(mainwindow, "mainvlayout", None)
@@ -141,6 +217,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
     if target_layout is None:
         if retry:
             QTimer.singleShot(0, lambda: install_default_modern_navigation(mainwindow, retry=False))
+            QTimer.singleShot(0, lambda: install_default_job_drawer(mainwindow, retry=False))
         return False
     rail = ModeRail(parent=mainwindow)
     rail.mode_requested.connect(lambda mode: route_modern_mode_request(mainwindow, mode))
@@ -151,6 +228,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
     target_layout.insertWidget(insert_at, rail)
     mainwindow.modeRail = rail
     _install_mode_sync_wrappers(mainwindow)
+    install_default_job_drawer(mainwindow, retry=retry)
     set_modern_mode(mainwindow, "home")
     return True
 

--- a/ui/default_modern_shell.py
+++ b/ui/default_modern_shell.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import MethodType
 from typing import Optional
 
 from qtpy.QtCore import QTimer
@@ -54,6 +55,7 @@ def route_modern_mode_request(mainwindow: QWidget, mode: str):
         mainwindow.on_open_realtime_translator()
     elif mode == "quick_image" and hasattr(mainwindow, "leftBar") and hasattr(mainwindow.leftBar, "onOpenImages"):
         mainwindow.leftBar.onOpenImages()
+        set_modern_mode(mainwindow, "quick_image")
     elif mode == "downloader" and hasattr(mainwindow, "on_open_manga_source"):
         mainwindow.on_open_manga_source()
     elif mode == "batch" and hasattr(mainwindow, "on_open_batch_queue"):
@@ -77,6 +79,50 @@ def set_modern_mode(mainwindow: QWidget, mode: str):
             pass
 
 
+def _install_mode_sync_wrappers(mainwindow: QWidget):
+    """Keep ModeRail checked state in sync when legacy menus/buttons navigate.
+
+    During migration the old left bar, top menus, welcome cards, and shortcuts can
+    all still change the current workspace.  Wrapping the existing handlers keeps
+    the new rail accurate without rewriting every call site in MainWindow.
+    """
+    if mainwindow is None or getattr(mainwindow, "_modern_mode_sync_wrappers_installed", False):
+        return
+
+    def wrap(handler_name: str, mode: str, *, editor_requires_project: bool = False):
+        original = getattr(mainwindow, handler_name, None)
+        if not callable(original):
+            return
+
+        def wrapped(self, *args, __original=original, __mode=mode, __editor_requires_project=editor_requires_project, **kwargs):
+            result = __original(*args, **kwargs)
+            resolved_mode = __mode
+            if __editor_requires_project:
+                try:
+                    resolved_mode = "editor" if self._has_open_project() else "home"
+                except Exception:
+                    resolved_mode = "home"
+            set_modern_mode(self, resolved_mode)
+            return result
+
+        try:
+            setattr(mainwindow, handler_name, MethodType(wrapped, mainwindow))
+        except Exception:
+            pass
+
+    wrap("_show_welcome_screen", "home")
+    wrap("_show_main_content", "editor", editor_requires_project=True)
+    wrap("setupImgTransUI", "editor", editor_requires_project=True)
+    wrap("setupConfigUI", "settings")
+    wrap("on_open_realtime_translator", "live")
+    wrap("on_open_manga_source", "downloader")
+    wrap("on_open_batch_queue", "batch")
+    wrap("on_open_translation_assist_dock", "assist")
+    wrap("on_open_manage_models", "models")
+    wrap("on_environment_doctor", "diagnostics")
+    mainwindow._modern_mode_sync_wrappers_installed = True
+
+
 def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True) -> bool:
     """Install ModeRail into the existing default MainWindow layout.
 
@@ -87,6 +133,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
     if mainwindow is None:
         return False
     if getattr(mainwindow, "modeRail", None) is not None:
+        _install_mode_sync_wrappers(mainwindow)
         return True
     left_bar = getattr(mainwindow, "leftBar", None)
     root_layout = getattr(mainwindow, "mainvlayout", None)
@@ -103,6 +150,7 @@ def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True
         insert_at = 0
     target_layout.insertWidget(insert_at, rail)
     mainwindow.modeRail = rail
+    _install_mode_sync_wrappers(mainwindow)
     set_modern_mode(mainwindow, "home")
     return True
 

--- a/ui/default_modern_shell.py
+++ b/ui/default_modern_shell.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from qtpy.QtCore import QTimer
+from qtpy.QtWidgets import QHBoxLayout, QWidget
+
+from .mode_rail import ModeRail
+
+
+def _find_layout_containing_widget(root_layout, widget: QWidget) -> Optional[QHBoxLayout]:
+    """Find the first nested layout that directly contains widget."""
+    if root_layout is None or widget is None:
+        return None
+    try:
+        if root_layout.indexOf(widget) >= 0:
+            return root_layout
+    except Exception:
+        pass
+    try:
+        count = root_layout.count()
+    except Exception:
+        return None
+    for idx in range(count):
+        item = root_layout.itemAt(idx)
+        if item is None:
+            continue
+        child_layout = item.layout()
+        if child_layout is None:
+            continue
+        found = _find_layout_containing_widget(child_layout, widget)
+        if found is not None:
+            return found
+    return None
+
+
+def route_modern_mode_request(mainwindow: QWidget, mode: str):
+    """Route ModeRail requests to existing MainWindow handlers.
+
+    This keeps the new default rail useful immediately while preserving legacy
+    left-bar/menu behavior during migration.
+    """
+    mode = str(mode or "").strip().lower()
+    if not mainwindow:
+        return
+    if mode == "home" and hasattr(mainwindow, "_show_welcome_screen"):
+        mainwindow._show_welcome_screen()
+    elif mode == "editor":
+        if hasattr(mainwindow, "_has_open_project") and mainwindow._has_open_project() and hasattr(mainwindow, "setupImgTransUI"):
+            mainwindow.setupImgTransUI()
+        elif hasattr(mainwindow, "_show_welcome_screen"):
+            mainwindow._show_welcome_screen()
+    elif mode == "live" and hasattr(mainwindow, "on_open_realtime_translator"):
+        mainwindow.on_open_realtime_translator()
+    elif mode == "quick_image" and hasattr(mainwindow, "leftBar") and hasattr(mainwindow.leftBar, "onOpenImages"):
+        mainwindow.leftBar.onOpenImages()
+    elif mode == "downloader" and hasattr(mainwindow, "on_open_manga_source"):
+        mainwindow.on_open_manga_source()
+    elif mode == "batch" and hasattr(mainwindow, "on_open_batch_queue"):
+        mainwindow.on_open_batch_queue()
+    elif mode == "assist" and hasattr(mainwindow, "on_open_translation_assist_dock"):
+        mainwindow.on_open_translation_assist_dock()
+    elif mode == "models" and hasattr(mainwindow, "on_open_manage_models"):
+        mainwindow.on_open_manage_models()
+    elif mode == "settings" and hasattr(mainwindow, "setupConfigUI"):
+        mainwindow.setupConfigUI()
+    elif mode == "diagnostics" and hasattr(mainwindow, "on_environment_doctor"):
+        mainwindow.on_environment_doctor()
+
+
+def set_modern_mode(mainwindow: QWidget, mode: str):
+    rail = getattr(mainwindow, "modeRail", None)
+    if rail is not None and hasattr(rail, "set_current_mode"):
+        try:
+            rail.set_current_mode(str(mode or ""))
+        except Exception:
+            pass
+
+
+def install_default_modern_navigation(mainwindow: QWidget, *, retry: bool = True) -> bool:
+    """Install ModeRail into the existing default MainWindow layout.
+
+    This makes the rework default-facing without replacing the whole editor at
+    once. It is safe to call more than once and safe to call before setupUi has
+    fully finished; in that case it retries once on the next event-loop tick.
+    """
+    if mainwindow is None:
+        return False
+    if getattr(mainwindow, "modeRail", None) is not None:
+        return True
+    left_bar = getattr(mainwindow, "leftBar", None)
+    root_layout = getattr(mainwindow, "mainvlayout", None)
+    target_layout = _find_layout_containing_widget(root_layout, left_bar)
+    if target_layout is None:
+        if retry:
+            QTimer.singleShot(0, lambda: install_default_modern_navigation(mainwindow, retry=False))
+        return False
+    rail = ModeRail(parent=mainwindow)
+    rail.mode_requested.connect(lambda mode: route_modern_mode_request(mainwindow, mode))
+    try:
+        insert_at = max(0, target_layout.indexOf(left_bar))
+    except Exception:
+        insert_at = 0
+    target_layout.insertWidget(insert_at, rail)
+    mainwindow.modeRail = rail
+    set_modern_mode(mainwindow, "home")
+    return True
+
+
+def install_default_welcome_signal_fallbacks(welcome_widget: QWidget, mainwindow: QWidget) -> bool:
+    """Connect new welcome workflow signals to existing handlers when MainWindow has not yet done so."""
+    if welcome_widget is None or mainwindow is None:
+        return False
+    if getattr(welcome_widget, "_modern_shell_fallbacks_installed", False):
+        return True
+    connected = False
+    pairs = (
+        ("open_assist_requested", "on_open_translation_assist_dock"),
+    )
+    for signal_name, handler_name in pairs:
+        signal = getattr(welcome_widget, signal_name, None)
+        handler = getattr(mainwindow, handler_name, None)
+        if signal is not None and callable(handler):
+            try:
+                signal.connect(handler)
+                connected = True
+            except Exception:
+                pass
+    welcome_widget._modern_shell_fallbacks_installed = True
+    return connected

--- a/ui/design_tokens.py
+++ b/ui/design_tokens.py
@@ -12,6 +12,7 @@ class SpacingTokens:
     lg: int = 16
     xl: int = 24
     xxl: int = 32
+    xxxl: int = 48
 
 
 @dataclass(frozen=True)
@@ -20,6 +21,7 @@ class RadiusTokens:
     md: int = 8
     lg: int = 12
     xl: int = 16
+    pill: int = 999
 
 
 @dataclass(frozen=True)
@@ -29,21 +31,49 @@ class TypographyTokens:
     body_large: int = 14
     title: int = 16
     headline: int = 20
+    display: int = 28
 
 
 @dataclass(frozen=True)
 class ColorTokens:
     background: str = "#111318"
+    background_soft: str = "#151922"
     surface: str = "#1a1d24"
     surface_alt: str = "#222733"
+    surface_hover: str = "#293040"
+    surface_glass: str = "rgba(34, 39, 51, 0.78)"
     border: str = "#303645"
+    border_soft: str = "rgba(255, 255, 255, 0.08)"
     text: str = "#f2f4f8"
     text_muted: str = "#aab2c0"
+    text_subtle: str = "#788295"
     primary: str = "#7aa2ff"
+    primary_soft: str = "rgba(122, 162, 255, 0.16)"
     success: str = "#5cc887"
+    success_soft: str = "rgba(92, 200, 135, 0.16)"
     warning: str = "#f4c76b"
+    warning_soft: str = "rgba(244, 199, 107, 0.18)"
     danger: str = "#ff7b7b"
+    danger_soft: str = "rgba(255, 123, 123, 0.16)"
     info: str = "#7fd7ff"
+    info_soft: str = "rgba(127, 215, 255, 0.16)"
+    dango_pink: str = "#ff9ecf"
+    dango_blue: str = "#9fd4ff"
+    dango_lavender: str = "#b9a7ff"
+
+
+@dataclass(frozen=True)
+class ShadowTokens:
+    sm: str = "0 1px 2px rgba(0, 0, 0, 0.18)"
+    md: str = "0 8px 24px rgba(0, 0, 0, 0.24)"
+    lg: str = "0 18px 48px rgba(0, 0, 0, 0.32)"
+
+
+@dataclass(frozen=True)
+class MotionTokens:
+    fast_ms: int = 120
+    normal_ms: int = 180
+    slow_ms: int = 260
 
 
 @dataclass(frozen=True)
@@ -52,6 +82,8 @@ class UITokens:
     radius: RadiusTokens = RadiusTokens()
     typography: TypographyTokens = TypographyTokens()
     colors: ColorTokens = ColorTokens()
+    shadows: ShadowTokens = ShadowTokens()
+    motion: MotionTokens = MotionTokens()
 
 
 TOKENS = UITokens()
@@ -64,47 +96,134 @@ STATUS_COLORS: Dict[str, str] = {
     "error": TOKENS.colors.danger,
     "disabled": TOKENS.colors.text_muted,
     "experimental": TOKENS.colors.warning,
+    "cat": TOKENS.colors.success,
+    "beta": TOKENS.colors.dango_lavender,
+}
+
+STATUS_BACKGROUNDS: Dict[str, str] = {
+    "idle": "transparent",
+    "running": TOKENS.colors.info_soft,
+    "success": TOKENS.colors.success_soft,
+    "warning": TOKENS.colors.warning_soft,
+    "error": TOKENS.colors.danger_soft,
+    "disabled": "transparent",
+    "experimental": TOKENS.colors.warning_soft,
+    "cat": TOKENS.colors.success_soft,
+    "beta": "rgba(185, 167, 255, 0.16)",
 }
 
 WORKFLOW_ACCENTS: Dict[str, str] = {
-    "home": TOKENS.colors.primary,
+    "home": TOKENS.colors.dango_lavender,
     "editor": TOKENS.colors.primary,
     "live": TOKENS.colors.info,
     "quick_image": TOKENS.colors.success,
     "downloader": TOKENS.colors.warning,
-    "batch": TOKENS.colors.info,
+    "batch": TOKENS.colors.dango_blue,
     "assist": TOKENS.colors.success,
     "models": TOKENS.colors.primary,
     "settings": TOKENS.colors.text_muted,
     "diagnostics": TOKENS.colors.warning,
 }
 
+WORKFLOW_GRADIENTS: Dict[str, str] = {
+    "home": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(185,167,255,0.30), stop:1 rgba(159,212,255,0.12))",
+    "editor": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(122,162,255,0.26), stop:1 rgba(127,215,255,0.10))",
+    "live": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(127,215,255,0.26), stop:1 rgba(255,158,207,0.10))",
+    "quick_image": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(92,200,135,0.24), stop:1 rgba(127,215,255,0.10))",
+    "downloader": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(244,199,107,0.24), stop:1 rgba(255,158,207,0.10))",
+    "assist": "qlineargradient(x1:0,y1:0,x2:1,y2:1, stop:0 rgba(92,200,135,0.24), stop:1 rgba(185,167,255,0.10))",
+}
+
 
 def badge_style(kind: str = "idle") -> str:
-    color = STATUS_COLORS.get(str(kind or "idle"), TOKENS.colors.text_muted)
+    color = STATUS_COLORS.get(str(kind or "idle").lower(), TOKENS.colors.text_muted)
+    bg = STATUS_BACKGROUNDS.get(str(kind or "idle").lower(), "transparent")
     return (
         f"border: 1px solid {color};"
         f"color: {color};"
-        f"border-radius: {TOKENS.radius.md}px;"
+        f"border-radius: {TOKENS.radius.pill}px;"
         f"padding: {TOKENS.spacing.xs}px {TOKENS.spacing.sm}px;"
-        "background: transparent;"
+        f"background: {bg};"
+        f"font-size: {TOKENS.typography.caption}px;"
+        "font-weight: 700;"
     )
 
 
-def card_style(accent: str | None = None) -> str:
-    border = accent or TOKENS.colors.border
+def card_style(accent: str | None = None, elevated: bool = True) -> str:
+    border = accent or TOKENS.colors.border_soft
+    shadow_note = f"/* shadow: {TOKENS.shadows.md}; */" if elevated else ""
     return (
-        f"background: {TOKENS.colors.surface};"
+        f"background: {TOKENS.colors.surface_glass};"
         f"border: 1px solid {border};"
-        f"border-radius: {TOKENS.radius.lg}px;"
+        f"border-radius: {TOKENS.radius.xl}px;"
         f"padding: {TOKENS.spacing.lg}px;"
+        f"{shadow_note}"
+    )
+
+
+def card_hover_style(accent: str | None = None) -> str:
+    border = accent or TOKENS.colors.primary
+    return (
+        f"background: {TOKENS.colors.surface_hover};"
+        f"border: 1px solid {border};"
+        f"border-radius: {TOKENS.radius.xl}px;"
+    )
+
+
+def hero_panel_style(workflow: str = "home") -> str:
+    gradient = WORKFLOW_GRADIENTS.get(workflow, WORKFLOW_GRADIENTS["home"])
+    return (
+        f"background: {gradient};"
+        f"border: 1px solid {TOKENS.colors.border_soft};"
+        f"border-radius: {TOKENS.radius.xl}px;"
+        f"padding: {TOKENS.spacing.xl}px;"
+    )
+
+
+def primary_button_style(workflow: str = "home") -> str:
+    accent = WORKFLOW_ACCENTS.get(workflow, TOKENS.colors.primary)
+    return (
+        "QPushButton, QToolButton {"
+        f"background: {accent};"
+        "color: #0b1020;"
+        f"border-radius: {TOKENS.radius.lg}px;"
+        f"padding: {TOKENS.spacing.sm}px {TOKENS.spacing.lg}px;"
+        "font-weight: 700;"
+        "border: none;"
+        "}"
+        "QPushButton:hover, QToolButton:hover {"
+        "filter: brightness(1.08);"
+        "}"
+    )
+
+
+def secondary_button_style() -> str:
+    return (
+        "QPushButton, QToolButton {"
+        f"background: {TOKENS.colors.surface_alt};"
+        f"color: {TOKENS.colors.text};"
+        f"border: 1px solid {TOKENS.colors.border_soft};"
+        f"border-radius: {TOKENS.radius.lg}px;"
+        f"padding: {TOKENS.spacing.sm}px {TOKENS.spacing.lg}px;"
+        "}"
+        "QPushButton:hover, QToolButton:hover {"
+        f"background: {TOKENS.colors.surface_hover};"
+        "}"
     )
 
 
 def inspector_section_style() -> str:
     return (
         f"background: {TOKENS.colors.surface_alt};"
-        f"border: 1px solid {TOKENS.colors.border};"
-        f"border-radius: {TOKENS.radius.md}px;"
+        f"border: 1px solid {TOKENS.colors.border_soft};"
+        f"border-radius: {TOKENS.radius.lg}px;"
         f"padding: {TOKENS.spacing.md}px;"
+    )
+
+
+def app_shell_style() -> str:
+    return (
+        f"background: {TOKENS.colors.background};"
+        f"color: {TOKENS.colors.text};"
+        f"font-size: {TOKENS.typography.body}px;"
     )

--- a/ui/design_tokens.py
+++ b/ui/design_tokens.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class SpacingTokens:
+    xs: int = 4
+    sm: int = 8
+    md: int = 12
+    lg: int = 16
+    xl: int = 24
+    xxl: int = 32
+
+
+@dataclass(frozen=True)
+class RadiusTokens:
+    sm: int = 4
+    md: int = 8
+    lg: int = 12
+    xl: int = 16
+
+
+@dataclass(frozen=True)
+class TypographyTokens:
+    caption: int = 11
+    body: int = 13
+    body_large: int = 14
+    title: int = 16
+    headline: int = 20
+
+
+@dataclass(frozen=True)
+class ColorTokens:
+    background: str = "#111318"
+    surface: str = "#1a1d24"
+    surface_alt: str = "#222733"
+    border: str = "#303645"
+    text: str = "#f2f4f8"
+    text_muted: str = "#aab2c0"
+    primary: str = "#7aa2ff"
+    success: str = "#5cc887"
+    warning: str = "#f4c76b"
+    danger: str = "#ff7b7b"
+    info: str = "#7fd7ff"
+
+
+@dataclass(frozen=True)
+class UITokens:
+    spacing: SpacingTokens = SpacingTokens()
+    radius: RadiusTokens = RadiusTokens()
+    typography: TypographyTokens = TypographyTokens()
+    colors: ColorTokens = ColorTokens()
+
+
+TOKENS = UITokens()
+
+STATUS_COLORS: Dict[str, str] = {
+    "idle": TOKENS.colors.text_muted,
+    "running": TOKENS.colors.info,
+    "success": TOKENS.colors.success,
+    "warning": TOKENS.colors.warning,
+    "error": TOKENS.colors.danger,
+    "disabled": TOKENS.colors.text_muted,
+    "experimental": TOKENS.colors.warning,
+}
+
+WORKFLOW_ACCENTS: Dict[str, str] = {
+    "home": TOKENS.colors.primary,
+    "editor": TOKENS.colors.primary,
+    "live": TOKENS.colors.info,
+    "quick_image": TOKENS.colors.success,
+    "downloader": TOKENS.colors.warning,
+    "batch": TOKENS.colors.info,
+    "assist": TOKENS.colors.success,
+    "models": TOKENS.colors.primary,
+    "settings": TOKENS.colors.text_muted,
+    "diagnostics": TOKENS.colors.warning,
+}
+
+
+def badge_style(kind: str = "idle") -> str:
+    color = STATUS_COLORS.get(str(kind or "idle"), TOKENS.colors.text_muted)
+    return (
+        f"border: 1px solid {color};"
+        f"color: {color};"
+        f"border-radius: {TOKENS.radius.md}px;"
+        f"padding: {TOKENS.spacing.xs}px {TOKENS.spacing.sm}px;"
+        "background: transparent;"
+    )
+
+
+def card_style(accent: str | None = None) -> str:
+    border = accent or TOKENS.colors.border
+    return (
+        f"background: {TOKENS.colors.surface};"
+        f"border: 1px solid {border};"
+        f"border-radius: {TOKENS.radius.lg}px;"
+        f"padding: {TOKENS.spacing.lg}px;"
+    )
+
+
+def inspector_section_style() -> str:
+    return (
+        f"background: {TOKENS.colors.surface_alt};"
+        f"border: 1px solid {TOKENS.colors.border};"
+        f"border-radius: {TOKENS.radius.md}px;"
+        f"padding: {TOKENS.spacing.md}px;"
+    )

--- a/ui/editor_inspector.py
+++ b/ui/editor_inspector.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPlainTextEdit,
+    QPushButton,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .design_tokens import TOKENS, badge_style, inspector_section_style
+
+
+@dataclass(frozen=True)
+class InspectorTabSpec:
+    key: str
+    title: str
+    description: str
+
+
+DEFAULT_INSPECTOR_TABS: tuple[InspectorTabSpec, ...] = (
+    InspectorTabSpec("text", "Text", "Source and translated text for the selected block."),
+    InspectorTabSpec("style", "Style", "Font, size, stroke, fill, shadow, and presets."),
+    InspectorTabSpec("layout", "Layout", "Bubble fitting, safe area, reading direction, and overflow checks."),
+    InspectorTabSpec("assist", "Assist", "Translation Assist candidates, TM, glossary, SFX, and concordance."),
+    InspectorTabSpec("ocr", "OCR", "OCR crop, confidence, engine, and rerun controls."),
+    InspectorTabSpec("qa", "QA", "Translation, typography, clipping, and render warnings."),
+    InspectorTabSpec("metadata", "Metadata", "Block IDs, geometry, model provenance, and export fields."),
+)
+
+
+class InspectorSection(QFrame):
+    def __init__(self, title: str, status: str = "idle", parent=None):
+        super().__init__(parent)
+        self.setObjectName("InspectorSection")
+        self.setStyleSheet(inspector_section_style())
+        self._layout = QVBoxLayout(self)
+        self._layout.setContentsMargins(TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md)
+        self._layout.setSpacing(TOKENS.spacing.sm)
+        header = QHBoxLayout()
+        title_label = QLabel(title)
+        title_label.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; font-weight: 700;")
+        header.addWidget(title_label, 1)
+        self.status_label = QLabel(status)
+        self.status_label.setStyleSheet(badge_style(status))
+        header.addWidget(self.status_label)
+        self._layout.addLayout(header)
+
+    def addWidget(self, widget):
+        self._layout.addWidget(widget)
+
+    def addLayout(self, layout):
+        self._layout.addLayout(layout)
+
+    def set_status(self, status: str):
+        self.status_label.setText(status)
+        self.status_label.setStyleSheet(badge_style(status))
+
+
+class EditorInspector(QWidget):
+    """Right-side inspector shell for the reworked editor workspace.
+
+    The component is standalone so it can be introduced beside the legacy
+    `TextPanel`/`DrawingPanel` stack first.  Later PRs should map each tab to
+    the existing concrete controls instead of duplicating behavior.
+    """
+
+    request_translation_assist = Signal()
+    request_ocr_rerun = Signal()
+    request_layout_review = Signal()
+    request_typography_qa = Signal()
+
+    def __init__(self, tabs: Optional[Iterable[InspectorTabSpec]] = None, parent=None):
+        super().__init__(parent)
+        self.tabs: List[InspectorTabSpec] = list(tabs or DEFAULT_INSPECTOR_TABS)
+        self._tab_widgets: Dict[str, QWidget] = {}
+        self._build_ui()
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(TOKENS.spacing.sm)
+
+        title = QLabel(self.tr("Inspector"))
+        title.setObjectName("EditorInspectorTitle")
+        title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 700;")
+        root.addWidget(title)
+
+        subtitle = QLabel(self.tr("Selected block tools, assist, OCR, layout, and QA live here."))
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        root.addWidget(subtitle)
+
+        self.tab_widget = QTabWidget(self)
+        root.addWidget(self.tab_widget, 1)
+
+        for spec in self.tabs:
+            page = self._build_tab_page(spec)
+            self._tab_widgets[spec.key] = page
+            self.tab_widget.addTab(page, spec.title)
+
+    def _build_tab_page(self, spec: InspectorTabSpec) -> QWidget:
+        page = QWidget(self)
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(TOKENS.spacing.sm, TOKENS.spacing.sm, TOKENS.spacing.sm, TOKENS.spacing.sm)
+        layout.setSpacing(TOKENS.spacing.md)
+
+        desc = QLabel(spec.description)
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(desc)
+
+        if spec.key == "text":
+            self.source_preview = QPlainTextEdit(page)
+            self.source_preview.setReadOnly(True)
+            self.source_preview.setPlaceholderText(self.tr("Source text"))
+            self.target_preview = QPlainTextEdit(page)
+            self.target_preview.setPlaceholderText(self.tr("Translated text"))
+            layout.addWidget(self.source_preview)
+            layout.addWidget(self.target_preview)
+        elif spec.key == "assist":
+            section = InspectorSection(self.tr("Translation Assist"), "CAT", page)
+            button = QPushButton(self.tr("Open Translation Assist"), section)
+            button.clicked.connect(self.request_translation_assist.emit)
+            section.addWidget(button)
+            layout.addWidget(section)
+        elif spec.key == "ocr":
+            section = InspectorSection(self.tr("OCR Crop Inspector"), "idle", page)
+            button = QPushButton(self.tr("Rerun OCR for selected block"), section)
+            button.clicked.connect(self.request_ocr_rerun.emit)
+            section.addWidget(button)
+            layout.addWidget(section)
+        elif spec.key == "layout":
+            section = InspectorSection(self.tr("Auto Layout"), "warning", page)
+            button = QPushButton(self.tr("Review selected layout"), section)
+            button.clicked.connect(self.request_layout_review.emit)
+            section.addWidget(button)
+            layout.addWidget(section)
+        elif spec.key == "qa":
+            section = InspectorSection(self.tr("Quality checks"), "warning", page)
+            button = QPushButton(self.tr("Run typography QA"), section)
+            button.clicked.connect(self.request_typography_qa.emit)
+            section.addWidget(button)
+            layout.addWidget(section)
+        else:
+            section = InspectorSection(spec.title, "idle", page)
+            placeholder = QLabel(self.tr("This tab will be wired to existing controls in a later UI migration step."), section)
+            placeholder.setWordWrap(True)
+            section.addWidget(placeholder)
+            layout.addWidget(section)
+
+        layout.addStretch(1)
+        return page
+
+    def tab_keys(self) -> List[str]:
+        return [t.key for t in self.tabs]
+
+    def tab_widget_for_key(self, key: str) -> Optional[QWidget]:
+        return self._tab_widgets.get(key)
+
+    def set_text_preview(self, source: str, target: str):
+        if hasattr(self, "source_preview"):
+            self.source_preview.setPlainText(source or "")
+        if hasattr(self, "target_preview"):
+            self.target_preview.setPlainText(target or "")

--- a/ui/experimental_app_shell.py
+++ b/ui/experimental_app_shell.py
@@ -4,9 +4,9 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional
 
 from qtpy.QtCore import QByteArray, Qt, Signal
-from qtpy.QtWidgets import QLabel, QSplitter, QStackedWidget, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QFrame, QLabel, QSplitter, QStackedWidget, QVBoxLayout, QWidget
 
-from .design_tokens import TOKENS
+from .design_tokens import TOKENS, WORKFLOW_ACCENTS, app_shell_style, hero_panel_style
 from .editor_inspector import EditorInspector
 from .job_status_drawer import JobStatusDrawer, JobStatusSpec
 from .mode_rail import DEFAULT_MODE_RAIL_ITEMS, ModeRail, ModeRailItemSpec
@@ -40,34 +40,33 @@ class PlaceholderShellPage(QWidget):
         self.spec = spec
         layout = QVBoxLayout(self)
         layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
-        layout.setSpacing(TOKENS.spacing.md)
-        title = QLabel(spec.title, self)
-        title.setStyleSheet(f"font-size: {TOKENS.typography.headline}px; font-weight: 700;")
-        layout.addWidget(title)
-        desc = QLabel(spec.description, self)
+        layout.setSpacing(TOKENS.spacing.lg)
+
+        hero = QFrame(self)
+        hero.setObjectName("PlaceholderShellHero")
+        hero.setStyleSheet(hero_panel_style(spec.key))
+        hero_layout = QVBoxLayout(hero)
+        hero_layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
+        hero_layout.setSpacing(TOKENS.spacing.sm)
+
+        title = QLabel(spec.title, hero)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.display}px; font-weight: 900; color: {TOKENS.colors.text};")
+        hero_layout.addWidget(title)
+        desc = QLabel(spec.description, hero)
         desc.setWordWrap(True)
         desc.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
-        layout.addWidget(desc)
-        note = QLabel(self.tr("This page is a shell placeholder. Future PRs should embed the existing workflow UI here without removing legacy paths."), self)
+        hero_layout.addWidget(desc)
+        layout.addWidget(hero)
+
+        note = QLabel(self.tr("This modern shell page is ready for the existing workflow UI to be embedded in a later migration step. Legacy menus and panels remain available while this page is wired."), self)
         note.setWordWrap(True)
-        note.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted};")
+        note.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted}; padding: {TOKENS.spacing.lg}px;")
         layout.addWidget(note)
         layout.addStretch(1)
 
 
 class ExperimentalAppShell(QWidget):
-    """Composable app-shell prototype for the phased UI/UX rework.
-
-    This widget is intentionally not wired as the default MainWindow central
-    layout yet. It provides a safe host for the target structure:
-
-    - left ModeRail
-    - central stacked workflow workspace
-    - right EditorInspector
-    - bottom JobStatusDrawer
-
-    Future PRs can embed existing legacy panels into each page one by one.
-    """
+    """Composable app-shell prototype for the phased UI/UX rework."""
 
     mode_changed = Signal(str)
     workflow_requested = Signal(str)
@@ -86,6 +85,17 @@ class ExperimentalAppShell(QWidget):
         parent=None,
     ):
         super().__init__(parent)
+        self.setObjectName("ExperimentalAppShell")
+        self.setStyleSheet(
+            "QWidget#ExperimentalAppShell {" + app_shell_style() + "}"
+            "QSplitter::handle { background: rgba(255, 255, 255, 0.05); }"
+            "QSplitter::handle:hover { background: rgba(122, 162, 255, 0.28); }"
+            "QStackedWidget#ExperimentalAppShellCenterStack {"
+            f"background: {TOKENS.colors.background_soft};"
+            f"border-left: 1px solid {TOKENS.colors.border_soft};"
+            f"border-right: 1px solid {TOKENS.colors.border_soft};"
+            "}"
+        )
         self.pages: List[ShellPageSpec] = list(pages or DEFAULT_SHELL_PAGES)
         self._page_indexes: Dict[str, int] = {}
         self._build_ui(rail_items)
@@ -119,6 +129,7 @@ class ExperimentalAppShell(QWidget):
         self.main_splitter.setStretchFactor(0, 0)
         self.main_splitter.setStretchFactor(1, 1)
         self.main_splitter.setStretchFactor(2, 0)
+        self.main_splitter.setSizes([128, 900, 340])
 
         self.job_drawer = JobStatusDrawer(parent=self)
         self.job_drawer.cancel_requested.connect(self.job_cancel_requested.emit)

--- a/ui/experimental_app_shell.py
+++ b/ui/experimental_app_shell.py
@@ -4,11 +4,12 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, List, Optional
 
 from qtpy.QtCore import QByteArray, Qt, Signal
-from qtpy.QtWidgets import QFrame, QLabel, QSplitter, QStackedWidget, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QSplitter, QStackedWidget, QVBoxLayout, QWidget
 
-from .design_tokens import TOKENS, WORKFLOW_ACCENTS, app_shell_style, hero_panel_style
+from .design_tokens import TOKENS, app_shell_style
 from .editor_inspector import EditorInspector
 from .job_status_drawer import JobStatusDrawer, JobStatusSpec
+from .mode_dashboard import ModeDashboard, dashboard_for_mode
 from .mode_rail import DEFAULT_MODE_RAIL_ITEMS, ModeRail, ModeRailItemSpec
 from .workflow_home import WorkflowHomeWidget
 
@@ -34,42 +35,16 @@ DEFAULT_SHELL_PAGES: tuple[ShellPageSpec, ...] = (
 )
 
 
-class PlaceholderShellPage(QWidget):
-    def __init__(self, spec: ShellPageSpec, parent=None):
-        super().__init__(parent)
-        self.spec = spec
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
-        layout.setSpacing(TOKENS.spacing.lg)
-
-        hero = QFrame(self)
-        hero.setObjectName("PlaceholderShellHero")
-        hero.setStyleSheet(hero_panel_style(spec.key))
-        hero_layout = QVBoxLayout(hero)
-        hero_layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
-        hero_layout.setSpacing(TOKENS.spacing.sm)
-
-        title = QLabel(spec.title, hero)
-        title.setStyleSheet(f"font-size: {TOKENS.typography.display}px; font-weight: 900; color: {TOKENS.colors.text};")
-        hero_layout.addWidget(title)
-        desc = QLabel(spec.description, hero)
-        desc.setWordWrap(True)
-        desc.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
-        hero_layout.addWidget(desc)
-        layout.addWidget(hero)
-
-        note = QLabel(self.tr("This modern shell page is ready for the existing workflow UI to be embedded in a later migration step. Legacy menus and panels remain available while this page is wired."), self)
-        note.setWordWrap(True)
-        note.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted}; padding: {TOKENS.spacing.lg}px;")
-        layout.addWidget(note)
-        layout.addStretch(1)
-
-
 class ExperimentalAppShell(QWidget):
-    """Composable app-shell prototype for the phased UI/UX rework."""
+    """Composable app-shell prototype for the phased UI/UX rework.
+
+    Modern here means advanced and polished: dashboards expose professional
+    actions, metrics, warnings, and notes instead of hiding complexity.
+    """
 
     mode_changed = Signal(str)
     workflow_requested = Signal(str)
+    dashboard_action_requested = Signal(str, str)
     translation_assist_requested = Signal()
     ocr_rerun_requested = Signal()
     layout_review_requested = Signal()
@@ -144,7 +119,9 @@ class ExperimentalAppShell(QWidget):
                 page.workflow_requested.connect(self.workflow_requested.emit)
                 page.workflow_requested.connect(self.set_current_mode)
             else:
-                page = PlaceholderShellPage(spec, self.center_stack)
+                dashboard_spec = dashboard_for_mode(spec.key, spec.title, spec.description)
+                page = ModeDashboard(dashboard_spec, self.center_stack)
+                page.action_requested.connect(self.dashboard_action_requested.emit)
             self._page_indexes[spec.key] = self.center_stack.addWidget(page)
 
     def set_current_mode(self, key: str):

--- a/ui/experimental_app_shell.py
+++ b/ui/experimental_app_shell.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from qtpy.QtCore import QByteArray, Qt, Signal
+from qtpy.QtWidgets import QLabel, QSplitter, QStackedWidget, QVBoxLayout, QWidget
+
+from .design_tokens import TOKENS
+from .editor_inspector import EditorInspector
+from .job_status_drawer import JobStatusDrawer, JobStatusSpec
+from .mode_rail import DEFAULT_MODE_RAIL_ITEMS, ModeRail, ModeRailItemSpec
+from .workflow_home import WorkflowHomeWidget
+
+
+@dataclass(frozen=True)
+class ShellPageSpec:
+    key: str
+    title: str
+    description: str
+
+
+DEFAULT_SHELL_PAGES: tuple[ShellPageSpec, ...] = (
+    ShellPageSpec("home", "Home", "Choose a workflow or continue recent work."),
+    ShellPageSpec("editor", "Editor", "Manga/comic localization workspace."),
+    ShellPageSpec("live", "Live Translation", "Realtime screen or Chrome manhua translation."),
+    ShellPageSpec("quick_image", "Image Quick Translation", "Drop images, translate quickly, and optionally promote to a project."),
+    ShellPageSpec("downloader", "Raw Downloader", "Search sources, choose chapters, and import raws."),
+    ShellPageSpec("batch", "Batch Queue", "Process many chapters, folders, or archives."),
+    ShellPageSpec("assist", "Translation Assist / QA", "Provider comparison, TM, glossary, concordance, SFX, and QA."),
+    ShellPageSpec("models", "Models & Providers", "Install models, test providers, and inspect runtime health."),
+    ShellPageSpec("settings", "Settings", "Searchable app and workflow settings."),
+    ShellPageSpec("diagnostics", "Diagnostics / Help", "Logs, doctors, reports, documentation, and support."),
+)
+
+
+class PlaceholderShellPage(QWidget):
+    def __init__(self, spec: ShellPageSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
+        layout.setSpacing(TOKENS.spacing.md)
+        title = QLabel(spec.title, self)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.headline}px; font-weight: 700;")
+        layout.addWidget(title)
+        desc = QLabel(spec.description, self)
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(desc)
+        note = QLabel(self.tr("This page is a shell placeholder. Future PRs should embed the existing workflow UI here without removing legacy paths."), self)
+        note.setWordWrap(True)
+        note.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(note)
+        layout.addStretch(1)
+
+
+class ExperimentalAppShell(QWidget):
+    """Composable app-shell prototype for the phased UI/UX rework.
+
+    This widget is intentionally not wired as the default MainWindow central
+    layout yet. It provides a safe host for the target structure:
+
+    - left ModeRail
+    - central stacked workflow workspace
+    - right EditorInspector
+    - bottom JobStatusDrawer
+
+    Future PRs can embed existing legacy panels into each page one by one.
+    """
+
+    mode_changed = Signal(str)
+    workflow_requested = Signal(str)
+    translation_assist_requested = Signal()
+    ocr_rerun_requested = Signal()
+    layout_review_requested = Signal()
+    typography_qa_requested = Signal()
+    job_cancel_requested = Signal(str)
+    job_pause_requested = Signal(str)
+    job_details_requested = Signal(str)
+
+    def __init__(
+        self,
+        pages: Optional[Iterable[ShellPageSpec]] = None,
+        rail_items: Optional[Iterable[ModeRailItemSpec]] = None,
+        parent=None,
+    ):
+        super().__init__(parent)
+        self.pages: List[ShellPageSpec] = list(pages or DEFAULT_SHELL_PAGES)
+        self._page_indexes: Dict[str, int] = {}
+        self._build_ui(rail_items)
+        self.set_current_mode("home")
+
+    def _build_ui(self, rail_items: Optional[Iterable[ModeRailItemSpec]]):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        self.main_splitter = QSplitter(Qt.Orientation.Horizontal, self)
+        self.main_splitter.setObjectName("ExperimentalAppShellMainSplitter")
+        self.main_splitter.setChildrenCollapsible(False)
+        root.addWidget(self.main_splitter, 1)
+
+        self.mode_rail = ModeRail(rail_items or DEFAULT_MODE_RAIL_ITEMS, self.main_splitter)
+        self.mode_rail.mode_requested.connect(self.set_current_mode)
+        self.main_splitter.addWidget(self.mode_rail)
+
+        self.center_stack = QStackedWidget(self.main_splitter)
+        self.center_stack.setObjectName("ExperimentalAppShellCenterStack")
+        self._populate_pages()
+        self.main_splitter.addWidget(self.center_stack)
+
+        self.editor_inspector = EditorInspector(parent=self.main_splitter)
+        self.editor_inspector.request_translation_assist.connect(self.translation_assist_requested.emit)
+        self.editor_inspector.request_ocr_rerun.connect(self.ocr_rerun_requested.emit)
+        self.editor_inspector.request_layout_review.connect(self.layout_review_requested.emit)
+        self.editor_inspector.request_typography_qa.connect(self.typography_qa_requested.emit)
+        self.main_splitter.addWidget(self.editor_inspector)
+        self.main_splitter.setStretchFactor(0, 0)
+        self.main_splitter.setStretchFactor(1, 1)
+        self.main_splitter.setStretchFactor(2, 0)
+
+        self.job_drawer = JobStatusDrawer(parent=self)
+        self.job_drawer.cancel_requested.connect(self.job_cancel_requested.emit)
+        self.job_drawer.pause_requested.connect(self.job_pause_requested.emit)
+        self.job_drawer.details_requested.connect(self.job_details_requested.emit)
+        root.addWidget(self.job_drawer, 0)
+
+    def _populate_pages(self):
+        for spec in self.pages:
+            if spec.key == "home":
+                page = WorkflowHomeWidget(parent=self.center_stack)
+                page.workflow_requested.connect(self.workflow_requested.emit)
+                page.workflow_requested.connect(self.set_current_mode)
+            else:
+                page = PlaceholderShellPage(spec, self.center_stack)
+            self._page_indexes[spec.key] = self.center_stack.addWidget(page)
+
+    def set_current_mode(self, key: str):
+        key = str(key or "home")
+        index = self._page_indexes.get(key)
+        if index is None:
+            index = self._page_indexes.get("home", 0)
+            key = "home"
+        self.center_stack.setCurrentIndex(index)
+        self.mode_rail.set_current_mode(key)
+        self.editor_inspector.setVisible(key in {"editor", "assist"})
+        self.mode_changed.emit(key)
+
+    def current_mode(self) -> str:
+        for key, index in self._page_indexes.items():
+            if index == self.center_stack.currentIndex():
+                return key
+        return ""
+
+    def page_keys(self) -> List[str]:
+        return [p.key for p in self.pages]
+
+    def save_splitter_state(self) -> bytes:
+        state = self.main_splitter.saveState()
+        return bytes(state)
+
+    def restore_splitter_state(self, data: bytes | QByteArray | None) -> bool:
+        if not data:
+            return False
+        if isinstance(data, QByteArray):
+            state = data
+        else:
+            state = QByteArray(data)
+        return bool(self.main_splitter.restoreState(state))
+
+    def refresh_jobs(self, jobs: Iterable[JobStatusSpec]):
+        self.job_drawer.refresh_jobs(jobs)

--- a/ui/experimental_shell_bootstrap.py
+++ b/ui/experimental_shell_bootstrap.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from qtpy.QtWidgets import QWidget
+
+from .dashboard_action_dispatcher import dispatch_dashboard_action, dispatch_message_for_result
+from .experimental_shell_menu import install_experimental_shell_preview_action
+
+
+def install_experimental_shell_ui_hooks(mainwindow: QWidget) -> bool:
+    """Install all safe experimental-shell hooks on a MainWindow-like object.
+
+    This helper is designed to be called once after the title bar / Diagnostics
+    menu exists. It keeps the actual MainWindow patch to a tiny guarded call:
+
+        try:
+            from ui.experimental_shell_bootstrap import install_experimental_shell_ui_hooks
+            install_experimental_shell_ui_hooks(self)
+        except Exception:
+            pass
+
+    The helper itself is safe to call more than once.
+    """
+    if mainwindow is None:
+        return False
+    action = install_experimental_shell_preview_action(mainwindow, mainwindow)
+    return action is not None
+
+
+def handle_experimental_dashboard_action(mainwindow: QWidget, mode: str, action: str) -> str:
+    """Dispatch a dashboard action and return a user-visible status string."""
+    result = dispatch_dashboard_action(mainwindow, mode, action)
+    return dispatch_message_for_result(result)
+
+
+def open_experimental_shell_preview_for(mainwindow: Optional[QWidget]):
+    """Open the preview dialog and connect safe dashboard dispatch if possible."""
+    from .experimental_shell_preview_dialog import ExperimentalShellPreviewDialog
+
+    dialog = ExperimentalShellPreviewDialog(mainwindow)
+    if mainwindow is not None:
+        def _dispatch(mode: str, action: str):
+            message = handle_experimental_dashboard_action(mainwindow, mode, action)
+            status = getattr(mainwindow, "statusBar", lambda: None)()
+            if status is not None and hasattr(status, "showMessage"):
+                status.showMessage(message, 5000)
+        dialog.dashboard_action_requested.connect(_dispatch)
+        setattr(mainwindow, "_experimental_shell_preview_dialog", dialog)
+    dialog.show()
+    return dialog

--- a/ui/experimental_shell_menu.py
+++ b/ui/experimental_shell_menu.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from qtpy.QtWidgets import QAction, QMenu, QWidget
+
+
+EXPERIMENTAL_SHELL_PREVIEW_ACTION_ID = "diagnostics.experimental_shell_preview"
+EXPERIMENTAL_SHELL_PREVIEW_TEXT = "Experimental advanced UI shell preview..."
+
+
+def _find_diagnostics_menu(owner: object) -> Optional[QMenu]:
+    """Best-effort diagnostics menu lookup for TitleBar/MainWindow-like owners."""
+    candidates = [owner]
+    for attr in ("titleBar", "titlebar", "title_bar"):
+        holder = getattr(owner, attr, None)
+        if holder is not None:
+            candidates.append(holder)
+    for obj in candidates:
+        btn = getattr(obj, "diagnosticsToolBtn", None)
+        if btn is not None and hasattr(btn, "menu"):
+            menu = btn.menu()
+            if isinstance(menu, QMenu):
+                return menu
+        menu = getattr(obj, "diagnosticsMenu", None)
+        if isinstance(menu, QMenu):
+            return menu
+    return None
+
+
+def _register_with_action_registry(owner: object, action: QAction):
+    """Best-effort action registry registration without depending on registry internals."""
+    candidates = [owner]
+    for attr in ("titleBar", "titlebar", "title_bar"):
+        holder = getattr(owner, attr, None)
+        if holder is not None:
+            candidates.append(holder)
+    for obj in candidates:
+        registry = getattr(obj, "_action_registry", None) or getattr(obj, "action_registry", None)
+        if registry is None:
+            continue
+        # Prefer a specific register method when present. If not, the existing
+        # menu-tree scan will discover the QAction once it is added to the menu.
+        for method_name in ("register_action", "add_action"):
+            method = getattr(registry, method_name, None)
+            if callable(method):
+                try:
+                    method(
+                        action_id=EXPERIMENTAL_SHELL_PREVIEW_ACTION_ID,
+                        action=action,
+                        label=EXPERIMENTAL_SHELL_PREVIEW_TEXT,
+                        category="Diagnostics",
+                        workflow_mode="diagnostics",
+                    )
+                    return True
+                except TypeError:
+                    try:
+                        method(EXPERIMENTAL_SHELL_PREVIEW_ACTION_ID, action)
+                        return True
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+    return False
+
+
+def install_experimental_shell_preview_action(owner: QWidget, parent: Optional[QWidget] = None) -> Optional[QAction]:
+    """Install a Diagnostics menu action that opens the experimental shell preview.
+
+    This installer is intentionally separate from `mainwindowbars.py` so the
+    preview command can be introduced without replacing a large title-bar file.
+    It is safe to call more than once: if an action with the same text already
+    exists in the diagnostics menu, that action is returned.
+    """
+    menu = _find_diagnostics_menu(owner)
+    if menu is None:
+        return None
+
+    for existing in menu.actions() or []:
+        if (existing.text() or "").replace("&", "").strip() == EXPERIMENTAL_SHELL_PREVIEW_TEXT:
+            return existing
+
+    action_parent = parent or owner
+    action = QAction(EXPERIMENTAL_SHELL_PREVIEW_TEXT, action_parent)
+    action.setObjectName("ExperimentalShellPreviewAction")
+    action.setToolTip("Open the modern advanced UI shell preview without replacing the current editor.")
+
+    def _open_preview():
+        try:
+            from .experimental_shell_preview_dialog import ExperimentalShellPreviewDialog
+            dialog = ExperimentalShellPreviewDialog(owner)
+            setattr(owner, "_experimental_shell_preview_dialog", dialog)
+            dialog.show()
+        except Exception as exc:
+            try:
+                from qtpy.QtWidgets import QMessageBox
+                QMessageBox.warning(owner, "Experimental shell preview", f"Failed to open preview: {exc}")
+            except Exception:
+                raise
+
+    action.triggered.connect(_open_preview)
+    menu.addSeparator()
+    menu.addAction(action)
+    setattr(owner, "experimental_shell_preview_trigger", action.triggered)
+    _register_with_action_registry(owner, action)
+    return action

--- a/ui/experimental_shell_preview_dialog.py
+++ b/ui/experimental_shell_preview_dialog.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QDialog, QHBoxLayout, QLabel, QPushButton, QVBoxLayout, QWidget
+
+from .design_tokens import TOKENS, badge_style, card_style, primary_button_style, secondary_button_style
+from .experimental_app_shell import ExperimentalAppShell
+from .job_status_drawer import JobStatusSpec
+
+
+class ExperimentalShellPreviewDialog(QDialog):
+    """Safe preview window for the advanced modern app shell.
+
+    This dialog deliberately does not replace MainWindow. It lets developers and
+    testers open the Dango-inspired, professional shell layout while keeping the
+    production editor untouched.
+    """
+
+    dashboard_action_requested = Signal(str, str)
+    workflow_requested = Signal(str)
+    mode_changed = Signal(str)
+    translation_assist_requested = Signal()
+    ocr_rerun_requested = Signal()
+    layout_review_requested = Signal()
+    typography_qa_requested = Signal()
+    job_cancel_requested = Signal(str)
+    job_pause_requested = Signal(str)
+    job_details_requested = Signal(str)
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.setObjectName("ExperimentalShellPreviewDialog")
+        self.setWindowTitle(self.tr("Experimental Advanced UI Shell Preview"))
+        self.resize(1320, 860)
+        self._build_ui()
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg)
+        root.setSpacing(TOKENS.spacing.md)
+
+        header = QVBoxLayout()
+        title_row = QHBoxLayout()
+        title = QLabel(self.tr("Advanced UI shell preview"), self)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.headline}px; font-weight: 900; color: {TOKENS.colors.text};")
+        title_row.addWidget(title, 1)
+        badge = QLabel(self.tr("Experimental"), self)
+        badge.setStyleSheet(badge_style("experimental"))
+        title_row.addWidget(badge)
+        header.addLayout(title_row)
+
+        subtitle = QLabel(
+            self.tr(
+                "Preview the modern, dense, professional shell without replacing the existing editor. "
+                "Actions route through safe dispatcher hooks when wired."
+            ),
+            self,
+        )
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted};")
+        header.addWidget(subtitle)
+        root.addLayout(header)
+
+        self.shell = ExperimentalAppShell(self)
+        self.shell.workflow_requested.connect(self.workflow_requested.emit)
+        self.shell.dashboard_action_requested.connect(self.dashboard_action_requested.emit)
+        self.shell.mode_changed.connect(self.mode_changed.emit)
+        self.shell.translation_assist_requested.connect(self.translation_assist_requested.emit)
+        self.shell.ocr_rerun_requested.connect(self.ocr_rerun_requested.emit)
+        self.shell.layout_review_requested.connect(self.layout_review_requested.emit)
+        self.shell.typography_qa_requested.connect(self.typography_qa_requested.emit)
+        self.shell.job_cancel_requested.connect(self.job_cancel_requested.emit)
+        self.shell.job_pause_requested.connect(self.job_pause_requested.emit)
+        self.shell.job_details_requested.connect(self.job_details_requested.emit)
+        root.addWidget(self.shell, 1)
+
+        footer = QHBoxLayout()
+        warning = QLabel(self.tr("This is a preview surface. Legacy menus and the existing editor remain the source of truth."), self)
+        warning.setWordWrap(True)
+        warning.setStyleSheet(card_style(TOKENS.colors.warning, elevated=False))
+        footer.addWidget(warning, 1)
+
+        self.sample_jobs_btn = QPushButton(self.tr("Add sample jobs"), self)
+        self.sample_jobs_btn.setStyleSheet(secondary_button_style())
+        self.sample_jobs_btn.clicked.connect(self.add_sample_jobs)
+        footer.addWidget(self.sample_jobs_btn)
+
+        close_btn = QPushButton(self.tr("Close"), self)
+        close_btn.setStyleSheet(primary_button_style("home"))
+        close_btn.clicked.connect(self.accept)
+        footer.addWidget(close_btn)
+        root.addLayout(footer)
+
+    def set_current_mode(self, mode: str):
+        self.shell.set_current_mode(mode)
+
+    def refresh_jobs(self, jobs: Iterable[JobStatusSpec]):
+        self.shell.refresh_jobs(jobs)
+
+    def add_sample_jobs(self):
+        self.refresh_jobs(
+            [
+                JobStatusSpec(
+                    job_id="sample-ocr",
+                    title=self.tr("OCR current page"),
+                    kind="OCR",
+                    status="running",
+                    progress=42,
+                    detail=self.tr("Running selected OCR provider on detected text blocks."),
+                    can_cancel=True,
+                ),
+                JobStatusSpec(
+                    job_id="sample-export",
+                    title=self.tr("Export proof pack"),
+                    kind="Export",
+                    status="warning",
+                    progress=78,
+                    detail=self.tr("Preparing reviewer assets and manifest."),
+                    can_cancel=True,
+                    warnings=[self.tr("2 blocks may overflow their bubbles"), self.tr("1 missing font fallback")],
+                ),
+            ]
+        )
+
+
+def open_experimental_shell_preview(parent: Optional[QWidget] = None) -> ExperimentalShellPreviewDialog:
+    dialog = ExperimentalShellPreviewDialog(parent)
+    dialog.show()
+    return dialog

--- a/ui/experimental_shell_settings.py
+++ b/ui/experimental_shell_settings.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+EXPERIMENTAL_APP_SHELL_KEY = "enable_experimental_app_shell"
+EXPERIMENTAL_MODE_RAIL_KEY = "enable_experimental_mode_rail"
+EXPERIMENTAL_EDITOR_INSPECTOR_KEY = "enable_experimental_editor_inspector"
+EXPERIMENTAL_JOB_DRAWER_KEY = "enable_experimental_job_drawer"
+EXPERIMENTAL_SHELL_MODE_KEY = "experimental_shell_initial_mode"
+EXPERIMENTAL_SHELL_SPLITTER_KEY = "experimental_shell_splitter_state"
+
+VALID_SHELL_MODES = {
+    "home",
+    "editor",
+    "live",
+    "quick_image",
+    "downloader",
+    "batch",
+    "assist",
+    "models",
+    "settings",
+    "diagnostics",
+}
+
+
+@dataclass(frozen=True)
+class ExperimentalShellSettings:
+    enable_app_shell: bool = False
+    enable_mode_rail: bool = False
+    enable_editor_inspector: bool = False
+    enable_job_drawer: bool = False
+    initial_mode: str = "home"
+    splitter_state: str = ""
+
+    def as_config_patch(self) -> dict:
+        return {
+            EXPERIMENTAL_APP_SHELL_KEY: self.enable_app_shell,
+            EXPERIMENTAL_MODE_RAIL_KEY: self.enable_mode_rail,
+            EXPERIMENTAL_EDITOR_INSPECTOR_KEY: self.enable_editor_inspector,
+            EXPERIMENTAL_JOB_DRAWER_KEY: self.enable_job_drawer,
+            EXPERIMENTAL_SHELL_MODE_KEY: self.initial_mode,
+            EXPERIMENTAL_SHELL_SPLITTER_KEY: self.splitter_state,
+        }
+
+
+def _get_bool(source: Any, key: str, default: bool) -> bool:
+    if isinstance(source, Mapping):
+        return bool(source.get(key, default))
+    return bool(getattr(source, key, default))
+
+
+def _get_str(source: Any, key: str, default: str) -> str:
+    if isinstance(source, Mapping):
+        value = source.get(key, default)
+    else:
+        value = getattr(source, key, default)
+    return str(value or default)
+
+
+def normalize_shell_mode(mode: str) -> str:
+    value = str(mode or "home").strip().lower()
+    return value if value in VALID_SHELL_MODES else "home"
+
+
+def read_experimental_shell_settings(source: Any) -> ExperimentalShellSettings:
+    return ExperimentalShellSettings(
+        enable_app_shell=_get_bool(source, EXPERIMENTAL_APP_SHELL_KEY, False),
+        enable_mode_rail=_get_bool(source, EXPERIMENTAL_MODE_RAIL_KEY, False),
+        enable_editor_inspector=_get_bool(source, EXPERIMENTAL_EDITOR_INSPECTOR_KEY, False),
+        enable_job_drawer=_get_bool(source, EXPERIMENTAL_JOB_DRAWER_KEY, False),
+        initial_mode=normalize_shell_mode(_get_str(source, EXPERIMENTAL_SHELL_MODE_KEY, "home")),
+        splitter_state=_get_str(source, EXPERIMENTAL_SHELL_SPLITTER_KEY, ""),
+    )
+
+
+def ensure_experimental_shell_defaults(config_obj: Any) -> ExperimentalShellSettings:
+    """Apply in-memory defaults to a config-like object and return normalized settings.
+
+    This is intentionally separate from `utils.config.ProgramConfig` so the
+    experimental shell can iterate without risky broad config rewrites.  A later
+    migration patch can add these fields to ProgramConfig and call this helper
+    during load.
+    """
+    settings = read_experimental_shell_settings(config_obj)
+    for key, value in settings.as_config_patch().items():
+        if not hasattr(config_obj, key):
+            try:
+                setattr(config_obj, key, value)
+            except Exception:
+                pass
+    return settings
+
+
+def shell_feature_flags(settings: ExperimentalShellSettings | Mapping[str, Any] | Any) -> dict:
+    if not isinstance(settings, ExperimentalShellSettings):
+        settings = read_experimental_shell_settings(settings)
+    return {
+        "app_shell": settings.enable_app_shell,
+        "mode_rail": settings.enable_app_shell or settings.enable_mode_rail,
+        "editor_inspector": settings.enable_app_shell or settings.enable_editor_inspector,
+        "job_drawer": settings.enable_app_shell or settings.enable_job_drawer,
+    }
+
+
+def allowed_shell_modes() -> Iterable[str]:
+    return tuple(sorted(VALID_SHELL_MODES))

--- a/ui/job_status_drawer.py
+++ b/ui/job_status_drawer.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QListWidget,
+    QListWidgetItem,
+    QProgressBar,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .design_tokens import TOKENS, badge_style, card_style
+
+
+@dataclass(frozen=True)
+class JobStatusSpec:
+    job_id: str
+    title: str
+    kind: str = "pipeline"
+    status: str = "idle"
+    progress: int = 0
+    detail: str = ""
+    can_cancel: bool = False
+    can_pause: bool = False
+    warnings: List[str] = field(default_factory=list)
+
+
+class JobStatusRow(QFrame):
+    cancel_requested = Signal(str)
+    pause_requested = Signal(str)
+    details_requested = Signal(str)
+
+    def __init__(self, spec: JobStatusSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName("JobStatusRow")
+        self.setStyleSheet(card_style())
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md)
+        layout.setSpacing(TOKENS.spacing.sm)
+
+        header = QHBoxLayout()
+        title = QLabel(self.spec.title)
+        title.setObjectName("JobStatusTitle")
+        title.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; font-weight: 700;")
+        header.addWidget(title, 1)
+
+        kind = QLabel(self.spec.kind)
+        kind.setStyleSheet(badge_style("idle"))
+        header.addWidget(kind)
+
+        status = QLabel(self.spec.status)
+        status.setStyleSheet(badge_style(self.spec.status))
+        header.addWidget(status)
+        layout.addLayout(header)
+
+        self.progress = QProgressBar(self)
+        self.progress.setRange(0, 100)
+        self.progress.setValue(max(0, min(100, int(self.spec.progress))))
+        layout.addWidget(self.progress)
+
+        if self.spec.detail:
+            detail = QLabel(self.spec.detail)
+            detail.setWordWrap(True)
+            detail.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+            layout.addWidget(detail)
+
+        if self.spec.warnings:
+            warning = QLabel("; ".join(str(w) for w in self.spec.warnings[:3]))
+            warning.setWordWrap(True)
+            warning.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.warning};")
+            layout.addWidget(warning)
+
+        actions = QHBoxLayout()
+        actions.addStretch(1)
+        details_btn = QPushButton(self.tr("Details"), self)
+        details_btn.clicked.connect(lambda: self.details_requested.emit(self.spec.job_id))
+        actions.addWidget(details_btn)
+        if self.spec.can_pause:
+            pause_btn = QPushButton(self.tr("Pause"), self)
+            pause_btn.clicked.connect(lambda: self.pause_requested.emit(self.spec.job_id))
+            actions.addWidget(pause_btn)
+        if self.spec.can_cancel:
+            cancel_btn = QPushButton(self.tr("Cancel"), self)
+            cancel_btn.clicked.connect(lambda: self.cancel_requested.emit(self.spec.job_id))
+            actions.addWidget(cancel_btn)
+        layout.addLayout(actions)
+
+
+class JobStatusDrawer(QWidget):
+    """Bottom job/status drawer for long-running workflows.
+
+    This is a shell component for OCR, translation, inpaint, render, export,
+    raw download, live translation, model download, batch queue, and Translation
+    Assist provider jobs.  It is standalone so it can be introduced beside the
+    legacy progress UI before becoming the final bottom drawer.
+    """
+
+    cancel_requested = Signal(str)
+    pause_requested = Signal(str)
+    details_requested = Signal(str)
+    clear_completed_requested = Signal()
+
+    def __init__(self, jobs: Optional[Iterable[JobStatusSpec]] = None, parent=None):
+        super().__init__(parent)
+        self._jobs: Dict[str, JobStatusSpec] = {j.job_id: j for j in (jobs or [])}
+        self._rows: Dict[str, JobStatusRow] = {}
+        self._expanded = True
+        self._build_ui()
+        self.refresh_jobs(self._jobs.values())
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(TOKENS.spacing.sm, TOKENS.spacing.sm, TOKENS.spacing.sm, TOKENS.spacing.sm)
+        root.setSpacing(TOKENS.spacing.sm)
+
+        header = QHBoxLayout()
+        self.toggle_btn = QToolButton(self)
+        self.toggle_btn.setText("▾")
+        self.toggle_btn.setToolTip(self.tr("Show or hide job details"))
+        self.toggle_btn.clicked.connect(self.toggle_expanded)
+        header.addWidget(self.toggle_btn)
+
+        title = QLabel(self.tr("Jobs & Status"), self)
+        title.setObjectName("JobStatusDrawerTitle")
+        title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 700;")
+        header.addWidget(title)
+
+        self.summary = QLabel(self.tr("No active jobs"), self)
+        self.summary.setStyleSheet(f"color: {TOKENS.colors.text_muted};")
+        header.addWidget(self.summary, 1)
+
+        clear_btn = QPushButton(self.tr("Clear completed"), self)
+        clear_btn.clicked.connect(self.clear_completed_requested.emit)
+        header.addWidget(clear_btn)
+        root.addLayout(header)
+
+        self.list_widget = QListWidget(self)
+        self.list_widget.setObjectName("JobStatusList")
+        root.addWidget(self.list_widget)
+
+    def refresh_jobs(self, jobs: Iterable[JobStatusSpec]):
+        self._jobs = {j.job_id: j for j in jobs}
+        self.list_widget.clear()
+        self._rows.clear()
+        for job in self._jobs.values():
+            item = QListWidgetItem(self.list_widget)
+            row = JobStatusRow(job, self.list_widget)
+            row.cancel_requested.connect(self.cancel_requested.emit)
+            row.pause_requested.connect(self.pause_requested.emit)
+            row.details_requested.connect(self.details_requested.emit)
+            item.setSizeHint(row.sizeHint())
+            self.list_widget.addItem(item)
+            self.list_widget.setItemWidget(item, row)
+            self._rows[job.job_id] = row
+        self._update_summary()
+
+    def upsert_job(self, job: JobStatusSpec):
+        jobs = dict(self._jobs)
+        jobs[job.job_id] = job
+        self.refresh_jobs(jobs.values())
+
+    def remove_job(self, job_id: str):
+        jobs = dict(self._jobs)
+        jobs.pop(job_id, None)
+        self.refresh_jobs(jobs.values())
+
+    def toggle_expanded(self):
+        self.set_expanded(not self._expanded)
+
+    def set_expanded(self, expanded: bool):
+        self._expanded = bool(expanded)
+        self.list_widget.setVisible(self._expanded)
+        self.toggle_btn.setText("▾" if self._expanded else "▸")
+
+    def job_ids(self) -> List[str]:
+        return list(self._jobs.keys())
+
+    def _update_summary(self):
+        total = len(self._jobs)
+        if total == 0:
+            self.summary.setText(self.tr("No active jobs"))
+            return
+        running = sum(1 for job in self._jobs.values() if str(job.status).lower() in {"running", "capturing", "ocr", "translating", "exporting"})
+        warnings = sum(1 for job in self._jobs.values() if job.warnings or str(job.status).lower() in {"warning", "error"})
+        self.summary.setText(self.tr("{running} running · {total} total · {warnings} need attention").format(running=running, total=total, warnings=warnings))

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -110,6 +110,7 @@ from utils.automation_jobs import new_job, append_log, add_warning, set_status, 
 from utils.workflow_presets import apply_workflow_preset, list_workflow_presets, workflow_stage_vector
 from utils.model_manager import get_available_module_keys
 from utils.realtime_mode import RealtimeService, RealtimeRegion
+from utils.feature_matrix import feature_matrix_text
 from utils.translation_assist import (
     TranslationAssistService,
     build_candidates_from_sources,
@@ -293,6 +294,10 @@ class MainWindow(mainwindow_cls):
         self.setupConfig()
         self.setupShortcuts()
         self.setupRegisterWidget()
+        try:
+            self.titleBar.apply_legacy_menu_layout(bool(getattr(pcfg, "show_legacy_menus", True)))
+        except Exception:
+            pass
         self.st_manager.layout_review_local_api_handler = self._layout_review_local_api_handler
         self.st_manager.layout_review_cloud_api_handler = self._layout_review_cloud_api_handler
         self._recover_window_geometry_if_offscreen()
@@ -303,25 +308,20 @@ class MainWindow(mainwindow_cls):
         force_welcome = bool(getattr(shared, 'FORCE_SHOW_WELCOME_ON_STARTUP', False))
         explicit_start_target = bool(open_dir and str(open_dir).strip())
 
-        # Startup routing:
-        # - explicit CLI/file target always wins
-        # - otherwise, respect the welcome preference
-        # - otherwise, try the first valid recent project
-        # - if nothing opens, always fall back to the welcome screen
         if explicit_start_target and osp.exists(open_dir):
             if osp.isfile(open_dir) and open_dir.lower().endswith('.json'):
                 self.openJsonProj(open_dir)
             else:
                 self.OpenProj(open_dir)
-        elif not force_welcome and not bool(getattr(pcfg, 'show_welcome_screen', True)) and pcfg.open_recent_on_startup:
-            for proj_dir in list(getattr(self.leftBar, 'recent_proj_list', []) or []):
-                if proj_dir and osp.exists(proj_dir):
-                    self.OpenProj(proj_dir)
-                    break
+            self._record_recent_workflow('editor')
+            self.titleBar.set_workflow_hint("editor")
+        elif not force_welcome:
+            self._open_startup_mode_target(getattr(pcfg, 'startup_mode', 'last_used'))
 
         if not (shared.HEADLESS or shared.HEADLESS_CONTINUOUS):
-            if force_welcome or not self._has_open_project():
+            if force_welcome or (not self._has_open_project() and not self._showing_welcome_screen):
                 self._show_welcome_screen()
+                self._record_recent_workflow('home')
                 shared.FORCE_SHOW_WELCOME_ON_STARTUP = False
 
         if shared.HEADLESS or shared.HEADLESS_CONTINUOUS:
@@ -568,6 +568,16 @@ class MainWindow(mainwindow_cls):
         self.welcomeWidget.open_images_requested.connect(self.leftBar.onOpenImages)
         self.welcomeWidget.open_acbf_requested.connect(self.leftBar.onOpenACBFCBZ)
         self.welcomeWidget.recent_project_clicked.connect(self._welcome_recent_clicked)
+        if hasattr(self.welcomeWidget, 'open_live_requested'):
+            self.welcomeWidget.open_live_requested.connect(self.on_open_realtime_translator)
+        if hasattr(self.welcomeWidget, 'open_downloader_requested'):
+            self.welcomeWidget.open_downloader_requested.connect(self.on_open_manga_source)
+        if hasattr(self.welcomeWidget, 'open_batch_requested'):
+            self.welcomeWidget.open_batch_requested.connect(self.on_open_batch_queue)
+        if hasattr(self.welcomeWidget, 'open_models_requested'):
+            self.welcomeWidget.open_models_requested.connect(self.on_open_manage_models)
+        if hasattr(self.welcomeWidget, 'open_diagnostics_requested'):
+            self.welcomeWidget.open_diagnostics_requested.connect(self.on_environment_doctor)
 
         self.titleBar = TitleBar(self)
         self.titleBar.closebtn_clicked.connect(self.on_closebtn_clicked)
@@ -898,6 +908,9 @@ class MainWindow(mainwindow_cls):
         self.configPanel.darkmode_changed.connect(self.on_config_darkmode_changed)
         self.configPanel.custom_cursor_changed.connect(self._on_config_custom_cursor_changed)
         self.configPanel.display_lang_changed.connect(self.on_display_lang_changed)
+        self.configPanel.ui_mode_changed.connect(self._on_ui_mode_changed)
+        self.configPanel.omni_options_changed.connect(self._on_omni_options_changed)
+        self.configPanel.legacy_menu_layout_changed.connect(self._on_legacy_menu_layout_changed)
         self.configPanel.dev_mode_changed.connect(self.on_dev_mode_changed)
         self.configPanel.manual_mode_changed.connect(self._update_run_button_tooltip)
         if pcfg.let_show_only_custom_fonts_flag:
@@ -1107,6 +1120,17 @@ class MainWindow(mainwindow_cls):
     def _realtime_service(self) -> RealtimeService:
         if not hasattr(self, '_realtime_service_obj') or self._realtime_service_obj is None:
             self._realtime_service_obj = RealtimeService()
+            try:
+                rect = list(getattr(pcfg, 'realtime_region_rect', [0, 0, 100, 100]) or [0, 0, 100, 100])
+                while len(rect) < 4:
+                    rect.append(0)
+                self._realtime_service_obj.apply_defaults(
+                    rect=(int(rect[0]), int(rect[1]), int(rect[2]), int(rect[3])),
+                    profile=str(getattr(pcfg, 'realtime_profile_id', 'generic_screen_ocr') or 'generic_screen_ocr'),
+                    follow_window=bool(getattr(pcfg, 'realtime_follow_window', False)),
+                )
+            except Exception:
+                pass
         return self._realtime_service_obj
 
     def _api_realtime_status(self, body: dict):
@@ -1125,13 +1149,30 @@ class MainWindow(mainwindow_cls):
                 rid = str((_b or {}).get('region_id', '') or '').strip() or f"region_{len(svc.regions)+1}"
                 rect = tuple((_b or {}).get('rect', [0, 0, 640, 360])[:4])
                 profile = str((_b or {}).get('profile', 'chrome_manhua_reader') or 'chrome_manhua_reader')
-                svc.regions[rid] = RealtimeRegion(region_id=rid, rect=rect, profile=profile)
+                follow_window = bool((_b or {}).get('follow_window', False))
+                window_id = str((_b or {}).get('window_id', '') or '')
+                svc.regions[rid] = RealtimeRegion(region_id=rid, rect=rect, profile=profile, follow_window=follow_window, window_id=window_id)
                 return {'ok': True, 'region': vars(svc.regions[rid])}
             if action == 'delete':
                 rid = str((_b or {}).get('region_id', '') or '').strip()
                 svc.regions.pop(rid, None)
                 return {'ok': True, 'deleted': rid}
-            raise ValueError('realtime_regions action must be list|add|delete')
+            if action == 'update':
+                rid = str((_b or {}).get('region_id', '') or '').strip()
+                if rid not in svc.regions:
+                    raise ValueError('realtime region not found')
+                region = svc.regions[rid]
+                if 'rect' in (_b or {}):
+                    rect = tuple((_b or {}).get('rect', list(region.rect))[:4])
+                    region.rect = rect
+                if 'profile' in (_b or {}):
+                    region.profile = str((_b or {}).get('profile', region.profile) or region.profile)
+                if 'follow_window' in (_b or {}):
+                    region.follow_window = bool((_b or {}).get('follow_window', region.follow_window))
+                if 'window_id' in (_b or {}):
+                    region.window_id = str((_b or {}).get('window_id', region.window_id) or "")
+                return {'ok': True, 'region': vars(region)}
+            raise ValueError('realtime_regions action must be list|add|delete|update')
         return self._api_call_ui(_ui, body)
 
     def _api_realtime_start(self, body: dict):
@@ -1144,13 +1185,29 @@ class MainWindow(mainwindow_cls):
         return self._api_call_ui(lambda _b: {'ok': True, **self._set_realtime_enabled(False), 'stopped': True}, body)
 
     def _api_realtime_translate_now(self, body: dict):
-        return self._api_call_ui(lambda _b: {'ok': True, 'status': 'queued_manual_tick'}, body)
+        def _ui(_b: dict):
+            svc = self._realtime_service()
+            rid = str((_b or {}).get('region_id', 'default') or 'default')
+            return {'ok': True, **svc.tick_region(region_id=rid)}
+        return self._api_call_ui(_ui, body)
 
     def _api_realtime_profiles(self, body: dict):
         return self._api_call_ui(lambda _b: {'profiles': list(self._realtime_service().profiles.values())}, body)
 
     def _set_realtime_enabled(self, enabled: bool):
         svc = self._realtime_service()
+        if enabled:
+            try:
+                rect = list(getattr(pcfg, 'realtime_region_rect', [0, 0, 100, 100]) or [0, 0, 100, 100])
+                while len(rect) < 4:
+                    rect.append(0)
+                svc.apply_defaults(
+                    rect=(int(rect[0]), int(rect[1]), int(rect[2]), int(rect[3])),
+                    profile=str(getattr(pcfg, 'realtime_profile_id', 'generic_screen_ocr') or 'generic_screen_ocr'),
+                    follow_window=bool(getattr(pcfg, 'realtime_follow_window', False)),
+                )
+            except Exception:
+                pass
         svc.enabled = bool(enabled)
         return svc.status()
 
@@ -3581,6 +3638,8 @@ class MainWindow(mainwindow_cls):
                 checker.blockSignals(False)
 
     def setupImgTransUI(self):
+        self._record_recent_workflow('editor')
+        self.titleBar.set_workflow_hint("editor")
         # The imgtrans checker can be toggled during startup by setupConfig() or
         # LeftBar.stateCheckerChanged(). Never show an empty canvas when no
         # project is loaded; route back to welcome instead.
@@ -3601,6 +3660,8 @@ class MainWindow(mainwindow_cls):
             self.leftStackWidget.hide()
 
     def setupConfigUI(self):
+        self._record_recent_workflow('settings')
+        self.titleBar.set_workflow_hint("settings")
         self._set_leftbar_mode('config')
         self.centralStackWidget.setCurrentIndex(2)
         self.bottomBar.setPipelineVisible(False)
@@ -3627,6 +3688,7 @@ class MainWindow(mainwindow_cls):
     def _show_welcome_screen(self):
         """Switch to welcome screen and refresh recent list."""
         self._showing_welcome_screen = True
+        self.titleBar.set_workflow_hint("home")
         self._set_leftbar_mode(None)
         if hasattr(self, 'welcomeWidget'):
             self.welcomeWidget.set_recent_projects(getattr(self.leftBar, 'recent_proj_list', []) or [])
@@ -4012,6 +4074,8 @@ class MainWindow(mainwindow_cls):
         self.titleBar.manga_source_trigger.connect(self.on_open_manga_source)
         if hasattr(self.titleBar, "realtime_translator_trigger"):
             self.titleBar.realtime_translator_trigger.connect(self.on_open_realtime_translator)
+        if hasattr(self.titleBar, "feature_matrix_trigger"):
+            self.titleBar.feature_matrix_trigger.connect(self.on_show_feature_matrix)
         if hasattr(self.titleBar, "translation_assist_trigger"):
             self.titleBar.translation_assist_trigger.connect(self.on_open_translation_assist_dock)
         self.titleBar.batch_queue_trigger.connect(self.on_open_batch_queue)
@@ -4042,6 +4106,10 @@ class MainWindow(mainwindow_cls):
         self.titleBar.runtime_resource_summary_trigger.connect(self.on_runtime_resource_summary)
         self.titleBar.export_startup_diag_trigger.connect(self.on_export_startup_report)
         self.titleBar.open_log_folder_trigger.connect(self.on_open_log_folder)
+        if hasattr(self.titleBar, "export_action_registry_trigger"):
+            self.titleBar.export_action_registry_trigger.connect(self.on_export_action_registry)
+        if hasattr(self.titleBar, "validate_action_registry_trigger"):
+            self.titleBar.validate_action_registry_trigger.connect(self.on_validate_action_registry)
         self.titleBar.relaunch_pyqt5_trigger.connect(self.on_relaunch_pyqt5_safe_mode)
         self.titleBar.relaunch_cpu_only_trigger.connect(self.on_relaunch_cpu_only_safe_mode)
         self.titleBar.release_model_caches_trigger.connect(self.on_release_model_caches)
@@ -4214,6 +4282,9 @@ class MainWindow(mainwindow_cls):
         from .theme_customizer_dialog import ThemeCustomizerDialog
         dlg = ThemeCustomizerDialog(self)
         dlg.theme_applied.connect(self._on_theme_customizer_applied)
+        dlg.ui_mode_changed.connect(self._on_ui_mode_changed)
+        if hasattr(dlg, "startup_mode_changed"):
+            dlg.startup_mode_changed.connect(self._on_startup_mode_changed)
         dlg.show()
 
     def _on_theme_customizer_applied(self, font_family: str, font_size: int):
@@ -4221,6 +4292,36 @@ class MainWindow(mainwindow_cls):
         self.titleBar.themeDarkAction.setChecked(pcfg.darkmode)
         self.resetStyleSheet()
         # Font is applied in resetStyleSheet() -> _apply_app_font() (pcfg already saved by dialog)
+
+    def _on_ui_mode_changed(self, mode: str):
+        pcfg.ui_mode = str(mode or "advanced")
+        try:
+            self.titleBar.apply_ui_mode_visibility(pcfg.ui_mode)
+        except Exception:
+            pass
+
+    def _on_omni_options_changed(self):
+        try:
+            self.titleBar._omni_actions_cache = None
+            if hasattr(self.titleBar, '_omniShowUnavailable'):
+                self.titleBar._omniShowUnavailable.setChecked(bool(getattr(pcfg, 'omni_show_unavailable', False)))
+            if hasattr(self.titleBar, '_omniTypeFilter'):
+                _tf = str(getattr(pcfg, 'omni_result_type_filter', 'all') or 'all')
+                _tidx = self.titleBar._omniTypeFilter.findData(_tf)
+                self.titleBar._omniTypeFilter.setCurrentIndex(_tidx if _tidx >= 0 else 0)
+        except Exception:
+            pass
+
+    def _on_legacy_menu_layout_changed(self, enabled: bool):
+        try:
+            self.titleBar.apply_legacy_menu_layout(bool(enabled))
+            self.titleBar._omni_actions_cache = None
+        except Exception:
+            pass
+
+    def _on_startup_mode_changed(self, mode: str):
+        pcfg.startup_mode = str(mode or "last_used")
+        self._show_status_message(self.tr('Startup mode set to: {0}').format(pcfg.startup_mode), 4000)
 
     def on_help_documentation(self):
         """Open project README (#126 Help menu)."""
@@ -5248,15 +5349,25 @@ class MainWindow(mainwindow_cls):
 
     def on_texteditlist_contextmenu_requested(self, pos: QPoint, from_empty: bool = True, block_idx: int = -1):
         menu = QMenu(self)
+        ui_mode = str(getattr(pcfg, "ui_mode", "advanced") or "advanced").lower()
+        is_simple = ui_mode == "simple"
         jump_act = None
-        compare_tr_act = menu.addAction(self.tr("Compare translation providers"))
-        compare_ocr_act = menu.addAction(self.tr("Compare OCR engines"))
-        compare_det_act = menu.addAction(self.tr("Compare detectors"))
-        compare_inp_act = menu.addAction(self.tr("Compare inpainters"))
-        menu.addSeparator()
-        open_assist_act = menu.addAction(self.tr("Open Translation Assist"))
+        compare_tr_act = compare_ocr_act = compare_det_act = compare_inp_act = None
+
+        translation_menu = menu.addMenu(self.tr("Translation"))
+        open_assist_act = translation_menu.addAction(self.tr("Open Translation Assist"))
+        compare_tr_act = translation_menu.addAction(self.tr("Compare translation providers"))
+
+        ocr_menu = menu.addMenu(self.tr("OCR"))
+        compare_ocr_act = ocr_menu.addAction(self.tr("Compare OCR engines"))
+
+        if not is_simple:
+            debug_menu = menu.addMenu(self.tr("Debug"))
+            compare_det_act = debug_menu.addAction(self.tr("Compare detectors"))
+            compare_inp_act = debug_menu.addAction(self.tr("Compare inpainters"))
         if not from_empty and block_idx >= 0:
-            jump_act = menu.addAction(self.tr("Jump to block on canvas"))
+            layout_menu = menu.addMenu(self.tr("Layout"))
+            jump_act = layout_menu.addAction(self.tr("Jump to block on canvas"))
         rst = menu.exec_(pos)
         if rst is None:
             return
@@ -5357,6 +5468,93 @@ class MainWindow(mainwindow_cls):
     def show_OCR_keyword_window(self):
         self.ocrSubWidget.show()
 
+    def _normalize_workflow_id(self, workflow_id: str) -> str:
+        wid = str(workflow_id or "").strip().lower()
+        alias = {
+            "model": "models",
+            "diag": "diagnostics",
+            "download": "downloader",
+        }
+        wid = alias.get(wid, wid)
+        allowed = {"home", "editor", "settings", "live", "downloader", "batch", "models", "diagnostics"}
+        return wid if wid in allowed else ""
+
+    def _record_recent_workflow(self, workflow_id: str):
+        wid = self._normalize_workflow_id(workflow_id)
+        if not wid:
+            return
+        cur = list(getattr(pcfg, 'recent_workflows', []) or [])
+        cur = [self._normalize_workflow_id(w) for w in cur]
+        cur = [w for w in cur if w and w != wid]
+        cur.insert(0, wid)
+        pcfg.recent_workflows = cur[:12]
+        try:
+            self.titleBar.set_workflow_hint(wid)
+        except Exception:
+            pass
+
+    def _open_startup_mode_target(self, startup_mode: str) -> bool:
+        mode = self._normalize_workflow_id(startup_mode) or "last_used"
+        if mode == 'home':
+            self._show_welcome_screen()
+            self._record_recent_workflow('home')
+            return True
+        if mode == 'live':
+            self.on_open_realtime_translator()
+            self._record_recent_workflow('live')
+            self.titleBar.set_workflow_hint("live")
+            return True
+        if mode == 'downloader':
+            self.on_open_manga_source()
+            self._record_recent_workflow('downloader')
+            self.titleBar.set_workflow_hint("downloader")
+            return True
+        if mode == 'settings':
+            self.setupConfigUI()
+            self._record_recent_workflow('settings')
+            self.titleBar.set_workflow_hint("settings")
+            return True
+        if mode == 'batch':
+            self.on_open_batch_queue()
+            self._record_recent_workflow('batch')
+            self.titleBar.set_workflow_hint("batch")
+            return True
+        if mode == 'models':
+            self.on_open_manage_models()
+            self._record_recent_workflow('models')
+            self.titleBar.set_workflow_hint("models")
+            return True
+        if mode == 'diagnostics':
+            self.on_environment_doctor()
+            self._record_recent_workflow('diagnostics')
+            self.titleBar.set_workflow_hint("diagnostics")
+            return True
+        if mode == 'editor':
+            if self._has_open_project():
+                self.setupImgTransUI()
+                self._record_recent_workflow('editor')
+                self.titleBar.set_workflow_hint("editor")
+                return True
+            if pcfg.open_recent_on_startup:
+                for proj_dir in list(getattr(self.leftBar, 'recent_proj_list', []) or []):
+                    if proj_dir and osp.exists(proj_dir):
+                        self.OpenProj(proj_dir)
+                        self._record_recent_workflow('editor')
+                        self.titleBar.set_workflow_hint("editor")
+                        return True
+            self._show_welcome_screen()
+            self._record_recent_workflow('home')
+            return True
+        # last_used
+        rec = list(getattr(pcfg, 'recent_workflows', []) or [])
+        if rec:
+            return self._open_startup_mode_target(rec[0])
+        if bool(getattr(pcfg, 'show_home_on_startup', True)):
+            self._show_welcome_screen()
+            self._record_recent_workflow('home')
+            return True
+        return False
+
     def on_open_merge_tool(self):
         """Open the region merge tool dialog."""
         if not hasattr(self, 'merge_dialog') or self.merge_dialog is None:
@@ -5387,6 +5585,8 @@ class MainWindow(mainwindow_cls):
             self.manga_source_dialog.activateWindow()
         else:
             self.manga_source_dialog.show()
+        self._record_recent_workflow('downloader')
+        self.titleBar.set_workflow_hint("downloader")
 
     def on_open_translation_assist_dock(self):
         if not hasattr(self, '_translation_assist_dock') or self._translation_assist_dock is None:
@@ -5661,6 +5861,8 @@ class MainWindow(mainwindow_cls):
             self._realtime_translator_dialog.activateWindow()
         else:
             self._realtime_translator_dialog.show()
+        self._record_recent_workflow('live')
+        self.titleBar.set_workflow_hint("live")
 
     def on_open_batch_queue(self):
         """Open the Batch queue dialog (multiple folders, Pause/Cancel)."""
@@ -5678,6 +5880,8 @@ class MainWindow(mainwindow_cls):
             self._batch_queue_dialog.activateWindow()
         else:
             self._batch_queue_dialog.show()
+        self._record_recent_workflow('batch')
+        self.titleBar.set_workflow_hint("batch")
 
     def _on_batch_start(self, paths: list, skip_ignored_pages: bool = True):
         self.run_batch(paths, skip_ignored_pages=skip_ignored_pages)
@@ -5699,9 +5903,14 @@ class MainWindow(mainwindow_cls):
                 self._batch_queue_dialog.list_widget.takeItem(0)
 
     def on_open_manage_models(self):
+        self._record_recent_workflow("models")
+        self.titleBar.set_workflow_hint("models")
         """Open the Manage models dialog (check downloaded models, download selected)."""
         dlg = ModelManagerDialog(self)
         dlg.exec()
+
+    def on_show_feature_matrix(self):
+        create_info_dialog({'title': self.tr('Feature matrix / model coverage'), 'text': feature_matrix_text()})
 
     def on_open_troubleshooting(self):
         """Open troubleshooting docs for model downloads and environment/network issues."""
@@ -5805,6 +6014,50 @@ class MainWindow(mainwindow_cls):
             self.on_relaunch_pyqt5_safe_mode()
         elif clicked == cpu_btn:
             self.on_relaunch_cpu_only_safe_mode()
+
+    def on_validate_action_registry(self):
+        try:
+            self.titleBar._get_actions_cache(force_rebuild=True)
+            reg = getattr(self.titleBar, '_action_registry', None)
+            if reg is None:
+                create_info_dialog({'title': self.tr('Action registry validation'), 'text': self.tr('Action registry is unavailable.')})
+                return
+            stats = reg.summary_stats() if hasattr(reg, 'summary_stats') else {}
+            dups = stats.get('duplicate_shortcuts', {}) if isinstance(stats, dict) else {}
+            lines = [
+                self.tr('Total actions: {0}').format(stats.get('total_actions', 0)),
+                self.tr('Enabled: {0} | Disabled: {1}').format(stats.get('enabled_actions', 0), stats.get('disabled_actions', 0)),
+                self.tr('Simple visible: {0} | Advanced visible: {1}').format(stats.get('simple_visible_actions', 0), stats.get('advanced_visible_actions', 0)),
+            ]
+            if dups:
+                lines.append(self.tr('Duplicate shortcuts:'))
+                for k, ids in sorted(dups.items()):
+                    lines.append(f"- {k}: {len(ids)} actions")
+            else:
+                lines.append(self.tr('No duplicate shortcuts detected in registered menu actions.'))
+            create_info_dialog({'title': self.tr('Action registry validation'), 'text': '\n'.join(lines)})
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to validate action registry.'))
+
+    def on_export_action_registry(self):
+        try:
+            import json
+            default_name = f"action_registry_{time.strftime('%Y%m%d_%H%M%S')}.json"
+            out_path = QFileDialog.getSaveFileName(self, self.tr('Export action registry'), default_name, self.tr('JSON files (*.json)'))[0]
+            if not out_path:
+                return
+            reg = getattr(self.titleBar, '_action_registry', None)
+            if reg is None:
+                create_info_dialog({'title': self.tr('Export action registry'), 'text': self.tr('Action registry is unavailable.')})
+                return
+            # Rebuild latest menu state first.
+            self.titleBar._get_actions_cache(force_rebuild=True)
+            rows = reg.to_rows() if hasattr(reg, 'to_rows') else []
+            with open(out_path, 'w', encoding='utf-8') as f:
+                json.dump(rows, f, ensure_ascii=False, indent=2)
+            create_info_dialog({'title': self.tr('Export action registry'), 'text': self.tr('Exported {0} actions.').format(len(rows))})
+        except Exception as e:
+            create_error_dialog(e, self.tr('Failed to export action registry.'))
 
     def on_copy_startup_diagnostics(self):
         text = self._collect_startup_diagnostics_text()
@@ -8825,6 +9078,8 @@ class MainWindow(mainwindow_cls):
             )
 
     def on_environment_doctor(self):
+        self._record_recent_workflow("diagnostics")
+        self.titleBar.set_workflow_hint("diagnostics")
         from utils.environment_doctor import run_environment_doctor
         checks = run_environment_doctor()
         lines = [f"{name}: {status} ({detail})" for name, status, detail in checks]
@@ -9027,6 +9282,11 @@ class MainWindow(mainwindow_cls):
         fit_action.setToolTip(self.tr("Zoom canvas so image width fits the view."))
         fit_action.triggered.connect(self._on_canvas_fit_to_width)
         self.titleBar.viewMenu.addAction(fit_action)
+
+        try:
+            self.titleBar.apply_ui_mode_visibility(getattr(pcfg, "ui_mode", "advanced"))
+        except Exception:
+            pass
 
     def _on_canvas_view_mode_triggered(self):
         action = self.sender()

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -185,7 +185,7 @@ class LeftBar(Widget):
         openMenu.addMenu(self.recentMenu)
         openMenu.addSeparator()
         actionCloseProject = QAction(self.tr("Close project and go to welcome screen"), self)
-        actionCloseProject.triggered.connect(self.close_project_requested.emit)
+        self.close_project_requested = actionCloseProject.triggered
         openMenu.addAction(actionCloseProject)
         openMenu.addSeparator()
         openMenu.addAction(actionSaveProj)
@@ -718,6 +718,10 @@ class TitleBar(Widget):
         exportActionRegistryAction = QAction(self.tr('Export action registry...'), self)
         exportActionRegistryAction.setToolTip(self.tr('Export all registered menu/command metadata to JSON for UI audit and migration checks.'))
         self.export_action_registry_trigger = exportActionRegistryAction.triggered
+        acValidateRegistry = QAction(self.tr('Validate action registry now'), self)
+        acValidateRegistry.setToolTip(self.tr('Show action counts, simple/advanced visibility counts, and duplicate shortcut report.'))
+        self.validate_action_registry_trigger = acValidateRegistry.triggered
+
         self.validate_action_registry_trigger = acValidateRegistry.triggered
         openLogFolderAction.setToolTip(self.tr('Open logs directory in your file explorer.'))
         self.open_log_folder_trigger = openLogFolderAction.triggered
@@ -897,13 +901,13 @@ class TitleBar(Widget):
         self.translationToolBtn.setText(self.tr('Translation'))
         translationMenu = QMenu(self.translationToolBtn)
         acTranslatePage = QAction(self.tr('Translate page'), self)
-        acTranslatePage.triggered.connect(self.translate_page_trigger.emit)
+        self.translate_page_trigger = acTranslatePage.triggered
         acTranslationAssist = QAction(self.tr('Translation Assist (beta)...'), self)
-        acTranslationAssist.triggered.connect(self.translation_assist_trigger.emit)
+        self.translation_assist_trigger = acTranslationAssist.triggered
         acConcordance = QAction(self.tr('Concordance search (project)...'), self)
-        acConcordance.triggered.connect(self.concordance_search_trigger.emit)
+        self.concordance_search_trigger = acConcordance.triggered
         acTranslationQA = QAction(self.tr('Translation QA report (current page)...'), self)
-        acTranslationQA.triggered.connect(self.translation_qa_report_trigger.emit)
+        self.translation_qa_report_trigger = acTranslationQA.triggered
         translationMenu.addActions([acTranslatePage, acTranslationAssist, acConcordance, acTranslationQA])
         self.translationToolBtn.setMenu(translationMenu)
         self.translationToolBtn.setPopupMode(QToolButton.InstantPopup)
@@ -912,16 +916,13 @@ class TitleBar(Widget):
         self.diagnosticsToolBtn.setText(self.tr('Diagnostics'))
         diagnosticsMenu = QMenu(self.diagnosticsToolBtn)
         acEnvDoctor = QAction(self.tr('Environment doctor...'), self)
-        acEnvDoctor.triggered.connect(self.environment_doctor_trigger.emit)
+        self.environment_doctor_trigger = acEnvDoctor.triggered
         acStartupDiag = QAction(self.tr('Copy startup diagnostics'), self)
-        acStartupDiag.triggered.connect(self.copy_startup_diag_trigger.emit)
+        self.copy_startup_diag_trigger = acStartupDiag.triggered
         acRuntimeSummary = QAction(self.tr('Runtime resource summary'), self)
-        acRuntimeSummary.triggered.connect(self.runtime_resource_summary_trigger.emit)
+        self.runtime_resource_summary_trigger = acRuntimeSummary.triggered
         acExportStartup = QAction(self.tr('Export startup report...'), self)
-        acExportStartup.triggered.connect(self.export_startup_diag_trigger.emit)
-        acValidateRegistry = QAction(self.tr('Validate action registry now'), self)
-        acValidateRegistry.setToolTip(self.tr('Show action counts, simple/advanced visibility counts, and duplicate shortcut report.'))
-        acValidateRegistry.triggered.connect(self.validate_action_registry_trigger.emit)
+        self.export_startup_diag_trigger = acExportStartup.triggered
         diagnosticsMenu.addActions([acEnvDoctor, acStartupDiag, acRuntimeSummary, acExportStartup, acValidateRegistry])
         self.diagnosticsToolBtn.setMenu(diagnosticsMenu)
         self.diagnosticsToolBtn.setPopupMode(QToolButton.InstantPopup)
@@ -932,13 +933,13 @@ class TitleBar(Widget):
         acExportCurrent = QAction(self.tr('Export current page as...'), self)
         acExportCurrent.triggered.connect(lambda: getattr(getattr(self.mainwindow, 'leftBar', None), 'export_current_page_as', self.batch_export_trigger).emit())
         acExportAll = QAction(self.tr('Export all pages'), self)
-        acExportAll.triggered.connect(self.batch_export_trigger.emit)
+        self.batch_export_trigger = acExportAll.triggered
         acExportAllAs = QAction(self.tr('Export all pages as...'), self)
-        acExportAllAs.triggered.connect(self.batch_export_as_trigger.emit)
+        self.batch_export_as_trigger = acExportAllAs.triggered
         acExportJson = QAction(self.tr('Export translation JSON...'), self)
-        acExportJson.triggered.connect(self.export_translation_json_trigger.emit)
+        self.export_translation_json_trigger = acExportJson.triggered
         acExportXliff = QAction(self.tr('Export XLIFF...'), self)
-        acExportXliff.triggered.connect(self.export_xliff_trigger.emit)
+        self.export_xliff_trigger = acExportXliff.triggered
         exportTopMenu.addActions([acExportCurrent, acExportAll, acExportAllAs, acExportJson, acExportXliff])
         self.exportToolBtn.setMenu(exportTopMenu)
         self.exportToolBtn.setPopupMode(QToolButton.InstantPopup)
@@ -947,15 +948,15 @@ class TitleBar(Widget):
         self.modelsToolBtn.setText(self.tr('Models'))
         modelsTopMenu = QMenu(self.modelsToolBtn)
         acManageModels = QAction(self.tr('Manage models...'), self)
-        acManageModels.triggered.connect(self.manage_models_trigger.emit)
+        self.manage_models_trigger = acManageModels.triggered
         acRetryModels = QAction(self.tr('Retry model downloads'), self)
-        acRetryModels.triggered.connect(self.retry_models_trigger.emit)
+        self.retry_models_trigger = acRetryModels.triggered
         acReleaseCaches = QAction(self.tr('Release model caches'), self)
-        acReleaseCaches.triggered.connect(self.release_model_caches_trigger.emit)
+        self.release_model_caches_trigger = acReleaseCaches.triggered
         acClearCaches = QAction(self.tr('Clear OCR and translation caches'), self)
-        acClearCaches.triggered.connect(self.clear_pipeline_caches_trigger.emit)
+        self.clear_pipeline_caches_trigger = acClearCaches.triggered
         acExportRegistry = QAction(self.tr('Export action registry...'), self)
-        acExportRegistry.triggered.connect(self.export_action_registry_trigger.emit)
+        self.export_action_registry_trigger = acExportRegistry.triggered
         modelsTopMenu.addActions([acManageModels, acRetryModels, acReleaseCaches, acClearCaches, acExportRegistry])
         self.modelsToolBtn.setMenu(modelsTopMenu)
         self.modelsToolBtn.setPopupMode(QToolButton.InstantPopup)
@@ -964,17 +965,17 @@ class TitleBar(Widget):
         self.helpToolBtn.setText(self.tr('Help'))
         helpTopMenu = QMenu(self.helpToolBtn)
         acHelpDoc = QAction(self.tr('Documentation'), self)
-        acHelpDoc.triggered.connect(self.help_doc_trigger.emit)
+        self.help_doc_trigger = acHelpDoc.triggered
         acHelpAbout = QAction(self.tr('About'), self)
-        acHelpAbout.triggered.connect(self.help_about_trigger.emit)
+        self.help_about_trigger = acHelpAbout.triggered
         acHelpUpdate = QAction(self.tr('Update from GitHub'), self)
-        acHelpUpdate.triggered.connect(self.help_update_from_github_trigger.emit)
+        self.help_update_from_github_trigger = acHelpUpdate.triggered
         acFeatureMatrix = QAction(self.tr('Feature matrix / model coverage'), self)
         self.feature_matrix_trigger = acFeatureMatrix.triggered
         acHelpShortcuts = QAction(self.tr('Keyboard Shortcuts...'), self)
-        acHelpShortcuts.triggered.connect(self.keyboard_shortcuts_trigger.emit)
+        self.keyboard_shortcuts_trigger = acHelpShortcuts.triggered
         acHelpCtx = QAction(self.tr('Context menu options...'), self)
-        acHelpCtx.triggered.connect(self.context_menu_options_trigger.emit)
+        self.context_menu_options_trigger = acHelpCtx.triggered
         helpTopMenu.addActions([acHelpDoc, acHelpAbout, acHelpUpdate, acFeatureMatrix])
         helpTopMenu.addSeparator()
         helpTopMenu.addActions([acHelpShortcuts, acHelpCtx])

--- a/ui/mainwindowbars.py
+++ b/ui/mainwindowbars.py
@@ -36,6 +36,7 @@ from .framelesswindow import FramelessMoveResize
 from utils.config import pcfg
 from utils import shared as C
 from utils.shortcuts import get_shortcut
+from .action_registry import ActionRegistry
 if C.FLAG_QT6:
     from qtpy.QtGui import QAction
 else:
@@ -249,12 +250,7 @@ class LeftBar(Widget):
         self._run_btn_pulse_down.setStartValue(up_sz)
         self._run_btn_pulse_down.setEndValue(icon_sz)
 
-    def apply_shortcuts(self, shortcuts_dict):
-        """Apply keyboard shortcuts from config (action_id -> key string)."""
-        from qtpy.QtGui import QKeySequence
-        for action_id, default_key, action in self._shortcut_actions_left:
-            key = (shortcuts_dict or {}).get(action_id) or default_key
-            action.setShortcut(QKeySequence.fromString(key) if key else QKeySequence())
+
 
     def initRecentProjMenu(self, proj_list: List[str]):
         self.recent_proj_list = proj_list
@@ -719,6 +715,10 @@ class TitleBar(Widget):
         exportStartupDiagAction.setToolTip(self.tr('Save startup diagnostics to a text file for support.'))
         self.export_startup_diag_trigger = exportStartupDiagAction.triggered
         openLogFolderAction = QAction(QIcon(osp.join(C.PROGRAM_PATH, 'icons', 'openbtn.svg')), self.tr('Open log folder'), self)
+        exportActionRegistryAction = QAction(self.tr('Export action registry...'), self)
+        exportActionRegistryAction.setToolTip(self.tr('Export all registered menu/command metadata to JSON for UI audit and migration checks.'))
+        self.export_action_registry_trigger = exportActionRegistryAction.triggered
+        self.validate_action_registry_trigger = acValidateRegistry.triggered
         openLogFolderAction.setToolTip(self.tr('Open logs directory in your file explorer.'))
         self.open_log_folder_trigger = openLogFolderAction.triggered
         relaunchPyQt5Action = QAction(self.tr('Relaunch with PyQt5 (safe mode)'), self)
@@ -878,6 +878,7 @@ class TitleBar(Widget):
         modelsMenu.addAction(runtimeResourceSummaryAction)
         modelsMenu.addAction(exportStartupDiagAction)
         modelsMenu.addAction(openLogFolderAction)
+        modelsMenu.addAction(exportActionRegistryAction)
         modelsMenu.addAction(relaunchPyQt5Action)
         modelsMenu.addAction(relaunchCpuOnlyAction)
         modelsMenu.addSeparator()
@@ -890,6 +891,95 @@ class TitleBar(Widget):
         toolsMenu.addMenu(modelsMenu)
         self.toolsToolBtn.setMenu(toolsMenu)
         self.toolsToolBtn.setPopupMode(QToolButton.InstantPopup)
+
+        # New workflow-oriented top-level menus (non-breaking; legacy Tools remains available)
+        self.translationToolBtn = TitleBarToolBtn(self)
+        self.translationToolBtn.setText(self.tr('Translation'))
+        translationMenu = QMenu(self.translationToolBtn)
+        acTranslatePage = QAction(self.tr('Translate page'), self)
+        acTranslatePage.triggered.connect(self.translate_page_trigger.emit)
+        acTranslationAssist = QAction(self.tr('Translation Assist (beta)...'), self)
+        acTranslationAssist.triggered.connect(self.translation_assist_trigger.emit)
+        acConcordance = QAction(self.tr('Concordance search (project)...'), self)
+        acConcordance.triggered.connect(self.concordance_search_trigger.emit)
+        acTranslationQA = QAction(self.tr('Translation QA report (current page)...'), self)
+        acTranslationQA.triggered.connect(self.translation_qa_report_trigger.emit)
+        translationMenu.addActions([acTranslatePage, acTranslationAssist, acConcordance, acTranslationQA])
+        self.translationToolBtn.setMenu(translationMenu)
+        self.translationToolBtn.setPopupMode(QToolButton.InstantPopup)
+
+        self.diagnosticsToolBtn = TitleBarToolBtn(self)
+        self.diagnosticsToolBtn.setText(self.tr('Diagnostics'))
+        diagnosticsMenu = QMenu(self.diagnosticsToolBtn)
+        acEnvDoctor = QAction(self.tr('Environment doctor...'), self)
+        acEnvDoctor.triggered.connect(self.environment_doctor_trigger.emit)
+        acStartupDiag = QAction(self.tr('Copy startup diagnostics'), self)
+        acStartupDiag.triggered.connect(self.copy_startup_diag_trigger.emit)
+        acRuntimeSummary = QAction(self.tr('Runtime resource summary'), self)
+        acRuntimeSummary.triggered.connect(self.runtime_resource_summary_trigger.emit)
+        acExportStartup = QAction(self.tr('Export startup report...'), self)
+        acExportStartup.triggered.connect(self.export_startup_diag_trigger.emit)
+        acValidateRegistry = QAction(self.tr('Validate action registry now'), self)
+        acValidateRegistry.setToolTip(self.tr('Show action counts, simple/advanced visibility counts, and duplicate shortcut report.'))
+        acValidateRegistry.triggered.connect(self.validate_action_registry_trigger.emit)
+        diagnosticsMenu.addActions([acEnvDoctor, acStartupDiag, acRuntimeSummary, acExportStartup, acValidateRegistry])
+        self.diagnosticsToolBtn.setMenu(diagnosticsMenu)
+        self.diagnosticsToolBtn.setPopupMode(QToolButton.InstantPopup)
+
+        self.exportToolBtn = TitleBarToolBtn(self)
+        self.exportToolBtn.setText(self.tr('Export'))
+        exportTopMenu = QMenu(self.exportToolBtn)
+        acExportCurrent = QAction(self.tr('Export current page as...'), self)
+        acExportCurrent.triggered.connect(lambda: getattr(getattr(self.mainwindow, 'leftBar', None), 'export_current_page_as', self.batch_export_trigger).emit())
+        acExportAll = QAction(self.tr('Export all pages'), self)
+        acExportAll.triggered.connect(self.batch_export_trigger.emit)
+        acExportAllAs = QAction(self.tr('Export all pages as...'), self)
+        acExportAllAs.triggered.connect(self.batch_export_as_trigger.emit)
+        acExportJson = QAction(self.tr('Export translation JSON...'), self)
+        acExportJson.triggered.connect(self.export_translation_json_trigger.emit)
+        acExportXliff = QAction(self.tr('Export XLIFF...'), self)
+        acExportXliff.triggered.connect(self.export_xliff_trigger.emit)
+        exportTopMenu.addActions([acExportCurrent, acExportAll, acExportAllAs, acExportJson, acExportXliff])
+        self.exportToolBtn.setMenu(exportTopMenu)
+        self.exportToolBtn.setPopupMode(QToolButton.InstantPopup)
+
+        self.modelsToolBtn = TitleBarToolBtn(self)
+        self.modelsToolBtn.setText(self.tr('Models'))
+        modelsTopMenu = QMenu(self.modelsToolBtn)
+        acManageModels = QAction(self.tr('Manage models...'), self)
+        acManageModels.triggered.connect(self.manage_models_trigger.emit)
+        acRetryModels = QAction(self.tr('Retry model downloads'), self)
+        acRetryModels.triggered.connect(self.retry_models_trigger.emit)
+        acReleaseCaches = QAction(self.tr('Release model caches'), self)
+        acReleaseCaches.triggered.connect(self.release_model_caches_trigger.emit)
+        acClearCaches = QAction(self.tr('Clear OCR and translation caches'), self)
+        acClearCaches.triggered.connect(self.clear_pipeline_caches_trigger.emit)
+        acExportRegistry = QAction(self.tr('Export action registry...'), self)
+        acExportRegistry.triggered.connect(self.export_action_registry_trigger.emit)
+        modelsTopMenu.addActions([acManageModels, acRetryModels, acReleaseCaches, acClearCaches, acExportRegistry])
+        self.modelsToolBtn.setMenu(modelsTopMenu)
+        self.modelsToolBtn.setPopupMode(QToolButton.InstantPopup)
+
+        self.helpToolBtn = TitleBarToolBtn(self)
+        self.helpToolBtn.setText(self.tr('Help'))
+        helpTopMenu = QMenu(self.helpToolBtn)
+        acHelpDoc = QAction(self.tr('Documentation'), self)
+        acHelpDoc.triggered.connect(self.help_doc_trigger.emit)
+        acHelpAbout = QAction(self.tr('About'), self)
+        acHelpAbout.triggered.connect(self.help_about_trigger.emit)
+        acHelpUpdate = QAction(self.tr('Update from GitHub'), self)
+        acHelpUpdate.triggered.connect(self.help_update_from_github_trigger.emit)
+        acFeatureMatrix = QAction(self.tr('Feature matrix / model coverage'), self)
+        self.feature_matrix_trigger = acFeatureMatrix.triggered
+        acHelpShortcuts = QAction(self.tr('Keyboard Shortcuts...'), self)
+        acHelpShortcuts.triggered.connect(self.keyboard_shortcuts_trigger.emit)
+        acHelpCtx = QAction(self.tr('Context menu options...'), self)
+        acHelpCtx.triggered.connect(self.context_menu_options_trigger.emit)
+        helpTopMenu.addActions([acHelpDoc, acHelpAbout, acHelpUpdate, acFeatureMatrix])
+        helpTopMenu.addSeparator()
+        helpTopMenu.addActions([acHelpShortcuts, acHelpCtx])
+        self.helpToolBtn.setMenu(helpTopMenu)
+        self.helpToolBtn.setPopupMode(QToolButton.InstantPopup)
 
         self.runToolBtn = TitleBarToolBtn(self)
         self.runToolBtn.setObjectName('PipelineRunBtn')
@@ -950,6 +1040,13 @@ class TitleBar(Widget):
         self.run_woupdate_textstyle_trigger = runWoUpdateTextStyle.triggered
         self.translate_page_trigger = translatePageAction.triggered
 
+        self._advanced_action_keywords = (
+            "diagnostics", "doctor", "triage", "qa", "concordance", "profile snapshot",
+            "model", "google font", "relaunch", "cache", "batch queue", "video", "subtitle",
+            "xliff", "json", "csv", "lptxt", "structured ocr", "layered psd", "svg text",
+            "layout review", "lettering workflow", "translation assist", "realtime screen",
+        )
+
         self.iconLabel = QLabel(self)
         if not C.ON_MACOS:
             self.iconLabel.setFixedWidth(LEFTBAR_WIDTH - 12)
@@ -965,6 +1062,9 @@ class TitleBar(Widget):
         self.fileToolBtn.setPopupMode(QToolButton.InstantPopup)
 
         self.titleLabel = QLabel(self.tr('BallonsTranslatorPro'))
+        self.workflowHintLabel = QLabel(self.tr("Workflow: home"))
+        self.workflowHintLabel.setObjectName("WorkflowHintLabel")
+        self.workflowHintLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.titleLabel.setObjectName('TitleLabel')
         self.titleLabel.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
@@ -1016,6 +1116,7 @@ class TitleBar(Widget):
             pass
         self.omniSearch.setCompleter(self._omni_completer)
         self._omni_actions_cache = None  # lazily built list of (label, QAction)
+        self._action_registry = ActionRegistry(self)
         
         # Center container: keep title + search aligned to the canvas area (between left/right panes).
         # Use two rows so the title stays visually centered and the search doesn't "steal" its space.
@@ -1026,6 +1127,7 @@ class TitleBar(Widget):
 
         # Row 1: title / project / page label
         self._centerLayout.addWidget(self.titleLabel)
+        self._centerLayout.addWidget(self.workflowHintLabel)
 
         # Row 2: omni search + dropdown button
         self._searchRow = QWidget(self._centerContainer)
@@ -1057,6 +1159,27 @@ class TitleBar(Widget):
 
         self._searchRowLayout.addStretch()
         self._searchRowLayout.addWidget(self._searchToggleBtn, 0)
+        self._omniShowUnavailable = QCheckBox(self.tr("Show unavailable"), self._searchRow)
+        self._omniShowUnavailable.setChecked(bool(getattr(pcfg, "omni_show_unavailable", False)))
+        self._omniShowUnavailable.setToolTip(self.tr("Include disabled commands in results and show why they are unavailable."))
+        self._omniShowUnavailable.stateChanged.connect(self._on_omni_show_unavailable_changed)
+        self._omniShowUnavailable.hide()
+        self._searchRowLayout.addWidget(self._omniShowUnavailable, 0)
+        self._omniTypeFilter = QComboBox(self._searchRow)
+        self._omniTypeFilter.addItem(self.tr("All"), "all")
+        self._omniTypeFilter.addItem(self.tr("Commands"), "command")
+        self._omniTypeFilter.addItem(self.tr("Settings"), "setting")
+        self._omniTypeFilter.addItem(self.tr("Text blocks"), "text_block")
+        self._omniTypeFilter.addItem(self.tr("Page"), "page")
+        self._omniTypeFilter.addItem(self.tr("Recent"), "recent")
+        self._omniTypeFilter.addItem(self.tr("Help"), "help")
+        _rf = str(getattr(pcfg, "omni_result_type_filter", "all") or "all")
+        _ridx = self._omniTypeFilter.findData(_rf)
+        self._omniTypeFilter.setCurrentIndex(_ridx if _ridx >= 0 else 0)
+        self._omniTypeFilter.setToolTip(self.tr("Filter omni-search results by result type."))
+        self._omniTypeFilter.currentIndexChanged.connect(self._on_omni_type_filter_changed)
+        self._omniTypeFilter.hide()
+        self._searchRowLayout.addWidget(self._omniTypeFilter, 0)
         self._searchRowLayout.addWidget(self.omniSearch, 0)
         self._searchRowLayout.addWidget(self._omniDropBtn, 0)
         self._searchRowLayout.addStretch()
@@ -1073,6 +1196,11 @@ class TitleBar(Widget):
         hlayout.addWidget(self.goToolBtn)
         hlayout.addWidget(self.runToolBtn)
         hlayout.addWidget(self.toolsToolBtn)
+        hlayout.addWidget(self.translationToolBtn)
+        hlayout.addWidget(self.diagnosticsToolBtn)
+        hlayout.addWidget(self.exportToolBtn)
+        hlayout.addWidget(self.modelsToolBtn)
+        hlayout.addWidget(self.helpToolBtn)
         hlayout.addStretch()
         hlayout.addWidget(self._centerContainer)
         hlayout.addStretch()
@@ -1095,7 +1223,7 @@ class TitleBar(Widget):
             hlayout.setContentsMargins(0, 0, 0, 0)
             hlayout.setSpacing(0)
 
-        for btn in (self.fileToolBtn, self.editToolBtn, self.viewToolBtn, self.goToolBtn, self.runToolBtn, self.toolsToolBtn):
+        for btn in (self.fileToolBtn, self.editToolBtn, self.viewToolBtn, self.goToolBtn, self.runToolBtn, self.toolsToolBtn, self.translationToolBtn, self.diagnosticsToolBtn, self.exportToolBtn, self.modelsToolBtn, self.helpToolBtn):
             install_button_animations(btn, normal_opacity=0.9, press_opacity=0.74, with_scale=True)
 
     def resizeEvent(self, event) -> None:
@@ -1133,6 +1261,8 @@ class TitleBar(Widget):
         else:
             self.omniSearch.show()
             self._omniDropBtn.show()
+            self._omniShowUnavailable.show()
+            self._omniTypeFilter.show()
             self.omniSearch.setFocus(Qt.FocusReason.ShortcutFocusReason)
             self.omniSearch.selectAll()
 
@@ -1147,6 +1277,8 @@ class TitleBar(Widget):
                 pass
             self.omniSearch.hide()
             self._omniDropBtn.hide()
+            self._omniShowUnavailable.hide()
+            self._omniTypeFilter.hide()
 
     def _toggle_omni_search(self):
         expand = not bool(getattr(self, '_searchExpanded', False))
@@ -1156,6 +1288,8 @@ class TitleBar(Widget):
         if expand:
             self.omniSearch.show()
             self._omniDropBtn.show()
+            self._omniShowUnavailable.show()
+            self._omniTypeFilter.show()
             self.omniSearch.setFocus()
             self.omniSearch.selectAll()
         else:
@@ -1172,6 +1306,8 @@ class TitleBar(Widget):
                 def _hide_after():
                     self.omniSearch.hide()
                     self._omniDropBtn.hide()
+                    self._omniShowUnavailable.hide()
+                    self._omniTypeFilter.hide()
                 anim.finished.connect(_hide_after)
             self._search_anim = anim
             anim.start()
@@ -1208,32 +1344,131 @@ class TitleBar(Widget):
             except Exception:
                 continue
 
+
+    def _on_omni_type_filter_changed(self, _index: int):
+        pcfg.omni_result_type_filter = str(self._omniTypeFilter.currentData() or "all")
+        q = (self.omniSearch.text() or "").strip()
+        if q:
+            self._on_omni_search_text_edited(q)
+
+    def _on_omni_show_unavailable_changed(self, state: int):
+        pcfg.omni_show_unavailable = bool(state)
+        self._omni_actions_cache = None
+        q = (self.omniSearch.text() or "").strip()
+        if q:
+            self._on_omni_search_text_edited(q)
+
+    @staticmethod
+    def _fuzzy_match(query: str, text: str) -> bool:
+        q = (query or "").lower().strip()
+        t = (text or "").lower()
+        if not q:
+            return True
+        if q in t:
+            return True
+        qi = 0
+        for ch in t:
+            if qi < len(q) and ch == q[qi]:
+                qi += 1
+                if qi == len(q):
+                    return True
+        return False
+
+    def _registry_meta_for_top_level(self, top_level: str):
+        t = str(top_level or "").lower()
+        category_map = {
+            "file": "File",
+            "edit": "Edit",
+            "view": "View",
+            "go": "Navigation",
+            "pipeline": "Pipeline",
+            "tools": "Developer / Advanced",
+            "translation": "Translation",
+            "diagnostics": "Diagnostics",
+            "export": "Export",
+            "models": "Models",
+            "help": "Help",
+        }
+        workflow_map = {
+            "file": "editor",
+            "edit": "editor",
+            "view": "editor",
+            "go": "editor",
+            "pipeline": "editor",
+            "tools": "advanced",
+            "translation": "editor",
+            "diagnostics": "diagnostics",
+            "export": "editor",
+            "models": "models",
+            "help": "help",
+        }
+        return category_map.get(t, top_level), workflow_map.get(t, "editor")
+
     def _get_actions_cache(self, force_rebuild: bool = False):
         if self._omni_actions_cache is not None and not force_rebuild:
             return self._omni_actions_cache
         actions = []
         try:
-            # Tool buttons hold menus (some are set later, but by the time user searches they should exist)
+            self._action_registry.clear()
             for btn, name in (
                 (getattr(self, "fileToolBtn", None), "File"),
                 (getattr(self, "editToolBtn", None), "Edit"),
                 (getattr(self, "viewToolBtn", None), "View"),
                 (getattr(self, "goToolBtn", None), "Go"),
-                (getattr(self, "runToolBtn", None), "Run"),
+                (getattr(self, "runToolBtn", None), "Pipeline"),
                 (getattr(self, "toolsToolBtn", None), "Tools"),
+                (getattr(self, "translationToolBtn", None), "Translation"),
+                (getattr(self, "diagnosticsToolBtn", None), "Diagnostics"),
+                (getattr(self, "exportToolBtn", None), "Export"),
+                (getattr(self, "modelsToolBtn", None), "Models"),
+                (getattr(self, "helpToolBtn", None), "Help"),
             ):
-                if btn is None:
-                    continue
-                m = btn.menu()
+                m = btn.menu() if btn is not None else None
                 if m is None:
                     continue
-                actions.extend(list(self._walk_menu_actions(m, prefix=f"{name} > ")))
+                self._action_registry.register_menu_tree(name, m, menu_path_prefix=f"{name} > ")
+                # annotate visibility defaults by top-level groups for simple mode
+                for act in m.actions() or []:
+                    pass
+            has_project = bool(getattr(self.mainwindow, "imgtrans_proj", None) and not getattr(self.mainwindow.imgtrans_proj, "is_empty", True))
+            for rec in self._action_registry.all_records():
+                cat, wf = self._registry_meta_for_top_level(rec.top_level)
+                rec.category = cat
+                rec.workflow_mode = wf
+                mp = (rec.menu_path or "").lower()
+                lbl = (rec.label or "").lower()
+                if mp.startswith("diagnostics") or mp.startswith("tools > models"):
+                    rec.simple_mode_visible = False
+                elif mp.startswith("translation") or mp.startswith("export") or mp.startswith("models"):
+                    rec.simple_mode_visible = True
+                else:
+                    rec.simple_mode_visible = True
+
+                # Populate clearer unavailable reasons for project-dependent actions.
+                requires_project = any(k in lbl for k in (
+                    "translate page", "concordance", "layout review", "ocr triage", "translation qa",
+                    "batch find/replace", "export current page", "export all pages", "structured ocr",
+                ))
+                if requires_project and not has_project:
+                    rec.enabled = False
+                    rec.disabled_reason = self.tr("Open a project first to use this command.")
+            actions = list(self._action_registry.discoverable_actions(show_unavailable=bool(getattr(pcfg, "omni_show_unavailable", False))))
         except Exception:
             pass
         self._omni_actions_cache = actions
         return actions
 
+    def _result_type_allowed(self, payload: dict) -> bool:
+        cur = str(getattr(pcfg, "omni_result_type_filter", "all") or "all")
+        if cur == "all":
+            return True
+        ptype = str((payload or {}).get("type") or "").lower()
+        mapping = {"action": "command", "config": "setting", "canvas": "text_block", "ui_text": "page", "recent": "recent", "help": "help"}
+        return mapping.get(ptype, ptype) == cur
+
     def _add_result_item(self, label: str, payload: dict):
+        if not self._result_type_allowed(payload):
+            return
         it = QStandardItem(label)
         it.setEditable(False)
         it.setData(payload, Qt.ItemDataRole.UserRole)
@@ -1250,9 +1485,9 @@ class TitleBar(Widget):
         max_items = 40
 
         # 1) Menu actions
-        for label, act in self._get_actions_cache():
-            if q_low in label.lower():
-                self._add_result_item(label, {"type": "action", "action": act})
+        for label, act, meta in self._get_actions_cache():
+            if self._fuzzy_match(q_low, label):
+                self._add_result_item(label, {"type": "action", "action": act, "enabled": bool(meta.get("enabled", True)), "reason": meta.get("reason", ""), "result_badge": "Command"})
                 n_added += 1
                 if n_added >= max_items:
                     break
@@ -1299,7 +1534,7 @@ class TitleBar(Widget):
                             label = f"{base_label} = {value_str}"
                         hay = f"{base_label} {value_str}".lower()
                         if q_low in hay:
-                            self._add_result_item(label, {"type": "config", "idx0": sb.idx0, "idx1": sb.idx1})
+                            self._add_result_item(f"[Setting] {label}", {"type": "config", "idx0": sb.idx0, "idx1": sb.idx1, "result_badge": "Setting"})
                             n_added += 1
                             if n_added >= max_items:
                                 break
@@ -1326,7 +1561,7 @@ class TitleBar(Widget):
                         if len(short) > 80:
                             short = short[:80] + "…"
                         label = f"Canvas > Block {getattr(it, 'idx', '?')}: {short}"
-                        self._add_result_item(label, {"type": "canvas", "block_idx": int(getattr(it, "idx", -1))})
+                        self._add_result_item(f"[Text block] {label}", {"type": "canvas", "block_idx": int(getattr(it, "idx", -1)), "result_badge": "Text block"})
                         n_added += 1
                         if n_added >= max_items:
                             break
@@ -1353,7 +1588,7 @@ class TitleBar(Widget):
                         bottom_items.append(label)
                     for lbl in bottom_items:
                         if q_low in lbl.lower():
-                            self._add_result_item(f"UI > Bottom bar > {lbl}", {"type": "ui_text", "target": "bottom"})
+                            self._add_result_item(f"[Page] UI > Bottom bar > {lbl}", {"type": "ui_text", "target": "bottom", "result_badge": "Page"})
                             n_added += 1
                             if n_added >= max_items:
                                 break
@@ -1368,7 +1603,7 @@ class TitleBar(Widget):
                         if not txt:
                             continue
                         if q_low in txt.lower():
-                            self._add_result_item(f"UI > Format/Text panel > {txt}", {"type": "ui_text", "target": "text_panel"})
+                            self._add_result_item(f"[Page] UI > Format/Text panel > {txt}", {"type": "ui_text", "target": "text_panel", "result_badge": "Page"})
                             n_added += 1
                             if n_added >= max_items:
                                 break
@@ -1381,7 +1616,7 @@ class TitleBar(Widget):
                             if not label:
                                 continue
                             if q_low in label.lower():
-                                self._add_result_item(f"UI > Format/Text panel > {label}", {"type": "ui_text", "target": "text_panel"})
+                                self._add_result_item(f"[Page] UI > Format/Text panel > {label}", {"type": "ui_text", "target": "text_panel", "result_badge": "Page"})
                                 n_added += 1
                                 if n_added >= max_items:
                                     break
@@ -1421,8 +1656,8 @@ class TitleBar(Widget):
                 # Show a short list of menu actions as a starting point.
                 self._omni_model.clear()
                 n = 0
-                for label, act in self._get_actions_cache():
-                    self._add_result_item(label, {"type": "action", "action": act})
+                for label, act, meta in self._get_actions_cache():
+                    self._add_result_item(label, {"type": "action", "action": act, "enabled": bool(meta.get("enabled", True)), "reason": meta.get("reason", ""), "result_badge": "Command"})
                     n += 1
                     if n >= 30:
                         break
@@ -1495,6 +1730,10 @@ class TitleBar(Widget):
             try:
                 t = payload.get("type")
                 if t == "action":
+                    if not bool(payload.get("enabled", True)):
+                        reason = payload.get("reason") or self.tr("Action is unavailable right now.")
+                        QMessageBox.information(self, self.tr("Unavailable command"), reason)
+                        return
                     act = payload.get("action")
                     if act is not None and hasattr(act, "trigger"):
                         act.trigger()
@@ -1514,6 +1753,18 @@ class TitleBar(Widget):
                     elif target == "bottom":
                         if hasattr(self.mainwindow, "setupImgTransUI"):
                             self.mainwindow.setupImgTransUI()
+                elif t == "recent":
+                    path = str(payload.get("path") or "").strip()
+                    if path and hasattr(self.mainwindow, "OpenProj"):
+                        self.mainwindow.OpenProj(path)
+                elif t == "help":
+                    hid = str(payload.get("help_id") or "")
+                    if hid == "help_doc" and hasattr(self.mainwindow, "on_help_documentation"):
+                        self.mainwindow.on_help_documentation()
+                    elif hid == "help_about" and hasattr(self.mainwindow, "on_help_about"):
+                        self.mainwindow.on_help_about()
+                    elif hid == "help_shortcuts" and hasattr(self.mainwindow, "open_shortcuts_dialog"):
+                        self.mainwindow.open_shortcuts_dialog()
             except Exception:
                 pass
 
@@ -1576,6 +1827,59 @@ class TitleBar(Widget):
         fileMenu.addMenu(importMenu)
         self.fileToolBtn.setMenu(fileMenu)
         self._omni_actions_cache = None
+
+
+
+    def apply_legacy_menu_layout(self, enabled: bool):
+        """Toggle visibility of legacy catch-all Tools menu during phased IA migration."""
+        try:
+            self.toolsToolBtn.setVisible(bool(enabled))
+            if not enabled:
+                self.toolsToolBtn.setToolTip(self.tr("Legacy Tools menu hidden; use Translation/Diagnostics/Export/Models."))
+            else:
+                self.toolsToolBtn.setToolTip("")
+            self._omni_actions_cache = None
+        except Exception:
+            pass
+
+    def apply_ui_mode_visibility(self, ui_mode: str):
+        """Simple mode hides advanced actions without changing handlers or shortcuts."""
+        mode = str(ui_mode or "advanced").lower()
+        show_all = mode in ("advanced", "developer")
+
+        def _apply_menu(menu):
+            if menu is None:
+                return
+            for action in menu.actions() or []:
+                sub = action.menu()
+                if sub is not None:
+                    _apply_menu(sub)
+                    continue
+                rec = self._action_registry.record_for_action(action)
+                if rec is not None:
+                    action.setVisible(bool(rec.advanced_mode_visible if show_all else rec.simple_mode_visible))
+                else:
+                    text = (action.text() or "").lower()
+                    is_advanced = any(k in text for k in self._advanced_action_keywords)
+                    action.setVisible(show_all or not is_advanced)
+
+        try:
+            for btn in (self.fileToolBtn, self.editToolBtn, self.viewToolBtn, self.goToolBtn, self.runToolBtn, self.toolsToolBtn, self.translationToolBtn, self.diagnosticsToolBtn, self.exportToolBtn, self.modelsToolBtn, self.helpToolBtn):
+                _apply_menu(btn.menu() if btn is not None else None)
+
+            # In simple mode, keep navigation light by hiding Go menu button.
+            self.goToolBtn.setVisible(show_all)
+            self.diagnosticsToolBtn.setVisible(show_all)
+            self.modelsToolBtn.setVisible(True)
+            self.exportToolBtn.setVisible(True)
+            self.helpToolBtn.setVisible(True)
+            if mode == "simple":
+                self.toolsToolBtn.setToolTip(self.tr("Tools (simple mode hides advanced actions)"))
+            else:
+                self.toolsToolBtn.setToolTip("")
+            self._omni_actions_cache = None
+        except Exception:
+            pass
 
     def apply_shortcuts(self, shortcuts_dict):
         """Apply shortcuts to title-bar menu actions without duplicating MainWindow shortcuts.
@@ -1692,6 +1996,20 @@ class TitleBar(Widget):
     def leaveEvent(self, e) -> None:
         self.mPos = None
         return super().leaveEvent(e)
+
+    def set_workflow_hint(self, workflow_id: str):
+        wf = str(workflow_id or "home").strip().lower() or "home"
+        labels = {
+            "home": self.tr("Home / Launcher"),
+            "editor": self.tr("Manga Editor"),
+            "settings": self.tr("Settings"),
+            "live": self.tr("Live Translator"),
+            "downloader": self.tr("Raw Downloader"),
+            "batch": self.tr("Batch Queue"),
+            "models": self.tr("Models"),
+            "diagnostics": self.tr("Diagnostics"),
+        }
+        self.workflowHintLabel.setText(self.tr("Workflow: {0}").format(labels.get(wf, wf)))
 
     def setTitleContent(self, proj_name: str = None, page_name: str = None, save_state: str = None):
         max_proj_len = 50

--- a/ui/mode_dashboard.py
+++ b/ui/mode_dashboard.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QPushButton, QScrollArea, QVBoxLayout, QWidget
+
+from .design_tokens import TOKENS, WORKFLOW_ACCENTS, badge_style, card_style, hero_panel_style, primary_button_style, secondary_button_style
+
+
+@dataclass(frozen=True)
+class DashboardActionSpec:
+    key: str
+    label: str
+    description: str
+    category: str = "Action"
+    primary: bool = False
+    status: str = "idle"
+
+
+@dataclass(frozen=True)
+class DashboardMetricSpec:
+    key: str
+    label: str
+    value: str
+    status: str = "idle"
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class ModeDashboardSpec:
+    key: str
+    title: str
+    description: str
+    primary_action: str = "Open"
+    actions: tuple[DashboardActionSpec, ...] = tuple()
+    metrics: tuple[DashboardMetricSpec, ...] = tuple()
+    advanced_notes: tuple[str, ...] = tuple()
+
+
+DEFAULT_MODE_DASHBOARDS: Dict[str, ModeDashboardSpec] = {
+    "editor": ModeDashboardSpec(
+        key="editor",
+        title="Manga & Comic Editor",
+        description="Production workspace for detection, OCR, translation, cleanup, typesetting, QA, and export.",
+        primary_action="Open project or folder",
+        actions=(
+            DashboardActionSpec("run_pipeline", "Run full pipeline", "Detection → OCR → Translation → Inpaint → Render.", "Pipeline", True, "running"),
+            DashboardActionSpec("selected_ocr", "OCR selected blocks", "Rerun OCR without touching the whole page.", "OCR"),
+            DashboardActionSpec("layout_review", "Review layout", "Check overflow, clipping, safe areas, and typography.", "QA", False, "warning"),
+            DashboardActionSpec("export_proof", "Export proof pack", "Create reviewer handoff with warnings and manifests.", "Export"),
+        ),
+        metrics=(
+            DashboardMetricSpec("pages", "Pages", "Project", "idle", "Shows current project/page state when wired."),
+            DashboardMetricSpec("warnings", "Warnings", "0", "success", "Typography, mask, and export warnings."),
+            DashboardMetricSpec("models", "Models", "Ready", "success", "Detector/OCR/inpaint/model health."),
+        ),
+        advanced_notes=("Keep manual text, style, mask, and layout controls visible.", "Do not hide professional scanlation tools behind a beginner-only flow."),
+    ),
+    "live": ModeDashboardSpec(
+        key="live",
+        title="Live Screen / Chrome Manhua Translator",
+        description="Watch a selected screen/window/Chrome region, OCR changed text, translate, and show an overlay.",
+        primary_action="Start live region picker",
+        actions=(
+            DashboardActionSpec("pick_region", "Select region", "Draw a screen region or choose a window.", "Capture", True, "running"),
+            DashboardActionSpec("chrome_profile", "Chrome Manhua preset", "Follow Chrome and translate after scroll changes.", "Profile", False, "experimental"),
+            DashboardActionSpec("overlay", "Overlay settings", "Opacity, click-through, font, padding, and history.", "Display"),
+            DashboardActionSpec("privacy", "Privacy controls", "Confirm captures/text are not persisted by default.", "Safety", False, "success"),
+        ),
+        metrics=(
+            DashboardMetricSpec("capture", "Capture", "Idle", "idle", "Region watcher status."),
+            DashboardMetricSpec("ocr", "OCR", "Provider", "warning", "Realtime provider health."),
+            DashboardMetricSpec("latency", "Latency", "-- ms", "idle", "OCR + translation timing."),
+        ),
+        advanced_notes=("SAM/refiner helpers should run only in high-quality/slower mode.", "Overlay must never contaminate OCR capture."),
+    ),
+    "assist": ModeDashboardSpec(
+        key="assist",
+        title="Translation Assist / QA",
+        description="ImageTrans-style professional assist surface for MT candidates, TM, glossary, concordance, SFX, and QA.",
+        primary_action="Open Translation Assist",
+        actions=(
+            DashboardActionSpec("compare", "Compare providers", "Generate candidate translations from selected providers.", "MT", True, "cat"),
+            DashboardActionSpec("tm", "Translation memory", "Find fuzzy matches and add current source/target pair.", "TM"),
+            DashboardActionSpec("glossary", "Glossary violations", "Check hard/soft termbase rules.", "QA", False, "warning"),
+            DashboardActionSpec("sfx", "SFX dictionary", "Search sound effects and lettering notes.", "Manga"),
+        ),
+        metrics=(
+            DashboardMetricSpec("candidates", "Candidates", "0", "idle", "Provider candidates for selected text."),
+            DashboardMetricSpec("glossary", "Glossary", "Ready", "success", "Termbase status."),
+            DashboardMetricSpec("qa", "QA", "Needs run", "warning", "Project/block QA status."),
+        ),
+        advanced_notes=("Never overwrite translation text unless the user applies a candidate.", "Keep TM, glossary, concordance, and SFX visible beside the selected block."),
+    ),
+    "downloader": ModeDashboardSpec(
+        key="downloader",
+        title="Raw Downloader",
+        description="Source browser, search, chapter selection, queues, health checks, and import to project.",
+        primary_action="Search sources",
+        actions=(
+            DashboardActionSpec("search", "Search manga/manhua", "Search configured source providers.", "Sources", True),
+            DashboardActionSpec("queue", "Chapter queue", "Review downloads and output structure.", "Queue"),
+            DashboardActionSpec("health", "Source health", "Check broken/experimental/disabled sources.", "Diagnostics", False, "warning"),
+            DashboardActionSpec("import", "Import to project", "Create/open Pro project from downloaded raws.", "Project"),
+        ),
+        metrics=(
+            DashboardMetricSpec("sources", "Sources", "Configured", "idle", "Registered providers."),
+            DashboardMetricSpec("queue", "Queue", "0", "idle", "Pending chapters."),
+            DashboardMetricSpec("rate", "Rate limits", "Safe", "success", "Downloader pacing status."),
+        ),
+        advanced_notes=("Experimental sources must be opt-in.", "Do not bypass DRM, paywalls, private APIs, or login restrictions."),
+    ),
+}
+
+
+class MetricCard(QFrame):
+    def __init__(self, spec: DashboardMetricSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName("MetricCard")
+        self.setStyleSheet(card_style())
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md)
+        layout.setSpacing(TOKENS.spacing.xs)
+        row = QHBoxLayout()
+        label = QLabel(spec.label, self)
+        label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        row.addWidget(label, 1)
+        status = QLabel(spec.status, self)
+        status.setStyleSheet(badge_style(spec.status))
+        row.addWidget(status)
+        layout.addLayout(row)
+        value = QLabel(spec.value, self)
+        value.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 800; color: {TOKENS.colors.text};")
+        layout.addWidget(value)
+        if spec.description:
+            desc = QLabel(spec.description, self)
+            desc.setWordWrap(True)
+            desc.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_subtle};")
+            layout.addWidget(desc)
+
+
+class ActionCard(QFrame):
+    activated = Signal(str)
+
+    def __init__(self, spec: DashboardActionSpec, workflow: str, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName("ActionCard")
+        accent = WORKFLOW_ACCENTS.get(workflow, TOKENS.colors.primary)
+        self.setStyleSheet(card_style(accent if spec.primary else None))
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md)
+        layout.setSpacing(TOKENS.spacing.sm)
+        row = QHBoxLayout()
+        title = QLabel(spec.label, self)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; font-weight: 800; color: {TOKENS.colors.text};")
+        row.addWidget(title, 1)
+        badge = QLabel(spec.category, self)
+        badge.setStyleSheet(badge_style(spec.status))
+        row.addWidget(badge)
+        layout.addLayout(row)
+        desc = QLabel(spec.description, self)
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(desc)
+        btn = QPushButton(spec.label, self)
+        btn.setStyleSheet(primary_button_style(workflow) if spec.primary else secondary_button_style())
+        btn.clicked.connect(lambda: self.activated.emit(spec.key))
+        layout.addWidget(btn)
+
+
+class ModeDashboard(QWidget):
+    """Dense, modern dashboard for each workflow mode.
+
+    Modern does not mean simple: this page exposes professional actions, health
+    metrics, and advanced notes in a polished layout instead of hiding them.
+    """
+
+    action_requested = Signal(str, str)
+
+    def __init__(self, spec: ModeDashboardSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self._build_ui()
+
+    def _build_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        scroll = QScrollArea(self)
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QFrame.Shape.NoFrame)
+        root.addWidget(scroll)
+
+        body = QWidget(scroll)
+        scroll.setWidget(body)
+        layout = QVBoxLayout(body)
+        layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
+        layout.setSpacing(TOKENS.spacing.lg)
+
+        hero = QFrame(body)
+        hero.setObjectName("ModeDashboardHero")
+        hero.setStyleSheet(hero_panel_style(self.spec.key))
+        hero_layout = QVBoxLayout(hero)
+        hero_layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
+        hero_layout.setSpacing(TOKENS.spacing.sm)
+        title = QLabel(self.spec.title, hero)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.display}px; font-weight: 900; color: {TOKENS.colors.text};")
+        hero_layout.addWidget(title)
+        desc = QLabel(self.spec.description, hero)
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
+        hero_layout.addWidget(desc)
+        primary = QPushButton(self.spec.primary_action, hero)
+        primary.setStyleSheet(primary_button_style(self.spec.key))
+        primary.clicked.connect(lambda: self.action_requested.emit(self.spec.key, "primary"))
+        hero_layout.addWidget(primary)
+        layout.addWidget(hero)
+
+        metrics_grid = QGridLayout()
+        metrics_grid.setHorizontalSpacing(TOKENS.spacing.md)
+        metrics_grid.setVerticalSpacing(TOKENS.spacing.md)
+        for idx, metric in enumerate(self.spec.metrics):
+            metrics_grid.addWidget(MetricCard(metric, body), 0, idx)
+        layout.addLayout(metrics_grid)
+
+        actions_title = QLabel(self.tr("Advanced actions"), body)
+        actions_title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 800; color: {TOKENS.colors.text};")
+        layout.addWidget(actions_title)
+        action_grid = QGridLayout()
+        action_grid.setHorizontalSpacing(TOKENS.spacing.md)
+        action_grid.setVerticalSpacing(TOKENS.spacing.md)
+        for idx, action in enumerate(self.spec.actions):
+            card = ActionCard(action, self.spec.key, body)
+            card.activated.connect(lambda action_key, mode=self.spec.key: self.action_requested.emit(mode, action_key))
+            row, col = divmod(idx, 2)
+            action_grid.addWidget(card, row, col)
+        layout.addLayout(action_grid)
+
+        if self.spec.advanced_notes:
+            notes = QFrame(body)
+            notes.setObjectName("AdvancedNotes")
+            notes.setStyleSheet(card_style(WORKFLOW_ACCENTS.get(self.spec.key)))
+            notes_layout = QVBoxLayout(notes)
+            notes_layout.setContentsMargins(TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg)
+            notes_title = QLabel(self.tr("Professional workflow notes"), notes)
+            notes_title.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; font-weight: 800;")
+            notes_layout.addWidget(notes_title)
+            for note in self.spec.advanced_notes:
+                label = QLabel(f"• {note}", notes)
+                label.setWordWrap(True)
+                label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+                notes_layout.addWidget(label)
+            layout.addWidget(notes)
+        layout.addStretch(1)
+
+
+def dashboard_for_mode(key: str, title: str, description: str) -> ModeDashboardSpec:
+    return DEFAULT_MODE_DASHBOARDS.get(key) or ModeDashboardSpec(key=key, title=title, description=description, primary_action="Open")

--- a/ui/mode_dashboard.py
+++ b/ui/mode_dashboard.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Dict, Iterable, List, Optional
 
 from qtpy.QtCore import Signal
@@ -46,13 +46,13 @@ DEFAULT_MODE_DASHBOARDS: Dict[str, ModeDashboardSpec] = {
         description="Production workspace for detection, OCR, translation, cleanup, typesetting, QA, and export.",
         primary_action="Open project or folder",
         actions=(
-            DashboardActionSpec("run_pipeline", "Run full pipeline", "Detection → OCR → Translation → Inpaint → Render.", "Pipeline", True, "running"),
+            DashboardActionSpec("run_pipeline", "Run full pipeline", "Detection -> OCR -> Translation -> Inpaint -> Render.", "Pipeline", True, "running"),
             DashboardActionSpec("selected_ocr", "OCR selected blocks", "Rerun OCR without touching the whole page.", "OCR"),
             DashboardActionSpec("layout_review", "Review layout", "Check overflow, clipping, safe areas, and typography.", "QA", False, "warning"),
             DashboardActionSpec("export_proof", "Export proof pack", "Create reviewer handoff with warnings and manifests.", "Export"),
         ),
         metrics=(
-            DashboardMetricSpec("pages", "Pages", "Project", "idle", "Shows current project/page state when wired."),
+            DashboardMetricSpec("pages", "Pages", "Project", "idle", "Current project/page state."),
             DashboardMetricSpec("warnings", "Warnings", "0", "success", "Typography, mask, and export warnings."),
             DashboardMetricSpec("models", "Models", "Ready", "success", "Detector/OCR/inpaint/model health."),
         ),
@@ -125,21 +125,39 @@ class MetricCard(QFrame):
         layout.setContentsMargins(TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md, TOKENS.spacing.md)
         layout.setSpacing(TOKENS.spacing.xs)
         row = QHBoxLayout()
-        label = QLabel(spec.label, self)
-        label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
-        row.addWidget(label, 1)
-        status = QLabel(spec.status, self)
-        status.setStyleSheet(badge_style(spec.status))
-        row.addWidget(status)
+        self.label = QLabel(spec.label, self)
+        self.label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        row.addWidget(self.label, 1)
+        self.status_label = QLabel(spec.status, self)
+        row.addWidget(self.status_label)
         layout.addLayout(row)
-        value = QLabel(spec.value, self)
-        value.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 800; color: {TOKENS.colors.text};")
-        layout.addWidget(value)
-        if spec.description:
-            desc = QLabel(spec.description, self)
-            desc.setWordWrap(True)
-            desc.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_subtle};")
-            layout.addWidget(desc)
+        self.value_label = QLabel(spec.value, self)
+        self.value_label.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 800; color: {TOKENS.colors.text};")
+        layout.addWidget(self.value_label)
+        self.description_label = QLabel("", self)
+        self.description_label.setWordWrap(True)
+        self.description_label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_subtle};")
+        layout.addWidget(self.description_label)
+        self.update_spec(spec)
+
+    def update_spec(self, spec: DashboardMetricSpec):
+        self.spec = spec
+        self.label.setText(spec.label)
+        self.status_label.setText(spec.status)
+        self.status_label.setStyleSheet(badge_style(spec.status))
+        self.value_label.setText(spec.value)
+        self.description_label.setText(spec.description or "")
+        self.description_label.setVisible(bool(spec.description))
+
+    def update_value(self, value: str, status: Optional[str] = None, description: Optional[str] = None):
+        self.update_spec(
+            replace(
+                self.spec,
+                value=str(value),
+                status=self.spec.status if status is None else str(status),
+                description=self.spec.description if description is None else str(description),
+            )
+        )
 
 
 class ActionCard(QFrame):
@@ -184,6 +202,7 @@ class ModeDashboard(QWidget):
     def __init__(self, spec: ModeDashboardSpec, parent=None):
         super().__init__(parent)
         self.spec = spec
+        self.metric_cards: Dict[str, MetricCard] = {}
         self._build_ui()
 
     def _build_ui(self):
@@ -225,7 +244,9 @@ class ModeDashboard(QWidget):
         metrics_grid.setHorizontalSpacing(TOKENS.spacing.md)
         metrics_grid.setVerticalSpacing(TOKENS.spacing.md)
         for idx, metric in enumerate(self.spec.metrics):
-            metrics_grid.addWidget(MetricCard(metric, body), 0, idx)
+            card = MetricCard(metric, body)
+            self.metric_cards[metric.key] = card
+            metrics_grid.addWidget(card, 0, idx)
         layout.addLayout(metrics_grid)
 
         actions_title = QLabel(self.tr("Advanced actions"), body)
@@ -251,12 +272,28 @@ class ModeDashboard(QWidget):
             notes_title.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; font-weight: 800;")
             notes_layout.addWidget(notes_title)
             for note in self.spec.advanced_notes:
-                label = QLabel(f"• {note}", notes)
+                label = QLabel(f"- {note}", notes)
                 label.setWordWrap(True)
                 label.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
                 notes_layout.addWidget(label)
             layout.addWidget(notes)
         layout.addStretch(1)
+
+    def update_metric(self, key: str, value: str, status: Optional[str] = None, description: Optional[str] = None) -> bool:
+        card = self.metric_cards.get(str(key or ""))
+        if card is None:
+            return False
+        card.update_value(value, status=status, description=description)
+        return True
+
+    def update_metrics(self, metrics: Iterable[DashboardMetricSpec]):
+        for metric in metrics:
+            card = self.metric_cards.get(metric.key)
+            if card is not None:
+                card.update_spec(metric)
+
+    def metric_snapshot(self) -> Dict[str, DashboardMetricSpec]:
+        return {key: card.spec for key, card in self.metric_cards.items()}
 
 
 def dashboard_for_mode(key: str, title: str, description: str) -> ModeDashboardSpec:

--- a/ui/mode_rail.py
+++ b/ui/mode_rail.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QButtonGroup, QFrame, QLabel, QSizePolicy, QToolButton, QVBoxLayout, QWidget
+
+from .design_tokens import TOKENS, WORKFLOW_ACCENTS, badge_style
+
+
+@dataclass(frozen=True)
+class ModeRailItemSpec:
+    key: str
+    label: str
+    tooltip: str = ""
+    badge: str = ""
+    status: str = "idle"
+
+
+DEFAULT_MODE_RAIL_ITEMS: tuple[ModeRailItemSpec, ...] = (
+    ModeRailItemSpec("home", "Home", "Choose a workflow or continue recent work."),
+    ModeRailItemSpec("editor", "Editor", "Manga/comic localization workspace."),
+    ModeRailItemSpec("live", "Live", "Realtime screen or Chrome manhua translation."),
+    ModeRailItemSpec("quick_image", "Quick", "Quick image translation."),
+    ModeRailItemSpec("downloader", "Raws", "Raw/source downloader."),
+    ModeRailItemSpec("batch", "Batch", "Batch queue and parent/child projects."),
+    ModeRailItemSpec("assist", "Assist", "Translation Assist and QA.", badge="CAT", status="success"),
+    ModeRailItemSpec("models", "Models", "Models and providers."),
+    ModeRailItemSpec("settings", "Settings", "App and workflow settings."),
+    ModeRailItemSpec("diagnostics", "Help", "Diagnostics, logs, docs, and support.", badge="!", status="warning"),
+)
+
+
+class ModeRailButton(QToolButton):
+    def __init__(self, spec: ModeRailItemSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName("ModeRailButton")
+        self.setText(spec.label)
+        self.setToolTip(spec.tooltip or spec.label)
+        self.setCheckable(True)
+        self.setAutoRaise(True)
+        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextOnly)
+        self.setMinimumHeight(42)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        accent = WORKFLOW_ACCENTS.get(spec.key, TOKENS.colors.border)
+        self.setStyleSheet(
+            "QToolButton#ModeRailButton {"
+            f"border: 1px solid transparent; border-radius: {TOKENS.radius.md}px;"
+            f"padding: {TOKENS.spacing.sm}px; color: {TOKENS.colors.text_muted};"
+            "text-align: left;"
+            "}"
+            "QToolButton#ModeRailButton:hover {"
+            f"border-color: {accent}; color: {TOKENS.colors.text};"
+            "}"
+            "QToolButton#ModeRailButton:checked {"
+            f"border-color: {accent}; color: {TOKENS.colors.text}; font-weight: 700;"
+            f"background: {TOKENS.colors.surface_alt};"
+            "}"
+        )
+
+
+class ModeRail(QWidget):
+    """Reusable left navigation rail for the phased UI rework.
+
+    It is intentionally independent from MainWindow.  The current left bar can
+    keep working while this rail is tested in isolation, then later replace or
+    sit beside it in the final app shell.
+    """
+
+    mode_requested = Signal(str)
+
+    def __init__(self, items: Optional[Iterable[ModeRailItemSpec]] = None, parent=None):
+        super().__init__(parent)
+        self.items: List[ModeRailItemSpec] = list(items or DEFAULT_MODE_RAIL_ITEMS)
+        self._buttons: dict[str, ModeRailButton] = {}
+        self._group = QButtonGroup(self)
+        self._group.setExclusive(True)
+        self._build_ui()
+
+    def _build_ui(self):
+        self.setObjectName("ModeRail")
+        self.setMinimumWidth(96)
+        self.setMaximumWidth(160)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.sm, TOKENS.spacing.md, TOKENS.spacing.sm, TOKENS.spacing.md)
+        layout.setSpacing(TOKENS.spacing.sm)
+
+        title = QLabel(self.tr("Modes"))
+        title.setObjectName("ModeRailTitle")
+        title.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        title.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(title)
+
+        for spec in self.items:
+            btn = ModeRailButton(spec, self)
+            self._buttons[spec.key] = btn
+            self._group.addButton(btn)
+            btn.clicked.connect(lambda checked=False, key=spec.key: self.mode_requested.emit(key))
+            layout.addWidget(btn)
+            if spec.badge:
+                badge = QLabel(spec.badge)
+                badge.setAlignment(Qt.AlignmentFlag.AlignCenter)
+                badge.setStyleSheet(badge_style(spec.status))
+                layout.addWidget(badge)
+
+        layout.addStretch(1)
+
+    def set_current_mode(self, key: str):
+        btn = self._buttons.get(str(key or ""))
+        if btn is not None:
+            btn.setChecked(True)
+
+    def current_mode(self) -> str:
+        for key, btn in self._buttons.items():
+            if btn.isChecked():
+                return key
+        return ""
+
+    def mode_keys(self) -> List[str]:
+        return [it.key for it in self.items]
+
+    def button_for_mode(self, key: str) -> Optional[ModeRailButton]:
+        return self._buttons.get(key)

--- a/ui/realtime_translator_dialog.py
+++ b/ui/realtime_translator_dialog.py
@@ -4,6 +4,7 @@ from qtpy.QtCore import QTimer
 import numpy as np
 
 from utils.realtime_mode import RealtimeRegion, RealtimeWatcher, NumpyFrameBackend, create_screenshot_backend, OverlayExclusionBackend
+from utils.config import pcfg, save_config
 
 
 class RealtimeTranslatorDialog(QDialog):
@@ -13,10 +14,19 @@ class RealtimeTranslatorDialog(QDialog):
         self.resize(520, 420)
         root = QVBoxLayout(self)
         row = QHBoxLayout()
+        self.profile_combo = QComboBox(self)
+        self.profile_combo.addItem(self.tr("Chrome Manhua Reader"), "chrome_manhua_reader")
+        self.profile_combo.addItem(self.tr("Manga Reader"), "manga_reader")
+        self.profile_combo.addItem(self.tr("Generic Screen OCR"), "generic_screen_ocr")
+        _profile = str(getattr(pcfg, "realtime_profile_id", "generic_screen_ocr") or "generic_screen_ocr")
+        _pidx = self.profile_combo.findData(_profile)
+        self.profile_combo.setCurrentIndex(_pidx if _pidx >= 0 else 2)
         self.ocr_combo = QComboBox(self)
         self.ocr_combo.addItems(["auto", "manga_ocr", "paddle", "llm_ocr"])
         self.tr_combo = QComboBox(self)
         self.tr_combo.addItems(["google", "deepl", "openai", "ollama"])
+        row.addWidget(QLabel(self.tr("Profile"), self))
+        row.addWidget(self.profile_combo)
         row.addWidget(QLabel(self.tr("OCR"), self))
         row.addWidget(self.ocr_combo)
         row.addWidget(QLabel(self.tr("Translator"), self))
@@ -28,20 +38,32 @@ class RealtimeTranslatorDialog(QDialog):
         root.addWidget(self.privacy_hint)
 
         self.follow_window = QCheckBox(self.tr("Follow selected window (when available)"), self)
+        self.follow_window.setChecked(bool(getattr(pcfg, "realtime_follow_window", False)))
+        self.follow_window.toggled.connect(lambda *_: self._persist_settings())
         root.addWidget(self.follow_window)
+        self.status_hint = QLabel(self.tr("Status: idle"), self)
+        self.status_hint.setStyleSheet("color: gray;")
+        root.addWidget(self.status_hint)
 
         form = QFormLayout()
         self.x_spin = QSpinBox(self); self.x_spin.setRange(0, 10000)
         self.y_spin = QSpinBox(self); self.y_spin.setRange(0, 10000)
         self.w_spin = QSpinBox(self); self.w_spin.setRange(1, 10000); self.w_spin.setValue(100)
         self.h_spin = QSpinBox(self); self.h_spin.setRange(1, 10000); self.h_spin.setValue(100)
+        _rect = list(getattr(pcfg, "realtime_region_rect", [0, 0, 100, 100]) or [0, 0, 100, 100])
+        while len(_rect) < 4:
+            _rect.append(0)
+        self.x_spin.setValue(int(_rect[0]))
+        self.y_spin.setValue(int(_rect[1]))
+        self.w_spin.setValue(max(1, int(_rect[2] or 100)))
+        self.h_spin.setValue(max(1, int(_rect[3] or 100)))
         form.addRow(self.tr("Region X"), self.x_spin)
         form.addRow(self.tr("Region Y"), self.y_spin)
         form.addRow(self.tr("Region Width"), self.w_spin)
         form.addRow(self.tr("Region Height"), self.h_spin)
 
-        self.capture_interval_ms = QSpinBox(self); self.capture_interval_ms.setRange(100, 5000); self.capture_interval_ms.setValue(700)
-        self.min_ocr_interval_ms = QSpinBox(self); self.min_ocr_interval_ms.setRange(0, 5000); self.min_ocr_interval_ms.setValue(0)
+        self.capture_interval_ms = QSpinBox(self); self.capture_interval_ms.setRange(100, 5000); self.capture_interval_ms.setValue(int(getattr(pcfg, "realtime_capture_interval_ms", 700) or 700))
+        self.min_ocr_interval_ms = QSpinBox(self); self.min_ocr_interval_ms.setRange(0, 5000); self.min_ocr_interval_ms.setValue(int(getattr(pcfg, "realtime_min_ocr_interval_ms", 0) or 0))
         form.addRow(self.tr("Capture interval (ms)"), self.capture_interval_ms)
         form.addRow(self.tr("Min OCR interval (ms)"), self.min_ocr_interval_ms)
         root.addLayout(form)
@@ -64,9 +86,8 @@ class RealtimeTranslatorDialog(QDialog):
         self._overlay.setStyleSheet("background: rgba(0,0,0,180); color: white; padding: 8px;")
         self._overlay.hide()
 
-        frames = [np.zeros((20, 40, 3), dtype=np.uint8), np.ones((20, 40, 3), dtype=np.uint8) * 255]
-        self._backend = NumpyFrameBackend(frames)
-        self._fallback_backend = create_screenshot_backend("auto")
+        self._backend = create_screenshot_backend("auto")
+        self._fallback_backend = NumpyFrameBackend([np.zeros((20, 40, 3), dtype=np.uint8)])
         self._wrapped_backend = OverlayExclusionBackend(self._backend, self._hide_overlay_for_capture, self._show_overlay_after_capture)
         self._watcher = RealtimeWatcher(self._wrapped_backend, lambda img: "示例文本" if img.mean() > 1 else "", lambda t: "sample translation")
         self._region = RealtimeRegion("default", (0, 0, 100, 100))
@@ -74,18 +95,35 @@ class RealtimeTranslatorDialog(QDialog):
         self._timer.setInterval(self.capture_interval_ms.value())
         self._timer.timeout.connect(self._tick)
         self.capture_interval_ms.valueChanged.connect(self._timer.setInterval)
+        self.profile_combo.currentIndexChanged.connect(lambda *_: self._persist_settings())
         self.min_ocr_interval_ms.valueChanged.connect(self._update_min_ocr_interval)
+        self.x_spin.valueChanged.connect(lambda *_: self._persist_settings())
+        self.y_spin.valueChanged.connect(lambda *_: self._persist_settings())
+        self.w_spin.valueChanged.connect(lambda *_: self._persist_settings())
+        self.h_spin.valueChanged.connect(lambda *_: self._persist_settings())
 
-        self.start_btn.clicked.connect(lambda: self._timer.start())
-        self.pause_btn.clicked.connect(lambda: self._timer.stop())
+        self.start_btn.clicked.connect(self._start_live)
+        self.pause_btn.clicked.connect(self._pause_live)
         self.now_btn.clicked.connect(self._tick)
         self._append_backend_info()
 
+    def _start_live(self):
+        self._persist_settings()
+        self._timer.start()
+        self.status_hint.setText(self.tr("Status: running"))
+
+    def _pause_live(self):
+        self._timer.stop()
+        self.status_hint.setText(self.tr("Status: paused"))
+
     def _tick(self):
+        self._region.profile = str(self.profile_combo.currentData() or "generic_screen_ocr")
+        self._region.follow_window = bool(self.follow_window.isChecked())
         self._region.rect = (self.x_spin.value(), self.y_spin.value(), self.w_spin.value(), self.h_spin.value())
         st = self._watcher.tick(self._region)
         line = f"status={st.status} | src={st.last_ocr_text} | tr={st.last_translation}"
         self.output.appendPlainText(line)
+        self.status_hint.setText(self.tr("Status: {0}").format(st.status))
         if st.last_translation:
             self._overlay.setText(st.last_translation)
             self._overlay.adjustSize()
@@ -93,6 +131,7 @@ class RealtimeTranslatorDialog(QDialog):
 
     def _update_min_ocr_interval(self):
         self._watcher.min_ocr_interval_sec = float(self.min_ocr_interval_ms.value()) / 1000.0
+        self._persist_settings()
 
     def _append_backend_info(self):
         primary = getattr(self._wrapped_backend, "backend_name", "unknown")
@@ -106,4 +145,13 @@ class RealtimeTranslatorDialog(QDialog):
             self._overlay.hide()
 
     def _show_overlay_after_capture(self):
-        pass
+        if self._timer.isActive() and bool(getattr(self._watcher, "state_by_region", None)):
+            self._overlay.show()
+
+    def _persist_settings(self):
+        pcfg.realtime_profile_id = str(self.profile_combo.currentData() or "generic_screen_ocr")
+        pcfg.realtime_capture_interval_ms = int(self.capture_interval_ms.value())
+        pcfg.realtime_min_ocr_interval_ms = int(self.min_ocr_interval_ms.value())
+        pcfg.realtime_follow_window = bool(self.follow_window.isChecked())
+        pcfg.realtime_region_rect = [int(self.x_spin.value()), int(self.y_spin.value()), int(self.w_spin.value()), int(self.h_spin.value())]
+        save_config()

--- a/ui/task_job_bridge.py
+++ b/ui/task_job_bridge.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Tuple
+
+from .job_status_drawer import JobStatusSpec
+
+
+@dataclass(frozen=True)
+class DashboardTaskJobSpec:
+    mode: str
+    action: str
+    job_id: str
+    title: str
+    kind: str
+    status: str = "running"
+    progress: int = 5
+    detail: str = ""
+    can_cancel: bool = False
+
+
+DASHBOARD_TASK_JOBS: Dict[Tuple[str, str], DashboardTaskJobSpec] = {
+    ("editor", "run_pipeline"): DashboardTaskJobSpec(
+        "editor",
+        "run_pipeline",
+        "pipeline-current",
+        "Pipeline",
+        "Pipeline",
+        "running",
+        1,
+        "Pipeline launched from dashboard.",
+        True,
+    ),
+    ("editor", "export_proof"): DashboardTaskJobSpec(
+        "editor",
+        "export_proof",
+        "export-proof-pack",
+        "Export proof pack",
+        "Export",
+        "running",
+        10,
+        "Proof-pack export launched from dashboard.",
+        False,
+    ),
+    ("downloader", "primary"): DashboardTaskJobSpec(
+        "downloader",
+        "primary",
+        "raw-downloader",
+        "Raw downloader",
+        "Download",
+        "running",
+        5,
+        "Raw downloader opened. Select sources/chapters to start downloads.",
+        False,
+    ),
+    ("downloader", "search"): DashboardTaskJobSpec(
+        "downloader",
+        "search",
+        "raw-downloader",
+        "Raw downloader",
+        "Download",
+        "running",
+        5,
+        "Raw source search opened from dashboard.",
+        False,
+    ),
+    ("downloader", "queue"): DashboardTaskJobSpec(
+        "downloader",
+        "queue",
+        "chapter-download-queue",
+        "Chapter queue",
+        "Queue",
+        "running",
+        5,
+        "Chapter/download queue opened from dashboard.",
+        False,
+    ),
+    ("downloader", "import"): DashboardTaskJobSpec(
+        "downloader",
+        "import",
+        "raw-import",
+        "Import raws",
+        "Project",
+        "running",
+        10,
+        "Import-to-project flow launched from dashboard.",
+        False,
+    ),
+    ("batch", "primary"): DashboardTaskJobSpec(
+        "batch",
+        "primary",
+        "batch-queue",
+        "Batch queue",
+        "Batch",
+        "running",
+        5,
+        "Batch queue opened from dashboard.",
+        True,
+    ),
+    ("models", "primary"): DashboardTaskJobSpec(
+        "models",
+        "primary",
+        "model-manager",
+        "Models & providers",
+        "Models",
+        "running",
+        5,
+        "Model/provider manager opened from dashboard.",
+        False,
+    ),
+    ("assist", "primary"): DashboardTaskJobSpec(
+        "assist",
+        "primary",
+        "translation-assist",
+        "Translation Assist",
+        "Assist",
+        "running",
+        5,
+        "Translation Assist opened from dashboard.",
+        False,
+    ),
+    ("assist", "compare"): DashboardTaskJobSpec(
+        "assist",
+        "compare",
+        "translation-assist-compare",
+        "Compare providers",
+        "Assist",
+        "running",
+        10,
+        "Provider comparison requested from dashboard.",
+        False,
+    ),
+}
+
+
+def dashboard_task_job_for(mode: str, action: str) -> Optional[DashboardTaskJobSpec]:
+    return DASHBOARD_TASK_JOBS.get((str(mode or ""), str(action or "")))
+
+
+def _drawer_for(mainwindow):
+    return getattr(mainwindow, "jobStatusDrawer", None)
+
+
+def upsert_task_job(mainwindow, spec: DashboardTaskJobSpec, *, handled: bool = True) -> bool:
+    drawer = _drawer_for(mainwindow)
+    if drawer is None or not hasattr(drawer, "upsert_job"):
+        return False
+    status = spec.status if handled else "warning"
+    detail = spec.detail if handled else f"{spec.detail} Action did not complete; check the legacy UI."
+    try:
+        drawer.upsert_job(
+            JobStatusSpec(
+                job_id=spec.job_id,
+                title=spec.title,
+                kind=spec.kind,
+                status=status,
+                progress=max(0, min(100, int(spec.progress))),
+                detail=detail,
+                can_cancel=spec.can_cancel,
+                warnings=[] if handled else ["Dashboard action was not handled by the existing UI."],
+            )
+        )
+        return True
+    except Exception:
+        return False
+
+
+def mirror_dashboard_task_job(mainwindow, mode: str, action: str, *, handled: bool = True) -> bool:
+    spec = dashboard_task_job_for(mode, action)
+    if spec is None:
+        return False
+    return upsert_task_job(mainwindow, spec, handled=handled)
+
+
+def complete_task_job(mainwindow, job_id: str, *, detail: str = "Completed") -> bool:
+    drawer = _drawer_for(mainwindow)
+    if drawer is None or not hasattr(drawer, "_jobs") or not hasattr(drawer, "upsert_job"):
+        return False
+    current = getattr(drawer, "_jobs", {}).get(job_id)
+    if current is None:
+        return False
+    try:
+        drawer.upsert_job(
+            JobStatusSpec(
+                job_id=job_id,
+                title=current.title,
+                kind=current.kind,
+                status="success",
+                progress=100,
+                detail=detail,
+                can_cancel=False,
+                warnings=list(current.warnings or []),
+            )
+        )
+        return True
+    except Exception:
+        return False

--- a/ui/theme_customizer_dialog.py
+++ b/ui/theme_customizer_dialog.py
@@ -46,6 +46,8 @@ class ThemeCustomizerDialog(QDialog):
     """Dialog to customize theme (light/dark), accent color, app font, and UI style (simple vs advanced)."""
 
     theme_applied = Signal(str, int)  # font_family, font_size (so main window applies exactly what was selected)
+    ui_mode_changed = Signal(str)
+    startup_mode_changed = Signal(str)
 
     def __init__(self, parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -103,6 +105,46 @@ class ThemeCustomizerDialog(QDialog):
         font_layout.addWidget(self.font_size_spin)
         layout.addWidget(font_grp)
 
+        # --- UI mode ---
+        ui_grp = QGroupBox(self.tr("UI mode"))
+        ui_layout = QHBoxLayout(ui_grp)
+        ui_layout.addWidget(QLabel(self.tr("Complexity:")))
+        self.ui_mode_combo = QComboBox(self)
+        self.ui_mode_combo.addItem(self.tr("Simple"), "simple")
+        self.ui_mode_combo.addItem(self.tr("Advanced"), "advanced")
+        self.ui_mode_combo.addItem(self.tr("Developer"), "developer")
+        current_mode = str(getattr(pcfg, "ui_mode", "advanced") or "advanced")
+        idx = max(0, self.ui_mode_combo.findData(current_mode))
+        self.ui_mode_combo.setCurrentIndex(idx)
+        self.ui_mode_combo.setToolTip(self.tr("Simple hides advanced and diagnostic-heavy actions. Advanced keeps full standard menus. Developer keeps all actions and diagnostics."))
+        ui_layout.addWidget(self.ui_mode_combo)
+
+        self.show_legacy_checker = QCheckBox(self.tr("Show legacy menu layout"))
+        self.show_legacy_checker.setChecked(bool(getattr(pcfg, "show_legacy_menus", True)))
+        self.show_legacy_checker.setToolTip(self.tr("Keep the current classic menu layout visible while the new workflow UI rolls out."))
+        ui_layout.addWidget(self.show_legacy_checker)
+        layout.addWidget(ui_grp)
+
+        startup_grp = QGroupBox(self.tr("Startup"))
+        startup_layout = QHBoxLayout(startup_grp)
+        startup_layout.addWidget(QLabel(self.tr("Open on launch:")))
+        self.startup_mode_combo = QComboBox(self)
+        self.startup_mode_combo.addItem(self.tr("Home / Launcher"), "home")
+        self.startup_mode_combo.addItem(self.tr("Editor"), "editor")
+        self.startup_mode_combo.addItem(self.tr("Last used workflow"), "last_used")
+        self.startup_mode_combo.addItem(self.tr("Settings"), "settings")
+        self.startup_mode_combo.addItem(self.tr("Live translator"), "live")
+        self.startup_mode_combo.addItem(self.tr("Raw downloader"), "downloader")
+        self.startup_mode_combo.addItem(self.tr("Batch queue"), "batch")
+        self.startup_mode_combo.addItem(self.tr("Models hub"), "models")
+        self.startup_mode_combo.addItem(self.tr("Diagnostics"), "diagnostics")
+        _sm = str(getattr(pcfg, "startup_mode", "last_used") or "last_used")
+        _idx = self.startup_mode_combo.findData(_sm)
+        self.startup_mode_combo.setCurrentIndex(_idx if _idx >= 0 else 0)
+        self.startup_mode_combo.setToolTip(self.tr("Default startup target when no explicit project path is provided."))
+        startup_layout.addWidget(self.startup_mode_combo)
+        layout.addWidget(startup_grp)
+
         # Buttons
         btn_layout = QHBoxLayout()
         btn_layout.setSpacing(8)
@@ -146,5 +188,10 @@ class ThemeCustomizerDialog(QDialog):
         size = max(0, self.font_size_spin.value())
         pcfg.app_font_family = family
         pcfg.app_font_size = size
+        pcfg.ui_mode = str(self.ui_mode_combo.currentData() or "advanced")
+        pcfg.show_legacy_menus = bool(self.show_legacy_checker.isChecked())
+        pcfg.startup_mode = str(self.startup_mode_combo.currentData() or "last_used")
         save_config()
         self.theme_applied.emit(family, size)
+        self.ui_mode_changed.emit(pcfg.ui_mode)
+        self.startup_mode_changed.emit(pcfg.startup_mode)

--- a/ui/welcome_widget.py
+++ b/ui/welcome_widget.py
@@ -128,6 +128,11 @@ class WelcomeWidget(Widget):
     open_images_requested = Signal()
     open_acbf_requested = Signal()
     recent_project_clicked = Signal(str)
+    open_live_requested = Signal()
+    open_downloader_requested = Signal()
+    open_batch_requested = Signal()
+    open_models_requested = Signal()
+    open_diagnostics_requested = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -157,7 +162,7 @@ class WelcomeWidget(Widget):
         title.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
-        subtitle = QLabel(self.tr("Open a project folder or choose a recent one to start."))
+        subtitle = QLabel(self.tr("Choose a workflow to begin, or open a recent project."))
         subtitle.setObjectName("WelcomeSubtitle")
         subtitle.setAlignment(Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(subtitle)
@@ -200,6 +205,49 @@ class WelcomeWidget(Widget):
         btn_layout.addStretch()
         actions_card.addLayout(btn_layout)
         layout.addWidget(actions_card)
+
+        workflows_card = WelcomeCard(self.tr("Workflows"), self)
+        wf_layout = QHBoxLayout()
+        wf_layout.setSpacing(10)
+
+        self._btn_wf_editor = NoBorderPushBtn(self.tr("Manga Editor  ·  Recommended"))
+        self._btn_wf_editor.setToolTip(self.tr("Open folder/project/images to edit manga/comic pages."))
+        self._btn_wf_editor.setMinimumHeight(40)
+        self._btn_wf_editor.clicked.connect(self._on_open_folder)
+        wf_layout.addWidget(self._btn_wf_editor)
+
+        self._btn_wf_live = NoBorderPushBtn(self.tr("Live Translator"))
+        self._btn_wf_live.setToolTip(self.tr("Realtime OCR + translation over your screen selection."))
+        self._btn_wf_live.setMinimumHeight(40)
+        self._btn_wf_live.clicked.connect(self.open_live_requested.emit)
+        wf_layout.addWidget(self._btn_wf_live)
+
+        self._btn_wf_downloader = NoBorderPushBtn(self.tr("Raw Downloader"))
+        self._btn_wf_downloader.setToolTip(self.tr("Search/download chapters from manga/manhua sources."))
+        self._btn_wf_downloader.setMinimumHeight(40)
+        self._btn_wf_downloader.clicked.connect(self.open_downloader_requested.emit)
+        wf_layout.addWidget(self._btn_wf_downloader)
+
+        self._btn_wf_batch = NoBorderPushBtn(self.tr("Batch Queue"))
+        self._btn_wf_batch.setToolTip(self.tr("Queue multiple folders for automated processing."))
+        self._btn_wf_batch.setMinimumHeight(40)
+        self._btn_wf_batch.clicked.connect(self.open_batch_requested.emit)
+        wf_layout.addWidget(self._btn_wf_batch)
+
+        self._btn_wf_models = NoBorderPushBtn(self.tr("Models"))
+        self._btn_wf_models.setToolTip(self.tr("Manage model downloads, caches, and runtime resources."))
+        self._btn_wf_models.setMinimumHeight(40)
+        self._btn_wf_models.clicked.connect(self.open_models_requested.emit)
+        wf_layout.addWidget(self._btn_wf_models)
+
+        self._btn_wf_diag = NoBorderPushBtn(self.tr("Diagnostics / Help"))
+        self._btn_wf_diag.setToolTip(self.tr("Run environment checks and export diagnostics."))
+        self._btn_wf_diag.setMinimumHeight(40)
+        self._btn_wf_diag.clicked.connect(self.open_diagnostics_requested.emit)
+        wf_layout.addWidget(self._btn_wf_diag)
+
+        workflows_card.addLayout(wf_layout)
+        layout.addWidget(workflows_card)
 
         # Recent projects card
         self._recent_card = WelcomeCard(self.tr("Recent projects"), self)

--- a/ui/welcome_widget.py
+++ b/ui/welcome_widget.py
@@ -22,6 +22,7 @@ from .custom_widget.push_button import NoBorderPushBtn
 from .custom_widget.helper import isDarkTheme
 from .workflow_home import WorkflowHomeWidget
 from .default_modern_shell import install_default_modern_navigation, install_default_welcome_signal_fallbacks
+from .default_mode_dashboards import install_default_mode_dashboards
 
 
 def _welcome_stylesheet(dark: bool) -> str:
@@ -166,6 +167,7 @@ class WelcomeWidget(Widget):
             mainwindow = self.parentWidget()
         install_default_welcome_signal_fallbacks(self, mainwindow)
         install_default_modern_navigation(mainwindow)
+        install_default_mode_dashboards(mainwindow)
 
     def _build_ui(self):
         layout = QVBoxLayout(self)

--- a/ui/welcome_widget.py
+++ b/ui/welcome_widget.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 Welcome / first-start screen when no project is open.
-Inspired by manhua-translator and Komakun: select or create project from a single, bubbly welcome view.
+Inspired by manhua-translator, Komakun, Dango-style workflow cards, and ImageTrans-style production entry points.
 """
 import os.path as osp
 
@@ -20,6 +20,7 @@ from qtpy.QtCore import Qt, Signal, QTimer
 from .custom_widget import Widget
 from .custom_widget.push_button import NoBorderPushBtn
 from .custom_widget.helper import isDarkTheme
+from .workflow_home import WorkflowHomeWidget
 
 
 def _welcome_stylesheet(dark: bool) -> str:
@@ -122,7 +123,7 @@ class WelcomeCard(QFrame):
 
 
 class WelcomeWidget(Widget):
-    """First-start / welcome screen: open or create project, recent projects list."""
+    """First-start / welcome screen: open projects, choose workflows, and resume recent work."""
     open_folder_requested = Signal()
     open_project_requested = Signal(str)
     open_images_requested = Signal()
@@ -133,6 +134,7 @@ class WelcomeWidget(Widget):
     open_batch_requested = Signal()
     open_models_requested = Signal()
     open_diagnostics_requested = Signal()
+    open_assist_requested = Signal()
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -206,48 +208,11 @@ class WelcomeWidget(Widget):
         actions_card.addLayout(btn_layout)
         layout.addWidget(actions_card)
 
-        workflows_card = WelcomeCard(self.tr("Workflows"), self)
-        wf_layout = QHBoxLayout()
-        wf_layout.setSpacing(10)
-
-        self._btn_wf_editor = NoBorderPushBtn(self.tr("Manga Editor  ·  Recommended"))
-        self._btn_wf_editor.setToolTip(self.tr("Open folder/project/images to edit manga/comic pages."))
-        self._btn_wf_editor.setMinimumHeight(40)
-        self._btn_wf_editor.clicked.connect(self._on_open_folder)
-        wf_layout.addWidget(self._btn_wf_editor)
-
-        self._btn_wf_live = NoBorderPushBtn(self.tr("Live Translator"))
-        self._btn_wf_live.setToolTip(self.tr("Realtime OCR + translation over your screen selection."))
-        self._btn_wf_live.setMinimumHeight(40)
-        self._btn_wf_live.clicked.connect(self.open_live_requested.emit)
-        wf_layout.addWidget(self._btn_wf_live)
-
-        self._btn_wf_downloader = NoBorderPushBtn(self.tr("Raw Downloader"))
-        self._btn_wf_downloader.setToolTip(self.tr("Search/download chapters from manga/manhua sources."))
-        self._btn_wf_downloader.setMinimumHeight(40)
-        self._btn_wf_downloader.clicked.connect(self.open_downloader_requested.emit)
-        wf_layout.addWidget(self._btn_wf_downloader)
-
-        self._btn_wf_batch = NoBorderPushBtn(self.tr("Batch Queue"))
-        self._btn_wf_batch.setToolTip(self.tr("Queue multiple folders for automated processing."))
-        self._btn_wf_batch.setMinimumHeight(40)
-        self._btn_wf_batch.clicked.connect(self.open_batch_requested.emit)
-        wf_layout.addWidget(self._btn_wf_batch)
-
-        self._btn_wf_models = NoBorderPushBtn(self.tr("Models"))
-        self._btn_wf_models.setToolTip(self.tr("Manage model downloads, caches, and runtime resources."))
-        self._btn_wf_models.setMinimumHeight(40)
-        self._btn_wf_models.clicked.connect(self.open_models_requested.emit)
-        wf_layout.addWidget(self._btn_wf_models)
-
-        self._btn_wf_diag = NoBorderPushBtn(self.tr("Diagnostics / Help"))
-        self._btn_wf_diag.setToolTip(self.tr("Run environment checks and export diagnostics."))
-        self._btn_wf_diag.setMinimumHeight(40)
-        self._btn_wf_diag.clicked.connect(self.open_diagnostics_requested.emit)
-        wf_layout.addWidget(self._btn_wf_diag)
-
-        workflows_card.addLayout(wf_layout)
-        layout.addWidget(workflows_card)
+        # Dango-style workflow cards.  Kept as a standalone widget so the final
+        # app-shell rework can promote it without rewriting the welcome screen.
+        self._workflow_home = WorkflowHomeWidget(parent=self)
+        self._workflow_home.workflow_requested.connect(self._on_workflow_requested)
+        layout.addWidget(self._workflow_home)
 
         # Recent projects card
         self._recent_card = WelcomeCard(self.tr("Recent projects"), self)
@@ -270,6 +235,26 @@ class WelcomeWidget(Widget):
         layout.addWidget(self._recent_card)
 
         layout.addStretch()
+
+    def _on_workflow_requested(self, key: str):
+        if key == "editor":
+            self._on_open_folder()
+        elif key == "live":
+            self.open_live_requested.emit()
+        elif key == "quick_image":
+            self.open_images_requested.emit()
+        elif key == "downloader":
+            self.open_downloader_requested.emit()
+        elif key == "batch":
+            self.open_batch_requested.emit()
+        elif key == "assist":
+            self.open_assist_requested.emit()
+        elif key == "models":
+            self.open_models_requested.emit()
+        elif key == "diagnostics":
+            self.open_diagnostics_requested.emit()
+        else:
+            self._on_open_folder()
 
     def _on_open_folder(self):
         self.open_folder_requested.emit()

--- a/ui/welcome_widget.py
+++ b/ui/welcome_widget.py
@@ -21,6 +21,7 @@ from .custom_widget import Widget
 from .custom_widget.push_button import NoBorderPushBtn
 from .custom_widget.helper import isDarkTheme
 from .workflow_home import WorkflowHomeWidget
+from .default_modern_shell import install_default_modern_navigation, install_default_welcome_signal_fallbacks
 
 
 def _welcome_stylesheet(dark: bool) -> str:
@@ -142,6 +143,10 @@ class WelcomeWidget(Widget):
         self._recent_buttons = []
         self._build_ui()
         self._update_styles()
+        # Install the new default shell even if the welcome page is not shown
+        # (for example, direct-open project startup).  The installer is idempotent
+        # and safely no-ops until MainWindow's layout exists.
+        QTimer.singleShot(0, self._install_default_modern_shell)
 
     def _update_styles(self):
         """Apply cohesive light/dark styles from current theme."""
@@ -152,6 +157,15 @@ class WelcomeWidget(Widget):
         # Defer stylesheet update to avoid QPainter conflicts with QGraphicsOpacityEffect
         # during the show/paint cycle (fixes "paint device can only be painted by one painter" spam).
         QTimer.singleShot(0, self._update_styles)
+        QTimer.singleShot(0, self._install_default_modern_shell)
+
+    def _install_default_modern_shell(self):
+        """Promote the modern navigation shell into the default app layout."""
+        mainwindow = self.window()
+        if mainwindow is self:
+            mainwindow = self.parentWidget()
+        install_default_welcome_signal_fallbacks(self, mainwindow)
+        install_default_modern_navigation(mainwindow)
 
     def _build_ui(self):
         layout = QVBoxLayout(self)

--- a/ui/workflow_home.py
+++ b/ui/workflow_home.py
@@ -7,7 +7,16 @@ from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
 
 from .custom_widget.push_button import NoBorderPushBtn
-from .design_tokens import TOKENS, WORKFLOW_ACCENTS, badge_style, card_style
+from .design_tokens import (
+    TOKENS,
+    WORKFLOW_ACCENTS,
+    WORKFLOW_GRADIENTS,
+    badge_style,
+    card_hover_style,
+    card_style,
+    hero_panel_style,
+    primary_button_style,
+)
 
 
 @dataclass(frozen=True)
@@ -22,78 +31,14 @@ class WorkflowCardSpec:
 
 
 DEFAULT_WORKFLOW_CARDS: tuple[WorkflowCardSpec, ...] = (
-    WorkflowCardSpec(
-        key="editor",
-        title="Manga & Comic Editor",
-        description="Open raws or an existing project for OCR, translation, inpaint, typesetting, QA, and export.",
-        primary_action="Open project or folder",
-        badge="Production",
-        recommended_for="Best for scanlation and full chapter work.",
-        status="running",
-    ),
-    WorkflowCardSpec(
-        key="live",
-        title="Live Screen Translator",
-        description="Translate a selected screen or Chrome manhua reader region without creating a full project.",
-        primary_action="Start live mode",
-        badge="Reader",
-        recommended_for="Best for reading in Chrome, games, or visual novels.",
-        status="experimental",
-    ),
-    WorkflowCardSpec(
-        key="quick_image",
-        title="Image Quick Translation",
-        description="Drop one or more images, run default OCR/translation/inpaint, preview, and export quickly.",
-        primary_action="Translate images",
-        badge="Fast",
-        recommended_for="Best for one-off images and testing providers.",
-        status="success",
-    ),
-    WorkflowCardSpec(
-        key="downloader",
-        title="Raw Downloader",
-        description="Search sources, choose chapters, queue downloads, and import results into a project.",
-        primary_action="Find raws",
-        badge="Sources",
-        recommended_for="Best before starting a chapter project.",
-        status="warning",
-    ),
-    WorkflowCardSpec(
-        key="batch",
-        title="Batch Queue",
-        description="Process multiple folders, archives, or child projects with progress, cancel, and resume.",
-        primary_action="Open queue",
-        badge="Automation",
-        recommended_for="Best for many chapters or repeated jobs.",
-        status="idle",
-    ),
-    WorkflowCardSpec(
-        key="assist",
-        title="Translation Assist / QA",
-        description="Compare providers, TM matches, glossary hits, concordance, SFX suggestions, and QA warnings.",
-        primary_action="Open assist",
-        badge="CAT",
-        recommended_for="Best for final polish and consistency.",
-        status="success",
-    ),
-    WorkflowCardSpec(
-        key="models",
-        title="Models & Providers",
-        description="Install models, test OCR/translation providers, check caches, and fix missing dependencies.",
-        primary_action="Manage setup",
-        badge="Setup",
-        recommended_for="Best when a module fails or first-run setup is incomplete.",
-        status="idle",
-    ),
-    WorkflowCardSpec(
-        key="diagnostics",
-        title="Diagnostics / Help",
-        description="Run environment checks, inspect logs, export startup reports, and find docs.",
-        primary_action="Open diagnostics",
-        badge="Support",
-        recommended_for="Best when something looks broken.",
-        status="warning",
-    ),
+    WorkflowCardSpec("editor", "Manga & Comic Editor", "Open raws or an existing project for OCR, translation, inpaint, typesetting, QA, and export.", "Open project or folder", "Production", "Best for scanlation and full chapter work.", "running"),
+    WorkflowCardSpec("live", "Live Screen Translator", "Translate a selected screen or Chrome manhua reader region without creating a full project.", "Start live mode", "Reader", "Best for reading in Chrome, games, or visual novels.", "experimental"),
+    WorkflowCardSpec("quick_image", "Image Quick Translation", "Drop one or more images, run default OCR/translation/inpaint, preview, and export quickly.", "Translate images", "Fast", "Best for one-off images and testing providers.", "success"),
+    WorkflowCardSpec("downloader", "Raw Downloader", "Search sources, choose chapters, queue downloads, and import results into a project.", "Find raws", "Sources", "Best before starting a chapter project.", "warning"),
+    WorkflowCardSpec("batch", "Batch Queue", "Process multiple folders, archives, or child projects with progress, cancel, and resume.", "Open queue", "Automation", "Best for many chapters or repeated jobs.", "idle"),
+    WorkflowCardSpec("assist", "Translation Assist / QA", "Compare providers, TM matches, glossary hits, concordance, SFX suggestions, and QA warnings.", "Open assist", "CAT", "Best for final polish and consistency.", "success"),
+    WorkflowCardSpec("models", "Models & Providers", "Install models, test OCR/translation providers, check caches, and fix missing dependencies.", "Manage setup", "Setup", "Best when a module fails or first-run setup is incomplete.", "idle"),
+    WorkflowCardSpec("diagnostics", "Diagnostics / Help", "Run environment checks, inspect logs, export startup reports, and find docs.", "Open diagnostics", "Support", "Best when something looks broken.", "warning"),
 )
 
 
@@ -106,18 +51,36 @@ class WorkflowCard(QFrame):
         self.setObjectName("WorkflowCard")
         self.setFrameShape(QFrame.Shape.NoFrame)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
-        self.setMinimumHeight(160)
+        self.setMinimumHeight(178)
         accent = WORKFLOW_ACCENTS.get(spec.key, TOKENS.colors.border)
-        self.setStyleSheet(card_style(accent))
+        gradient = WORKFLOW_GRADIENTS.get(spec.key, "transparent")
+        self.setStyleSheet(
+            "QFrame#WorkflowCard {"
+            f"{card_style(accent)}"
+            f"background: {TOKENS.colors.surface_glass};"
+            "}"
+            "QFrame#WorkflowCard:hover {"
+            f"{card_hover_style(accent)}"
+            "}"
+            "QLabel#WorkflowCardAccent {"
+            f"background: {gradient};"
+            f"border-radius: {TOKENS.radius.pill}px;"
+            "}"
+        )
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg)
         layout.setSpacing(TOKENS.spacing.sm)
 
+        accent_bar = QLabel()
+        accent_bar.setObjectName("WorkflowCardAccent")
+        accent_bar.setFixedHeight(5)
+        layout.addWidget(accent_bar)
+
         header = QHBoxLayout()
         title = QLabel(spec.title)
         title.setObjectName("WorkflowCardTitle")
-        title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 700; color: {TOKENS.colors.text};")
+        title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 800; color: {TOKENS.colors.text};")
         title.setWordWrap(True)
         header.addWidget(title, 1)
         if spec.badge:
@@ -130,30 +93,27 @@ class WorkflowCard(QFrame):
         desc = QLabel(spec.description)
         desc.setObjectName("WorkflowCardDescription")
         desc.setWordWrap(True)
-        desc.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted};")
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted}; line-height: 150%;")
         layout.addWidget(desc)
 
         if spec.recommended_for:
             rec = QLabel(spec.recommended_for)
             rec.setObjectName("WorkflowCardRecommended")
             rec.setWordWrap(True)
-            rec.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+            rec.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_subtle};")
             layout.addWidget(rec)
 
         layout.addStretch(1)
         action = NoBorderPushBtn(spec.primary_action)
         action.setObjectName("WorkflowCardAction")
-        action.setMinimumHeight(34)
+        action.setMinimumHeight(38)
+        action.setStyleSheet(primary_button_style(spec.key))
         action.clicked.connect(lambda: self.activated.emit(self.spec.key))
         layout.addWidget(action)
 
 
 class WorkflowHomeWidget(QWidget):
-    """Workflow-card launcher for the reworked Home screen.
-
-    This widget is intentionally standalone so it can be embedded into the
-    existing WelcomeWidget first, then promoted to the final app shell later.
-    """
+    """Workflow-card launcher for the reworked Home screen."""
 
     workflow_requested = Signal(str)
 
@@ -166,23 +126,31 @@ class WorkflowHomeWidget(QWidget):
     def _build_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(TOKENS.spacing.md)
+        layout.setSpacing(TOKENS.spacing.lg)
 
-        header = QLabel(self.tr("Choose a workflow"))
+        hero = QFrame(self)
+        hero.setObjectName("WorkflowHomeHero")
+        hero.setStyleSheet(hero_panel_style("home"))
+        hero_layout = QVBoxLayout(hero)
+        hero_layout.setContentsMargins(TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl, TOKENS.spacing.xl)
+        hero_layout.setSpacing(TOKENS.spacing.sm)
+
+        header = QLabel(self.tr("Choose your workflow"))
         header.setObjectName("WorkflowHomeTitle")
-        header.setStyleSheet(f"font-size: {TOKENS.typography.headline}px; font-weight: 700;")
-        layout.addWidget(header)
+        header.setStyleSheet(f"font-size: {TOKENS.typography.display}px; font-weight: 900; color: {TOKENS.colors.text};")
+        hero_layout.addWidget(header)
 
-        subtitle = QLabel(self.tr("Pick the mode that matches what you want to do. You can still reach every advanced command from menus or the command palette."))
+        subtitle = QLabel(self.tr("Start with a simple card, then use menus or the command palette whenever you need advanced tools."))
         subtitle.setObjectName("WorkflowHomeSubtitle")
         subtitle.setWordWrap(True)
         subtitle.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
-        layout.addWidget(subtitle)
+        hero_layout.addWidget(subtitle)
+        layout.addWidget(hero)
 
         grid = QGridLayout()
-        grid.setContentsMargins(0, TOKENS.spacing.sm, 0, 0)
-        grid.setHorizontalSpacing(TOKENS.spacing.md)
-        grid.setVerticalSpacing(TOKENS.spacing.md)
+        grid.setContentsMargins(0, 0, 0, 0)
+        grid.setHorizontalSpacing(TOKENS.spacing.lg)
+        grid.setVerticalSpacing(TOKENS.spacing.lg)
         layout.addLayout(grid)
 
         for idx, spec in enumerate(self.cards):

--- a/ui/workflow_home.py
+++ b/ui/workflow_home.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtWidgets import QFrame, QGridLayout, QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout, QWidget
+
+from .custom_widget.push_button import NoBorderPushBtn
+from .design_tokens import TOKENS, WORKFLOW_ACCENTS, badge_style, card_style
+
+
+@dataclass(frozen=True)
+class WorkflowCardSpec:
+    key: str
+    title: str
+    description: str
+    primary_action: str
+    badge: str = ""
+    recommended_for: str = ""
+    status: str = "idle"
+
+
+DEFAULT_WORKFLOW_CARDS: tuple[WorkflowCardSpec, ...] = (
+    WorkflowCardSpec(
+        key="editor",
+        title="Manga & Comic Editor",
+        description="Open raws or an existing project for OCR, translation, inpaint, typesetting, QA, and export.",
+        primary_action="Open project or folder",
+        badge="Production",
+        recommended_for="Best for scanlation and full chapter work.",
+        status="running",
+    ),
+    WorkflowCardSpec(
+        key="live",
+        title="Live Screen Translator",
+        description="Translate a selected screen or Chrome manhua reader region without creating a full project.",
+        primary_action="Start live mode",
+        badge="Reader",
+        recommended_for="Best for reading in Chrome, games, or visual novels.",
+        status="experimental",
+    ),
+    WorkflowCardSpec(
+        key="quick_image",
+        title="Image Quick Translation",
+        description="Drop one or more images, run default OCR/translation/inpaint, preview, and export quickly.",
+        primary_action="Translate images",
+        badge="Fast",
+        recommended_for="Best for one-off images and testing providers.",
+        status="success",
+    ),
+    WorkflowCardSpec(
+        key="downloader",
+        title="Raw Downloader",
+        description="Search sources, choose chapters, queue downloads, and import results into a project.",
+        primary_action="Find raws",
+        badge="Sources",
+        recommended_for="Best before starting a chapter project.",
+        status="warning",
+    ),
+    WorkflowCardSpec(
+        key="batch",
+        title="Batch Queue",
+        description="Process multiple folders, archives, or child projects with progress, cancel, and resume.",
+        primary_action="Open queue",
+        badge="Automation",
+        recommended_for="Best for many chapters or repeated jobs.",
+        status="idle",
+    ),
+    WorkflowCardSpec(
+        key="assist",
+        title="Translation Assist / QA",
+        description="Compare providers, TM matches, glossary hits, concordance, SFX suggestions, and QA warnings.",
+        primary_action="Open assist",
+        badge="CAT",
+        recommended_for="Best for final polish and consistency.",
+        status="success",
+    ),
+    WorkflowCardSpec(
+        key="models",
+        title="Models & Providers",
+        description="Install models, test OCR/translation providers, check caches, and fix missing dependencies.",
+        primary_action="Manage setup",
+        badge="Setup",
+        recommended_for="Best when a module fails or first-run setup is incomplete.",
+        status="idle",
+    ),
+    WorkflowCardSpec(
+        key="diagnostics",
+        title="Diagnostics / Help",
+        description="Run environment checks, inspect logs, export startup reports, and find docs.",
+        primary_action="Open diagnostics",
+        badge="Support",
+        recommended_for="Best when something looks broken.",
+        status="warning",
+    ),
+)
+
+
+class WorkflowCard(QFrame):
+    activated = Signal(str)
+
+    def __init__(self, spec: WorkflowCardSpec, parent=None):
+        super().__init__(parent)
+        self.spec = spec
+        self.setObjectName("WorkflowCard")
+        self.setFrameShape(QFrame.Shape.NoFrame)
+        self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        self.setMinimumHeight(160)
+        accent = WORKFLOW_ACCENTS.get(spec.key, TOKENS.colors.border)
+        self.setStyleSheet(card_style(accent))
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg, TOKENS.spacing.lg)
+        layout.setSpacing(TOKENS.spacing.sm)
+
+        header = QHBoxLayout()
+        title = QLabel(spec.title)
+        title.setObjectName("WorkflowCardTitle")
+        title.setStyleSheet(f"font-size: {TOKENS.typography.title}px; font-weight: 700; color: {TOKENS.colors.text};")
+        title.setWordWrap(True)
+        header.addWidget(title, 1)
+        if spec.badge:
+            badge = QLabel(spec.badge)
+            badge.setObjectName("WorkflowCardBadge")
+            badge.setStyleSheet(badge_style(spec.status))
+            header.addWidget(badge, 0, Qt.AlignmentFlag.AlignTop)
+        layout.addLayout(header)
+
+        desc = QLabel(spec.description)
+        desc.setObjectName("WorkflowCardDescription")
+        desc.setWordWrap(True)
+        desc.setStyleSheet(f"font-size: {TOKENS.typography.body}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(desc)
+
+        if spec.recommended_for:
+            rec = QLabel(spec.recommended_for)
+            rec.setObjectName("WorkflowCardRecommended")
+            rec.setWordWrap(True)
+            rec.setStyleSheet(f"font-size: {TOKENS.typography.caption}px; color: {TOKENS.colors.text_muted};")
+            layout.addWidget(rec)
+
+        layout.addStretch(1)
+        action = NoBorderPushBtn(spec.primary_action)
+        action.setObjectName("WorkflowCardAction")
+        action.setMinimumHeight(34)
+        action.clicked.connect(lambda: self.activated.emit(self.spec.key))
+        layout.addWidget(action)
+
+
+class WorkflowHomeWidget(QWidget):
+    """Workflow-card launcher for the reworked Home screen.
+
+    This widget is intentionally standalone so it can be embedded into the
+    existing WelcomeWidget first, then promoted to the final app shell later.
+    """
+
+    workflow_requested = Signal(str)
+
+    def __init__(self, cards: Optional[Iterable[WorkflowCardSpec]] = None, parent=None):
+        super().__init__(parent)
+        self.cards: List[WorkflowCardSpec] = list(cards or DEFAULT_WORKFLOW_CARDS)
+        self._card_widgets: Dict[str, WorkflowCard] = {}
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(TOKENS.spacing.md)
+
+        header = QLabel(self.tr("Choose a workflow"))
+        header.setObjectName("WorkflowHomeTitle")
+        header.setStyleSheet(f"font-size: {TOKENS.typography.headline}px; font-weight: 700;")
+        layout.addWidget(header)
+
+        subtitle = QLabel(self.tr("Pick the mode that matches what you want to do. You can still reach every advanced command from menus or the command palette."))
+        subtitle.setObjectName("WorkflowHomeSubtitle")
+        subtitle.setWordWrap(True)
+        subtitle.setStyleSheet(f"font-size: {TOKENS.typography.body_large}px; color: {TOKENS.colors.text_muted};")
+        layout.addWidget(subtitle)
+
+        grid = QGridLayout()
+        grid.setContentsMargins(0, TOKENS.spacing.sm, 0, 0)
+        grid.setHorizontalSpacing(TOKENS.spacing.md)
+        grid.setVerticalSpacing(TOKENS.spacing.md)
+        layout.addLayout(grid)
+
+        for idx, spec in enumerate(self.cards):
+            card = WorkflowCard(spec, self)
+            card.activated.connect(self.workflow_requested.emit)
+            self._card_widgets[spec.key] = card
+            row, col = divmod(idx, 2)
+            grid.addWidget(card, row, col)
+
+    def card_keys(self) -> List[str]:
+        return [card.key for card in self.cards]
+
+    def card_widget(self, key: str) -> Optional[WorkflowCard]:
+        return self._card_widgets.get(key)

--- a/utils/auto_text_layout.py
+++ b/utils/auto_text_layout.py
@@ -33,7 +33,9 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        # Default to a simple rectangular textbox shape. Users can still opt
+        # into Auto/Round/Diamond/etc. from advanced settings or the context menu.
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 80.0,
@@ -57,7 +59,7 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 70.0,
@@ -81,7 +83,7 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 92.0,
@@ -118,10 +120,10 @@ def apply_auto_layout_profile(config_obj, value: str | None) -> dict:
 def auto_layout_profile_summary(value: str | None) -> str:
     preset = normalize_auto_layout_preset(value)
     if preset == AUTO_LAYOUT_PRESET_FIT:
-        return "Strict fit: smaller min font, strong overflow penalties, compact line widths, mask-safe area, no model checks by default."
+        return "Strict fit: smaller min font, strong overflow penalties, compact line widths, mask-safe area, and simple rectangular text boxes by default."
     if preset == AUTO_LAYOUT_PRESET_READABLE:
-        return "Readable: allows roomier boxes/fewer lines and larger font while keeping final overflow checks and bubble centering on."
-    return "Balanced: mask-safe geometry, centered bubbles, optimal line breaks, binary font fitting, and model-free shape detection by default."
+        return "Readable: allows roomier boxes/fewer lines and larger font while keeping final overflow checks and simple rectangular text boxes by default."
+    return "Balanced: mask-safe geometry, centered bubbles, optimal line breaks, binary font fitting, and simple rectangular text boxes by default."
 
 
 def _band(value: float, bands: tuple[tuple[float, str], ...], fallback: str) -> str:
@@ -160,6 +162,7 @@ def auto_layout_setting_hints(values: dict | object | None = None) -> dict:
     box_model = str(get("layout_box_size_check_model_id", "") or "").strip()
     shape_model = str(get("layout_balloon_shape_model_id", "") or "").strip()
     shape_method = str(get("layout_balloon_shape_auto_method", "contour_ratio") or "contour_ratio")
+    shape_value = str(get("layout_balloon_shape", "square") or "square").strip().lower()
 
     return {
         "font_range": f"{min_pt:g}–{max_pt:g} pt (" + _band(min_pt, ((6.5, "tiny text allowed"), (9.5, "normal manga range")), "large/readable minimum") + ")",
@@ -170,7 +173,7 @@ def auto_layout_setting_hints(values: dict | object | None = None) -> dict:
         "no_bubble_width": _band(no_bubble, ((0.70, "compact"), (0.82, "balanced"), (0.92, "wide/readable")), "very wide"),
         "center_gap": "never skip centering" if center_gap <= 0 else f"skip combined bubbles within {center_gap:g}px",
         "box_model": "geometry only" if not box_model else ("built-in CLIP" if box_model == "builtin" else "custom model"),
-        "shape_detection": ("model-assisted" if shape_model or shape_method.startswith("model") else "model-free contour/aspect"),
+        "shape_detection": "simple rectangle" if shape_value in ("square", "rectangle", "rect") else ("model-assisted" if shape_model or shape_method.startswith("model") else "model-free contour/aspect"),
     }
 
 
@@ -372,6 +375,8 @@ def candidate_layout_widths(
         "narrow": (0.50, 0.60, 0.72, 0.84),
         "point": (0.52, 0.64, 0.76, 0.88),
         "square": (0.66, 0.76, 0.86, 0.96),
+        "rectangle": (0.66, 0.76, 0.86, 0.96),
+        "rect": (0.66, 0.76, 0.86, 0.96),
         "bevel": (0.64, 0.74, 0.86, 0.96),
         "pentagon": (0.62, 0.74, 0.84, 0.94),
         "elongated": (0.74, 0.84, 0.92, 1.0),

--- a/utils/config.py
+++ b/utils/config.py
@@ -593,10 +593,16 @@ class ProgramConfig(Config):
     region_merge_settings: Dict = field(default_factory=dict)  # Region merge tool dialog (persisted)
     context_menu: Dict = field(default_factory=dict)  # Canvas right-click: action key -> visible (default True)
     context_menu_pinned: List = field(default_factory=list)  # Action keys to show at top of right-click menu (order preserved)
+    context_menu_profile: str = "custom"  # Last-applied quick profile: editing|pipeline|layout|custom
     context_run_macros: List = field(default_factory=lambda: [
         {'id': 'detect_ocr_translate', 'label': 'Macro: Detect+OCR+Translate', 'mode': 1, 'detect_first': True},
         {'id': 'ocr_translate_inpaint', 'label': 'Macro: OCR+Translate+Inpaint', 'mode': 2, 'detect_first': False},
     ])
+    realtime_profile_id: str = "generic_screen_ocr"
+    realtime_capture_interval_ms: int = 700
+    realtime_min_ocr_interval_ms: int = 0
+    realtime_follow_window: bool = False
+    realtime_region_rect: List[int] = field(default_factory=lambda: [0, 0, 100, 100])
     huggingface_token: str = ''  # Optional: gated models + faster HF downloads (Xet). Prefer env HF_TOKEN to avoid storing in config.
     translator_last_model_by_provider: Dict = field(default_factory=dict)  # Section 9: last-used model per LLM provider
     # When True, the "Add Open in BallonsTranslator to context menu?" dialog has been shown once (first launch); don't show again.
@@ -645,6 +651,16 @@ class ProgramConfig(Config):
     motion_blur_on_scroll: bool = False
     # When True, shorten or disable UI animations (accessibility / preference). Durations → 0 or minimal; scale and motion-blur effects off.
     reduce_motion: bool = False
+
+    # UI complexity and startup flow defaults (UI rework migration-safe fields).
+    ui_mode: str = "advanced"  # "simple" | "advanced" | "developer"
+    show_experimental_features: bool = False
+    show_legacy_menus: bool = True
+    startup_mode: str = "last_used"  # "home" | "editor" | "last_used" | "settings" | "live" | "downloader" | "batch" | "models" | "diagnostics"
+    show_home_on_startup: bool = True
+    recent_workflows: List = field(default_factory=list)
+    omni_show_unavailable: bool = False
+    omni_result_type_filter: str = "all"  # all|command|setting|text_block|page|recent|help
 
     @staticmethod
     def default_downloaded_chapters_dir() -> str:
@@ -697,6 +713,55 @@ class ProgramConfig(Config):
             config_dict["offline_local_only_mode"] = False
         if not config_dict.get("model_package_preset_ids"):
             config_dict["model_package_preset_ids"] = ["balanced_default"]
+
+        # UI rework migration-safe defaults for existing configs.
+        if config_dict.get("ui_mode") not in {"simple", "advanced", "developer"}:
+            config_dict["ui_mode"] = "advanced"
+        if "show_experimental_features" not in config_dict:
+            config_dict["show_experimental_features"] = False
+        if "show_legacy_menus" not in config_dict:
+            config_dict["show_legacy_menus"] = True
+        if config_dict.get("startup_mode") not in {"home", "editor", "last_used", "settings", "live", "downloader", "batch", "models", "diagnostics"}:
+            config_dict["startup_mode"] = "last_used"
+        if "show_home_on_startup" not in config_dict:
+            config_dict["show_home_on_startup"] = bool(config_dict.get("show_welcome_screen", True))
+        allowed_workflows = {"home", "editor", "settings", "live", "downloader", "batch", "models", "diagnostics"}
+        if not isinstance(config_dict.get("recent_workflows"), list):
+            config_dict["recent_workflows"] = []
+        else:
+            cleaned = []
+            for w in config_dict.get("recent_workflows", []):
+                ws = str(w or "").strip().lower()
+                if ws in allowed_workflows and ws not in cleaned:
+                    cleaned.append(ws)
+            config_dict["recent_workflows"] = cleaned[:12]
+        if "omni_show_unavailable" not in config_dict:
+            config_dict["omni_show_unavailable"] = False
+        if config_dict.get("omni_result_type_filter") not in {"all", "command", "setting", "text_block", "page", "recent", "help"}:
+            config_dict["omni_result_type_filter"] = "all"
+        if str(config_dict.get("realtime_profile_id") or "") not in {"chrome_manhua_reader", "manga_reader", "generic_screen_ocr"}:
+            config_dict["realtime_profile_id"] = "generic_screen_ocr"
+        try:
+            config_dict["realtime_capture_interval_ms"] = max(100, min(5000, int(config_dict.get("realtime_capture_interval_ms", 700))))
+        except Exception:
+            config_dict["realtime_capture_interval_ms"] = 700
+        try:
+            config_dict["realtime_min_ocr_interval_ms"] = max(0, min(5000, int(config_dict.get("realtime_min_ocr_interval_ms", 0))))
+        except Exception:
+            config_dict["realtime_min_ocr_interval_ms"] = 0
+        config_dict["realtime_follow_window"] = bool(config_dict.get("realtime_follow_window", False))
+        rect = config_dict.get("realtime_region_rect", [0, 0, 100, 100])
+        if not isinstance(rect, (list, tuple)) or len(rect) < 4:
+            rect = [0, 0, 100, 100]
+        try:
+            rx, ry, rw, rh = [int(rect[i]) for i in range(4)]
+            rw = max(1, min(10000, rw))
+            rh = max(1, min(10000, rh))
+            rx = max(0, min(10000, rx))
+            ry = max(0, min(10000, ry))
+            config_dict["realtime_region_rect"] = [rx, ry, rw, rh]
+        except Exception:
+            config_dict["realtime_region_rect"] = [0, 0, 100, 100]
 
         return ProgramConfig(**config_dict)
     
@@ -757,10 +822,12 @@ CONFIG_KEY_ORDER = (
     "model_packages_enabled", "model_download_last_status",
     "model_packages_enabled", "model_package_preset_ids",
     "dev_mode",
+    "ui_mode", "show_experimental_features", "show_legacy_menus", "startup_mode", "show_home_on_startup", "recent_workflows", "omni_show_unavailable", "omni_result_type_filter",
     "diagnostic_mode",
     "release_caches_after_batch", "manual_mode", "skip_ignored_in_run", "skip_satisfied_pipeline_steps", "auto_mark_translated_pages", "render_default_writing_mode", "render_default_fit_mode", "render_default_line_break_strategy", "render_default_reading_order", "render_overflow_warnings", "render_diagnostics_overlay", "render_auto_polish_on_ocr", "render_default_font_family", "render_default_stroke_width", "render_default_secondary_stroke_width", "render_default_secondary_stroke_color", "render_default_shadow_radius", "render_default_shadow_strength", "render_default_text_padding", "render_atomic_fit_target_fill", "render_atomic_fit_max_expand", "render_atomic_fit_profile", "render_fallback_fonts_latin", "render_fallback_fonts_cjk", "render_fallback_fonts_korean", "render_fallback_fonts_rtl", "render_fallback_fonts_emoji", "render_favorite_fonts", "render_recent_fonts", "render_custom_manga_presets", "export_open_folder_after_batch", "export_include_unrendered_pages", "export_filename_template", "text_editor_top_padding",
     "smooth_scroll_duration_ms", "motion_blur_on_scroll", "reduce_motion",
-    "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_run_macros",
+    "shortcuts", "auto_region_merge_after_run", "region_merge_settings", "context_menu", "context_menu_pinned", "context_menu_profile", "context_run_macros",
+    "realtime_profile_id", "realtime_capture_interval_ms", "realtime_min_ocr_interval_ms", "realtime_follow_window", "realtime_region_rect",
     "huggingface_token", "translator_last_model_by_provider",
     "windows_context_menu_offered",
 )
@@ -883,6 +950,8 @@ def load_config(config_path: str = shared.CONFIG_PATH):
         pcfg.context_menu = dict(CONTEXT_MENU_DEFAULT)
     if not isinstance(getattr(pcfg, 'context_menu_pinned', None), list):
         pcfg.context_menu_pinned = []
+    if str(getattr(pcfg, 'context_menu_profile', 'custom') or 'custom') not in {'editing', 'pipeline', 'layout', 'custom'}:
+        pcfg.context_menu_profile = 'custom'
     if not isinstance(getattr(pcfg, 'context_run_macros', None), list):
         pcfg.context_run_macros = [
             {'id': 'detect_ocr_translate', 'label': 'Macro: Detect+OCR+Translate', 'mode': 1, 'detect_first': True},

--- a/utils/feature_matrix.py
+++ b/utils/feature_matrix.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import importlib.util
+import os.path as osp
+from typing import List, Dict
+
+
+def _exists_module(rel_path: str) -> bool:
+    return osp.isfile(rel_path)
+
+
+def _has_pkg(name: str) -> bool:
+    return importlib.util.find_spec(name) is not None
+
+
+def build_feature_matrix() -> List[Dict[str, str]]:
+    rows = [
+        {"feature": "Detection", "detail": "Speech bubble detection + segmentation (YOLO + SAM2/3)",
+         "status": "available" if _exists_module('modules/textdetector/detector_hf_object_detection.py') else "missing"},
+        {"feature": "Cleaning", "detail": "Inpaint speech bubbles / OSB text (Flux / OpenCV / others)",
+         "status": "available" if _exists_module('modules/inpaint/inpaint_flux_fill.py') else "partial"},
+        {"feature": "Translation", "detail": "LLM OCR + translation multi-language",
+         "status": "available" if _exists_module('modules/ocr/ocr_paddleocr_vl_hf.py') else "partial"},
+        {"feature": "Rendering", "detail": "Alignment + custom font packs",
+         "status": "available"},
+        {"feature": "Upscaling", "detail": "Real-CUGAN / ESRGAN style upscalers",
+         "status": "available" if _exists_module('modules/upscaling/esrgan_upscaler.py') else "partial"},
+        {"feature": "Processing", "detail": "Single + batch + ZIP workflows",
+         "status": "available"},
+        {"feature": "Interfaces", "detail": "Desktop UI + automation API (+ optional web/CLI sidecar)",
+         "status": "available"},
+        {"feature": "Automation", "detail": "One-click pipeline + local API",
+         "status": "available"},
+        {"feature": "Models: PaddleOCR", "detail": "PaddleOCR / PaddleOCR-VL / MangaOCR variants",
+         "status": "available" if _exists_module('modules/ocr/ocr_paddleVL_manga.py') else "partial"},
+        {"feature": "Models: Segmentation", "detail": "SAM2/SAM3 refinement toggle",
+         "status": "available" if _has_pkg('transformers') else "optional_dep_missing"},
+        {"feature": "Models: Community showcase", "detail": "YSG segmenters, MangaLens bubble segmentation, Flux variants, PaddleOCR-VL-1.5, Real-CUGAN/AnimeSharp",
+         "status": "available" if _exists_module('modules/textdetector/detector_hf_object_detection.py') else "partial"},
+    ]
+    return rows
+
+
+def feature_matrix_text() -> str:
+    lines = ["Feature Matrix (runtime capability)"]
+    for row in build_feature_matrix():
+        lines.append(f"- {row['feature']}: {row['detail']} [{row['status']}]")
+    return "\n".join(lines)

--- a/utils/line_breaking.py
+++ b/utils/line_breaking.py
@@ -6,6 +6,9 @@ _HYPHEN_CHARS = "\u002d\u2010\u2011\u2012\u2013\u2014\u2212"
 _HYPHEN_CLASS = re.escape(_HYPHEN_CHARS)
 _ARTIFICIAL_ALPHA_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]+([a-z]{{1,18}})")
 _ARTIFICIAL_PUNCT_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]*(?=(?:\.{2,}|…|[!?！？]))")
+# Short all-caps/translated manga words look terrible when split (NE- VER,
+# MI- ND).  Hyphenation remains available only for genuinely long tokens.
+_MIN_HYPHENATE_ALPHA_LEN = 12
 
 
 def _badness(slack: float) -> float:
@@ -38,6 +41,10 @@ def normalize_artificial_hyphenation(text: str) -> str:
         out = _ARTIFICIAL_ALPHA_HYPHEN_RE.sub(lambda m: m.group(1) + m.group(2), out)
     out = _ARTIFICIAL_PUNCT_HYPHEN_RE.sub(lambda m: m.group(1), out)
     return out
+
+
+def _alpha_len(token: str) -> int:
+    return sum(1 for ch in str(token or "") if ch.isalpha())
 
 
 def find_optimal_breaks_dp(
@@ -126,13 +133,16 @@ def split_long_token_with_hyphenation(
 
     Hyphenation is now opt-in.  It can look very poor in manga/manhua bubbles
     (e.g. ``NE- VER``), so default auto-layout should shrink/fit/reflow before
-    inserting visible hyphens.
+    inserting visible hyphens.  Even when explicitly enabled, short translated
+    words are not hyphenated.
     """
     tok = token or ""
     w = int(measure(tok))
     if w <= max_width or max_width <= 0:
         return [(tok, w)]
     if not hyphenate:
+        return [(tok, w)]
+    if _alpha_len(tok) < _MIN_HYPHENATE_ALPHA_LEN:
         return [(tok, w)]
 
     parts = hyphenate_word_pyphen(tok, lang=hyphen_lang)

--- a/utils/line_breaking.py
+++ b/utils/line_breaking.py
@@ -1,4 +1,11 @@
 from typing import Callable, List, Optional, Tuple
+import re
+
+
+_HYPHEN_CHARS = "\u002d\u2010\u2011\u2012\u2013\u2014\u2212"
+_HYPHEN_CLASS = re.escape(_HYPHEN_CHARS)
+_ARTIFICIAL_ALPHA_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]+([a-z]{{1,18}})")
+_ARTIFICIAL_PUNCT_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]*(?=(?:\.{2,}|…|[!?！？]))")
 
 
 def _badness(slack: float) -> float:
@@ -8,9 +15,29 @@ def _badness(slack: float) -> float:
     return slack * slack * slack
 
 
-# Penalty per line break to strongly prefer fewer, longer lines (avoids 1–2 words per line)
+# Penalty per line break to strongly prefer fewer, longer lines (avoids 1-2 words per line)
 # Increase slightly so long sentences are less likely to be split into many very short lines.
 _LINE_BREAK_PENALTY = 130.0
+
+
+def normalize_artificial_hyphenation(text: str) -> str:
+    """Remove hyphens that were inserted only to split a word across lines.
+
+    Comic auto-lettering used to enable Pyphen by default.  That can turn short
+    translated words into awkward fragments such as ``NE-\nVER`` or
+    ``MI‐ ND``.  This helper only removes hyphens followed by whitespace/newline
+    or punctuation ellipses, so normal typed hyphenated words like
+    ``well-being`` are preserved.
+    """
+    if not text:
+        return text or ""
+    out = str(text)
+    previous = None
+    while previous != out:
+        previous = out
+        out = _ARTIFICIAL_ALPHA_HYPHEN_RE.sub(lambda m: m.group(1) + m.group(2), out)
+    out = _ARTIFICIAL_PUNCT_HYPHEN_RE.sub(lambda m: m.group(1), out)
+    return out
 
 
 def find_optimal_breaks_dp(
@@ -91,12 +118,15 @@ def split_long_token_with_hyphenation(
     token: str,
     measure: Callable[[str], int],
     max_width: int,
-    hyphenate: bool = True,
+    hyphenate: bool = False,
     hyphen_lang: str = "en_US",
 ) -> List[Tuple[str, int]]:
     """
-    If token is wider than max_width, try to split it into smaller pieces with hyphens.
-    Returns list of (piece, piece_width) where pieces may include trailing hyphen.
+    If token is wider than max_width, optionally split it into smaller pieces.
+
+    Hyphenation is now opt-in.  It can look very poor in manga/manhua bubbles
+    (e.g. ``NE- VER``), so default auto-layout should shrink/fit/reflow before
+    inserting visible hyphens.
     """
     tok = token or ""
     w = int(measure(tok))
@@ -130,4 +160,3 @@ def split_long_token_with_hyphenation(
     if len(out) == 1 and out[0][0] == tok:
         return [(tok, w)]
     return out
-

--- a/utils/model_packages.py
+++ b/utils/model_packages.py
@@ -47,6 +47,7 @@ PACKAGE_TIERS = {
     "advanced_inpaint": "Beta",
     "advanced_ocr": "External dependency heavy",
     "optional_onnx": "Experimental",
+    "community_showcase": "Community / optional",
 }
 
 # Human-readable labels and short descriptions for the first-launch dialog
@@ -74,6 +75,10 @@ PACKAGE_LABELS = {
     "optional_onnx": (
         QT_TRANSLATE_NOOP("ModelPackageCatalog", "Optional ONNX inpainting"),
         QT_TRANSLATE_NOOP("ModelPackageCatalog", "Lama 2025 / lama-manga ONNX (smaller, CPU-friendly)"),
+    ),
+    "community_showcase": (
+        QT_TRANSLATE_NOOP("ModelPackageCatalog", "Community showcase models"),
+        QT_TRANSLATE_NOOP("ModelPackageCatalog", "Optional community models from feature screenshots: YSG, MangaLens, SAM2/3, Flux variants, PaddleOCR-VL-1.5, Real-CUGAN/AnimeSharp."),
     ),
 }
 
@@ -389,6 +394,13 @@ MODEL_PACKAGE_PRESETS: Dict[str, Dict[str, Any]] = {
         "approx_size": "~5.0 GB",
         "package_ids": ["core", "advanced_ocr", "advanced_inpaint", "optional_onnx"],
         "dependency_hints": "Largest download. Recommended only with stable bandwidth/storage and optional GPU runtimes.",
+    },
+    "showcase_full_stack": {
+        "label": "Showcase full stack (community)",
+        "intended_use": "Installs baseline + community screenshot models (segmentation/inpaint/OCR/upscaling) for feature parity exploration.",
+        "approx_size": "10+ GB (varies by backend/model)",
+        "package_ids": ["core", "advanced_ocr", "advanced_inpaint", "optional_onnx", "community_showcase"],
+        "dependency_hints": "Very large download; community models may require extra runtimes and stronger GPU/VRAM.",
     },
 }
 

--- a/utils/realtime_mode.py
+++ b/utils/realtime_mode.py
@@ -276,10 +276,31 @@ class RealtimeService:
             "generic_screen_ocr": {"id": "generic_screen_ocr", "label": "Generic Screen OCR"},
         }
         self.watcher = RealtimeWatcher(NumpyFrameBackend([]), lambda _im: "", lambda _tx: "")
+        self._default_region_id = "default"
 
     def status(self) -> Dict[str, Any]:
         return {
             "enabled": bool(self.enabled),
             "region_count": len(self.regions),
             "regions": sorted(self.regions.keys()),
+            "states": {k: vars(v) for k, v in self.states.items()},
         }
+
+    def ensure_region(self, region_id: str = "default", rect: Tuple[int, int, int, int] = (0, 0, 640, 360), profile: str = "generic_screen_ocr") -> RealtimeRegion:
+        rid = str(region_id or "default").strip() or "default"
+        if rid not in self.regions:
+            self.regions[rid] = RealtimeRegion(region_id=rid, rect=tuple(int(v) for v in rect[:4]), profile=str(profile or "generic_screen_ocr"))
+        return self.regions[rid]
+
+    def apply_defaults(self, *, rect: Tuple[int, int, int, int], profile: str = "generic_screen_ocr", follow_window: bool = False):
+        region = self.ensure_region(region_id=self._default_region_id, rect=rect, profile=profile)
+        region.rect = tuple(int(v) for v in rect[:4])
+        region.profile = str(profile or "generic_screen_ocr")
+        region.follow_window = bool(follow_window)
+        return region
+
+    def tick_region(self, region_id: str = "default") -> Dict[str, Any]:
+        region = self.ensure_region(region_id=region_id)
+        state = self.watcher.tick(region)
+        self.states[region.region_id] = state
+        return {"region_id": region.region_id, "status": state.status, "ocr_text": state.last_ocr_text, "translation": state.last_translation}

--- a/utils/sam3_refinement.py
+++ b/utils/sam3_refinement.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+try:
+    from utils.text_masking import bubble_safe_text_rect
+except Exception:  # pragma: no cover
+    bubble_safe_text_rect = None
+
+MaskRunner = Callable[[np.ndarray, str], Sequence[np.ndarray]]
+BoxRunner = Callable[[np.ndarray, str], Sequence[Sequence[float]]]
+
+SAM3_REFINEMENT_MODEL_DEFAULT = "facebook/sam3"
+SAM3_REFINEMENT_MODEL_CUSTOM = "Custom SAM 3 model id"
+SAM3_REFINEMENT_MODEL_OPTIONS: Tuple[str, ...] = (
+    SAM3_REFINEMENT_MODEL_DEFAULT,
+    SAM3_REFINEMENT_MODEL_CUSTOM,
+)
+
+# Keep this broad on purpose: sam3_refiner is a wrapper detector, so users should
+# be able to use any detector they already trust as the first pass.  Some names
+# are optional and may only appear in dev mode or when dependencies are installed.
+KNOWN_BASE_DETECTOR_OPTIONS: Tuple[str, ...] = (
+    "ctd",
+    "hf_object_det",
+    "ysgyolo",
+    "mangalens_bubble_segmentation",
+    "paddle_det",
+    "paddle_det_v5",
+    "easyocr_det",
+    "craft_det",
+    "surya_det",
+    "mmocr_det",
+    "dptext_detr",
+    "swintextspotter_v2",
+    "magi_det",
+    "hunyuan_ocr_det",
+    "stariver_ocr",
+    "rapidocr_det",
+    "vlm_spotting",
+    "sam_text_det",
+    "textmamba_det",
+)
+
+# Second-pass refiners are intentionally curated. These are detectors likely to
+# improve mask/bubble geometry rather than general OCR/translation/inpaint models.
+CURATED_REFINER_DETECTOR_OPTIONS: Tuple[str, ...] = (
+    "sam_text_det",
+    "hf_object_det",
+    "ysgyolo",
+    "mangalens_bubble_segmentation",
+)
+
+
+def curated_sam3_refinement_models() -> Tuple[str, ...]:
+    return SAM3_REFINEMENT_MODEL_OPTIONS
+
+
+def all_base_detector_options(registered: Sequence[str] | None = None) -> Tuple[str, ...]:
+    """Return all usable first-pass detector choices.
+
+    If a registry list is supplied, preserve registry order and include every
+    detector except the wrapper itself.  Otherwise return the broad known list.
+    """
+    if registered is not None:
+        return tuple(k for k in registered if k and k != "sam3_refiner")
+    return tuple(k for k in KNOWN_BASE_DETECTOR_OPTIONS if k != "sam3_refiner")
+
+
+def curated_refiner_detector_options(registered: Sequence[str] | None = None) -> Tuple[str, ...]:
+    if registered is None:
+        return CURATED_REFINER_DETECTOR_OPTIONS
+    available = set(registered)
+    return tuple(k for k in CURATED_REFINER_DETECTOR_OPTIONS if k in available)
+
+
+def resolve_refinement_model_id(choice: str, custom_model_id: str = "") -> str:
+    choice = (choice or SAM3_REFINEMENT_MODEL_DEFAULT).strip()
+    if choice == SAM3_REFINEMENT_MODEL_CUSTOM:
+        return (custom_model_id or "").strip() or SAM3_REFINEMENT_MODEL_DEFAULT
+    if choice not in SAM3_REFINEMENT_MODEL_OPTIONS:
+        return SAM3_REFINEMENT_MODEL_DEFAULT
+    return choice
+
+
+@dataclass(frozen=True)
+class SAM3RefinementOptions:
+    enabled: bool = False
+    prompt: str = "speech bubble"
+    fallback_prompt: str = "text"
+    merge_mode: str = "union"  # union | intersect | replace_if_nonempty
+    min_mask_area: int = 64
+    max_mask_area_ratio: float = 0.75
+    min_iou_with_initial: float = 0.02
+    expand_px: int = 0
+    safe_rect_min_coverage: float = 0.88
+
+    @classmethod
+    def from_settings(cls, settings: Mapping[str, Any]) -> "SAM3RefinementOptions":
+        return cls(
+            enabled=bool(settings.get("enabled", False)),
+            prompt=str(settings.get("prompt", "speech bubble") or "speech bubble"),
+            fallback_prompt=str(settings.get("fallback_prompt", "text") or "text"),
+            merge_mode=str(settings.get("merge_mode", "union") or "union"),
+            min_mask_area=int(settings.get("min_mask_area", 64) or 64),
+            max_mask_area_ratio=float(settings.get("max_mask_area_ratio", 0.75) or 0.75),
+            min_iou_with_initial=float(settings.get("min_iou_with_initial", 0.02) or 0.02),
+            expand_px=int(settings.get("expand_px", 0) or 0),
+            safe_rect_min_coverage=float(settings.get("safe_rect_min_coverage", 0.88) or 0.88),
+        )
+
+
+@dataclass(frozen=True)
+class SAM3RefinementResult:
+    mask: np.ndarray
+    used_refiner: bool
+    prompt: str
+    merge_mode: str
+    warnings: Tuple[str, ...] = tuple()
+    candidate_count: int = 0
+    selected_candidate_count: int = 0
+    safe_areas: Tuple[Dict[str, Any], ...] = tuple()
+
+    @property
+    def used_sam3(self) -> bool:
+        return self.used_refiner
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "used_refiner": self.used_refiner,
+            "used_sam3": self.used_refiner,
+            "prompt": self.prompt,
+            "merge_mode": self.merge_mode,
+            "warnings": list(self.warnings),
+            "candidate_count": self.candidate_count,
+            "selected_candidate_count": self.selected_candidate_count,
+            "safe_areas": list(self.safe_areas),
+        }
+
+
+def as_binary_mask(mask: np.ndarray | None, shape: Tuple[int, int] | None = None) -> np.ndarray:
+    if mask is None:
+        return np.zeros(shape[:2], dtype=np.uint8) if shape else np.zeros((0, 0), dtype=np.uint8)
+    arr = np.asarray(mask)
+    if arr.ndim == 3:
+        arr = arr[..., 0]
+    arr = (arr > 0).astype(np.uint8) * 255
+    if shape is None or arr.shape[:2] == tuple(shape[:2]):
+        return np.ascontiguousarray(arr)
+    out = np.zeros(tuple(shape[:2]), dtype=np.uint8)
+    h = min(out.shape[0], arr.shape[0])
+    w = min(out.shape[1], arr.shape[1])
+    if h > 0 and w > 0:
+        out[:h, :w] = arr[:h, :w]
+    return out
+
+
+def mask_area(mask: np.ndarray | None) -> int:
+    return int(np.count_nonzero(as_binary_mask(mask) > 0))
+
+
+def mask_iou(a: np.ndarray | None, b: np.ndarray | None) -> float:
+    aa = as_binary_mask(a)
+    bb = as_binary_mask(b, aa.shape if aa.size else None)
+    if aa.size == 0 or bb.size == 0:
+        return 0.0
+    inter = np.logical_and(aa > 0, bb > 0).sum()
+    union = np.logical_or(aa > 0, bb > 0).sum()
+    return float(inter) / float(union) if union else 0.0
+
+
+def dilate_mask_numpy(mask: np.ndarray, radius: int) -> np.ndarray:
+    arr = as_binary_mask(mask)
+    r = max(0, int(radius or 0))
+    if r <= 0 or arr.size == 0:
+        return arr
+    padded = np.pad(arr > 0, ((r, r), (r, r)), mode="constant", constant_values=False)
+    out = np.zeros(arr.shape, dtype=bool)
+    for dy in range(0, 2 * r + 1):
+        for dx in range(0, 2 * r + 1):
+            out |= padded[dy:dy + arr.shape[0], dx:dx + arr.shape[1]]
+    return out.astype(np.uint8) * 255
+
+
+def masks_from_boxes(boxes: Sequence[Sequence[float]], shape: Tuple[int, int]) -> List[np.ndarray]:
+    out: List[np.ndarray] = []
+    h, w = shape[:2]
+    for box in boxes or []:
+        if len(box) < 4:
+            continue
+        x1, y1, x2, y2 = [int(round(float(v))) for v in box[:4]]
+        x1, x2 = max(0, min(x1, w)), max(0, min(x2, w))
+        y1, y2 = max(0, min(y1, h)), max(0, min(y2, h))
+        if x2 <= x1 or y2 <= y1:
+            continue
+        m = np.zeros((h, w), dtype=np.uint8)
+        m[y1:y2, x1:x2] = 255
+        out.append(m)
+    return out
+
+
+def filter_refiner_candidates(initial_mask: np.ndarray, candidates: Sequence[np.ndarray], opts: SAM3RefinementOptions) -> Tuple[List[np.ndarray], List[str]]:
+    base = as_binary_mask(initial_mask)
+    page_area = max(1, base.shape[0] * base.shape[1]) if base.size else 1
+    selected: List[np.ndarray] = []
+    warnings: List[str] = []
+    for cand in candidates or []:
+        cm = as_binary_mask(cand, base.shape if base.size else None)
+        area = mask_area(cm)
+        if area < int(opts.min_mask_area):
+            continue
+        if opts.max_mask_area_ratio > 0 and area > float(opts.max_mask_area_ratio) * page_area:
+            warnings.append("ignored oversized refiner candidate")
+            continue
+        if mask_area(base) > 0 and mask_iou(base, cm) < float(opts.min_iou_with_initial):
+            continue
+        selected.append(cm)
+    return selected, warnings
+
+
+def combine_refined_mask(initial_mask: np.ndarray, refined: Sequence[np.ndarray], opts: SAM3RefinementOptions) -> np.ndarray:
+    base = as_binary_mask(initial_mask)
+    if not refined:
+        return base
+    stack = np.zeros_like(base)
+    for cm in refined:
+        stack = np.maximum(stack, as_binary_mask(cm, base.shape))
+    mode = (opts.merge_mode or "union").strip().lower()
+    if mode == "intersect":
+        merged = np.where(np.logical_and(base > 0, stack > 0), 255, 0).astype(np.uint8)
+    elif mode == "replace_if_nonempty":
+        merged = stack if mask_area(stack) > 0 else base
+    else:
+        merged = np.maximum(base, stack)
+    return dilate_mask_numpy(merged, opts.expand_px) if int(opts.expand_px or 0) > 0 else merged
+
+
+def refine_mask_with_sam3(image: np.ndarray, initial_mask: np.ndarray, opts: SAM3RefinementOptions, *, mask_runner: Optional[MaskRunner] = None, box_runner: Optional[BoxRunner] = None) -> SAM3RefinementResult:
+    base = as_binary_mask(initial_mask, np.asarray(image).shape[:2])
+    if not opts.enabled:
+        return SAM3RefinementResult(base, False, opts.prompt, opts.merge_mode)
+    if mask_runner is None and box_runner is None:
+        return SAM3RefinementResult(base, False, opts.prompt, opts.merge_mode, ("Mask refinement enabled but no runner was provided",))
+    prompt = opts.prompt or "speech bubble"
+    raw: List[np.ndarray] = []
+    warnings: List[str] = []
+    try:
+        if mask_runner is not None:
+            raw.extend(as_binary_mask(m, base.shape) for m in (mask_runner(image, prompt) or []))
+        if box_runner is not None:
+            raw.extend(masks_from_boxes(box_runner(image, prompt) or [], base.shape))
+    except Exception as exc:
+        warnings.append(f"mask refinement failed: {exc}")
+    if not raw and opts.fallback_prompt and opts.fallback_prompt != prompt:
+        prompt = opts.fallback_prompt
+        try:
+            if mask_runner is not None:
+                raw.extend(as_binary_mask(m, base.shape) for m in (mask_runner(image, prompt) or []))
+            if box_runner is not None:
+                raw.extend(masks_from_boxes(box_runner(image, prompt) or [], base.shape))
+        except Exception as exc:
+            warnings.append(f"mask refinement fallback failed: {exc}")
+    selected, filter_warnings = filter_refiner_candidates(base, raw, opts)
+    warnings.extend(filter_warnings)
+    merged = combine_refined_mask(base, selected, opts)
+    safe_areas = tuple(sam3_safe_areas_from_mask(merged, opts)) if selected else tuple()
+    return SAM3RefinementResult(merged, bool(selected), prompt, opts.merge_mode, tuple(warnings), len(raw), len(selected), safe_areas)
+
+
+def sam3_safe_areas_from_mask(mask: np.ndarray, opts: SAM3RefinementOptions | None = None) -> List[Dict[str, Any]]:
+    arr = as_binary_mask(mask)
+    if arr.size == 0 or not np.any(arr > 0):
+        return []
+    ys, xs = np.where(arr > 0)
+    rect = [float(xs.min()), float(ys.min()), float(xs.max() + 1 - xs.min()), float(ys.max() + 1 - ys.min())]
+    if bubble_safe_text_rect is not None:
+        safe = bubble_safe_text_rect(arr, rect, min_coverage=float((opts.safe_rect_min_coverage if opts else 0.88) or 0.88))
+    else:
+        safe = {"rect": rect, "coverage": 1.0, "edge_coverage": 1.0, "used_mask": False}
+    return [{"kind": "sam3_bubble_safe_area", "bbox": rect, "safe_rect": list(safe.get("rect", rect)), "coverage": float(safe.get("coverage", 0.0)), "edge_coverage": float(safe.get("edge_coverage", 0.0)), "used_mask": bool(safe.get("used_mask", False))}]
+
+
+def should_use_sam3_for_live_translation(profile: str | Mapping[str, Any] | None) -> bool:
+    if profile is None:
+        return False
+    if isinstance(profile, Mapping):
+        if bool(profile.get("use_sam3")):
+            quality = str(profile.get("quality_mode", profile.get("mode", ""))).lower()
+            return quality in {"high_quality", "quality", "slower", "slow", "hq"}
+        profile = str(profile.get("name", profile.get("preset", profile.get("mode", ""))))
+    text = str(profile or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return any(t in text for t in ("high_quality", "hq", "slower", "slow")) and "fast" not in text
+
+
+def cleanup_only_mode_plan(detector: str = "sam3_refiner", sam_prompt: str = "speech bubble", inpainter: str = "lama_manga_onnx", export_clean_raws: bool = True) -> Dict[str, Any]:
+    return {"mode": "cleanup_only", "run_detection": True, "run_ocr": False, "run_translation": False, "run_inpaint": True, "run_render": False, "detector": detector, "sam_prompt": sam_prompt, "inpainter": inpainter, "export_clean_raws": bool(export_clean_raws)}


### PR DESCRIPTION
### Motivation
- Move BallonsTranslator-Pro toward a complete workflow-centered default UI without breaking the existing editor, model manager, startup/config compatibility, local API, or advanced scanlation workflows.
- Use competitor visual direction rather than vague polish: Dango-style friendly modern entry points, ImageTrans-style professional Translation Assist/editor depth, and manga-image-translator-style pipeline/job mental models.
- Keep modern advanced, not simple: dense where useful, discoverable, fast for power users, and still approachable for new users.

### Default-facing UI shell progress
- `WelcomeWidget` embeds `WorkflowHomeWidget` and schedules the default modern shell during startup/show.
- `ModeRail` is inserted into the default `MainWindow` layout beside the legacy `LeftBar`, instead of staying only in an experimental preview.
- Legacy navigation handlers are wrapped so the ModeRail checked state stays synced when old menus/buttons/shortcuts navigate.
- `JobStatusDrawer` is installed collapsed before the legacy `BottomBar`; it does not replace old progress dialogs yet.
- Pipeline stage events mirror into the drawer as a `pipeline-current` job, and pipeline completion marks it succeeded at 100%.
- `task_job_bridge.py` mirrors dashboard-launched task actions into the drawer for proof-pack export, raw/downloader flows, batch queue, model manager, and Translation Assist actions.
- `EditorInspector` is added to the existing right-side editor stack and its buttons reuse current handlers for Translation Assist, OCR crop/triage, layout review, and typography QA.
- `default_mode_dashboards.py` appends mode landing pages into the default `centralStackWidget` for Live, Quick Image, Downloader, Batch, Assist, Models, and Diagnostics.
- ModeRail workflow modes now show these dashboard landing pages first; dashboard action buttons dispatch to the existing app handlers.
- `dashboard_status_provider.py` refreshes dashboard metrics from best-effort project/page state, warning counts, job drawer state, model/provider state, downloader source counts, and Translation Assist dock state.
- `mode_dashboard.py` metric cards are now updateable, with `update_metric`, `update_metrics`, and `metric_snapshot` helpers.
- `dashboard_action_router.py` points dashboard actions at current MainWindow handlers instead of placeholder names.
- `dashboard_action_dispatcher.py` can dispatch QAction IDs, direct handlers, and dotted child-widget handlers such as `leftBar.onOpenImages`.

### Bug fixes included
- Issue #136: fixed `modules.ocr.ocr_windows` optional import failure where missing/broken Windows OCR dependencies could raise `NameError: LOGGER is not defined` during startup/module discovery.
- Issue #137: fixed artificial visible hyphen fragments in translated text such as `NE‐ VER` and `MI‐ ND‐...` by normalizing translator output and making auto-layout hyphenation opt-in/safe for short translated words.

### UI/UX research and architecture docs
- Added/updated docs for competitor visual research, information architecture, user workflows, action registry, shell components, migration plan, and the default UI commitment.
- `docs/DEFAULT_UI_REWORK_COMMITMENT.md` records that the modern UI should become default and legacy UI should become fallback/compatibility, not the main product surface.

### Existing UI rework foundation
- Added reusable design tokens and shell components: `ui/design_tokens.py`, `ui/workflow_home.py`, `ui/mode_rail.py`, `ui/default_modern_shell.py`, `ui/default_mode_dashboards.py`, `ui/dashboard_status_provider.py`, `ui/task_job_bridge.py`, `ui/editor_inspector.py`, `ui/job_status_drawer.py`, and `ui/mode_dashboard.py`.
- Added action registry and dispatcher/router groundwork so menus, dashboards, and command search can be reorganized safely.
- Extended title/menu/config surfaces for workflow-oriented menus, startup mode, UI mode, omni-search options, realtime defaults, diagnostics, and model/provider surfaces.

### SAM3/refiner detector changes
- Added `utils/sam3_refinement.py` and `modules/textdetector/detector_sam3_refiner.py`.
- `sam3_refiner` behaves as a normal selectable detector module.
- The base detector selector can use any registered detector except `sam3_refiner` itself.
- The second-pass/refiner selector is curated to detectors likely to improve bubble/text mask geometry when available.
- The refiner runs the selected base detector first, runs the selected curated refiner, filters candidates against the base mask, merges masks, and can attach safe-area metadata to blocks.

### Tests
Recommended local commands:

```bash
python -m pytest tests/test_default_modern_shell.py tests/test_default_mode_dashboards.py tests/test_dashboard_status_provider.py tests/test_task_job_bridge.py tests/test_dashboard_action_dispatcher.py tests/test_action_registry.py
python -m pytest tests/test_ocr_windows_import_safety.py tests/test_line_breaking_hyphenation.py tests/test_translation_sanitize_hyphenation.py
python -m pytest tests/test_ui_config_migration.py tests/test_mangalens_detector_registration.py
python launch.py
```

The new default-shell/dashboard tests cover rail insertion/idempotency, drawer installation/job updates, pipeline event mirroring, editor inspector insertion/action wiring, ModeRail sync, welcome Assist fallback behavior, dashboard page insertion/idempotency, ModeRail-to-dashboard routing, dashboard fallbacks, dashboard action dispatch to existing handlers, dashboard metric refresh from live app state, and dashboard-launched task mirroring into the drawer.

The bugfix tests cover Windows OCR optional import safety and translated/artificial hyphen cleanup for the exact issue #137 pattern while preserving real hyphenated words.

### Manual validation
1. Launch the app and confirm the modern ModeRail appears beside the legacy LeftBar.
2. Click Live, Quick Image, Downloader, Batch, Assist, Models, and Diagnostics in the rail; confirm dashboard landing pages appear in the center stack.
3. Click dashboard action buttons and confirm they call the existing workflows, including Quick Image via the existing image opener.
4. Click dashboard actions for Models, Batch, Downloader, Assist, and proof-pack export; confirm corresponding task rows appear in the collapsed Jobs & Status drawer when expanded.
5. Open Home, Editor, and Settings through the rail and confirm the legacy welcome/editor/settings behavior still works.
6. Open a project and run a pipeline; confirm the legacy progress behavior remains and the collapsed Jobs & Status drawer receives progress.
7. Confirm dashboard metrics update after project load/pipeline changes where best-effort state is available.
8. Open the right-side inspector panel and confirm Assist/OCR/Layout/QA buttons call the existing workflows.
9. Translate text similar to `ああ．．．もういっか．．．` and confirm artificial output fragments like `NE‐ VER` become readable text like `NEVER`.
10. Verify `sam3_refiner` still exposes all eligible base detectors and only curated refiner candidates.

### Remaining UI migration work
- Replace the dashboard-launched task rows with exact export/download/model lifecycle events as those internal APIs are identified.
- Replace any remaining placeholder dashboard values with exact project/job/provider APIs as they are identified.
- Move existing text/style/OCR/layout/assist/QA controls into `EditorInspector` tabs after parity checks.
- Add `use_legacy_ui` / rollback settings before hiding or replacing legacy panels.
- Make the full modern shell default only after legacy editor embedding and feature parity are validated.