### PR TITLE
Add selectable SAM 3 refiner detector with persistent settings

### DIFF
--- a/docs/SAM3_REFINEMENT_HOOKS.md
+++ b/docs/SAM3_REFINEMENT_HOOKS.md
@@ -1,116 +1,103 @@
 # SAM 3 refinement hooks
 
-This document describes the first SAM 3 integration layer for BallonsTranslator-Pro.
+This document describes the SAM 3 mask-refinement integration for BallonsTranslator-Pro.
 
-The goal is **not** to replace CTD, YOLO, Paddle, EasyOCR, or other production detectors. The intended pipeline is:
+The goal is not to replace CTD, YOLO, Paddle, EasyOCR, or other production detectors. The intended pipeline is:
 
-1. Run an existing detector first, such as `ctd`, `hf_object_det`, `ysgyolo`, or `paddle_det`.
-2. Optionally run SAM 3 with prompts such as `speech bubble` or `text`.
+1. Run an existing detector first, such as `ctd`, `hf_object_det`, `ysgyolo`, `paddle_det`, or `paddle_det_v5`.
+2. Run SAM 3 with prompts such as `speech bubble` or `text`.
 3. Filter SAM 3 candidates against the original detector mask.
 4. Merge the selected SAM 3 candidates with the detector mask.
-5. Expose the refined mask and safe-area metadata to inpainting, auto-layout, cleanup-only mode, and live translation high-quality mode.
+5. Expose the refined mask and safe-area metadata to inpainting, auto-layout, cleanup-only mode, and high-quality live translation profiles.
+
+## UI entry point
+
+The feature is wired as a normal detector module named `sam3_refiner`.
+
+Open Settings -> DL Module -> Text Detection, then set Detector to `sam3_refiner`.
+
+Because this is a normal detector module, it uses the same module selector, parameter editor, config save/load path, and per-module parameter persistence as other detectors.
+
+## Persistence
+
+The selected detector is stored through the normal config field:
+
+- `pcfg.module.textdetector = "sam3_refiner"`
+
+The refiner parameters are stored through the normal detector parameter path:
+
+- `pcfg.module.textdetector_params["sam3_refiner"]`
+
+The selected base detector also keeps its own normal settings, such as `pcfg.module.textdetector_params["ctd"]` or `pcfg.module.textdetector_params["paddle_det"]`.
+
+This means a user can tune CTD, YOLO, or Paddle exactly as before, then select `sam3_refiner` and choose that detector as the first pass.
+
+## Curated model choices
+
+The refinement-model selector intentionally exposes only model choices expected to help SAM-style mask refinement:
+
+- `facebook/sam3`
+- `Custom SAM 3 model id`
+
+OCR models, LLMs, inpainters, translation models, and YOLO detectors are intentionally excluded from this selector because they are not SAM-style mask-refinement models.
+
+Use `Custom SAM 3 model id` only for SAM 3-compatible Hugging Face models. If the custom ID is empty, the code falls back to `facebook/sam3`.
+
+## Curated base detectors
+
+The first-pass detector list is curated to detectors that make sense before SAM 3 refinement:
+
+- `ctd`
+- `hf_object_det`
+- `ysgyolo`
+- `paddle_det`
+- `paddle_det_v5`
+- `easyocr_det`
+- `craft_det`
+
+These detectors create useful coarse text or bubble regions that SAM 3 can refine.
 
 ## Added utility module
 
-`utils/sam3_refinement.py` is dependency-safe. It does not import `transformers`, `torch`, or SAM 3 directly. Instead, callers provide a `mask_runner(image, prompt)` or `box_runner(image, prompt)` callback.
+`utils/sam3_refinement.py` is dependency-safe. It does not import `transformers`, `torch`, or SAM 3 directly. Instead, callers provide a mask or box runner callback.
 
-This keeps normal installs working even when:
+This keeps normal installs working even when SAM 3 dependencies are missing, the user has not accepted gated model access, the user is offline, or tests are running in a lightweight environment.
 
-- SAM 3 dependencies are missing.
-- the user has not accepted the SAM 3 Hugging Face gated model terms.
-- the user is offline.
-- the app is running in a lightweight/headless test environment.
+## Added detector module
 
-## Core helpers
+`modules/textdetector/detector_sam3_refiner.py` registers `sam3_refiner`.
 
-- `SAM3RefinementOptions`
-- `SAM3RefinementResult`
-- `refine_mask_with_sam3(...)`
-- `sam3_safe_areas_from_mask(...)`
-- `should_use_sam3_for_live_translation(...)`
-- `cleanup_only_mode_plan(...)`
+It behaves like a normal text detector. Internally it:
 
-## Bubble mask refiner
+1. Loads the selected base detector and its normal saved parameters.
+2. Runs the base detector on the page.
+3. Loads `sam_text_det` with the selected SAM 3 model ID and prompt.
+4. Runs SAM 3 as a refinement candidate source.
+5. Filters candidates by area and IoU with the base detector mask.
+6. Merges masks using `union`, `intersect`, or `replace_if_nonempty`.
+7. Attaches `region_inpaint_dict["sam3_refinement"]` metadata to detected blocks when safe-area attachment is enabled.
 
-Use `refine_mask_with_sam3(...)` after an existing detector has produced an initial mask.
-
-Recommended settings:
-
-```python
-from utils.sam3_refinement import SAM3RefinementOptions, refine_mask_with_sam3
-
-opts = SAM3RefinementOptions(
-    enabled=True,
-    prompt="speech bubble",
-    fallback_prompt="text",
-    merge_mode="union",
-    min_iou_with_initial=0.02,
-    max_mask_area_ratio=0.75,
-)
-result = refine_mask_with_sam3(image, detector_mask, opts, mask_runner=sam3_mask_runner)
-refined_mask = result.mask
-```
-
-For strict cleanup, use `merge_mode="intersect"` to avoid expanding the mask too far. For whole-bubble cleanup, use `merge_mode="replace_if_nonempty"` or `union`.
-
-## Auto-layout safe-area detector
-
-`sam3_safe_areas_from_mask(...)` turns a refined SAM/bubble mask into conservative safe-area metadata. The current implementation returns a stable merged safe rectangle for the contour. Future UI/API wiring can attach these safe areas per text block.
-
-This is meant to feed the auto-layout engine so text can fit inside a real bubble contour instead of a rectangular detector box.
+Current limitation: the first UI-wired implementation uses the existing `sam_text_det` detector output, which exposes SAM detections as boxes/blocks. These are converted into masks for refinement. A later PR can expose raw SAM pixel masks from `sam_text_det` for more precise contour refinement.
 
 ## Cleanup-only mode
 
-`cleanup_only_mode_plan(...)` returns a serializable plan for a future UI/API preset:
+`cleanup_only_mode_plan(...)` returns a serializable plan for a cleanup-only UI/API preset. The default detector is now `sam3_refiner`, with `speech bubble` as the SAM prompt and `lama_manga_onnx` as the inpainter.
 
-- run detection
-- skip OCR
-- skip translation
-- run inpainting
-- skip render/typesetting
-- export clean raws
-
-Default preset:
-
-```python
-cleanup_only_mode_plan(
-    detector="sam_text_det",
-    sam_prompt="speech bubble",
-    inpainter="lama_manga_onnx",
-)
-```
+In the current UI, users can approximate this by selecting `sam3_refiner` as the detector, enabling detection and inpaint, and disabling OCR/translation/render paths where available.
 
 ## Live translation helper
 
 SAM 3 is too heavy for every live frame. Use `should_use_sam3_for_live_translation(...)` to gate SAM 3 so it only runs in high-quality/slower live profiles.
 
-Examples that enable SAM 3:
-
-- `high_quality_slower`
-- `hq_slow`
-- `{ "use_sam3": true, "quality_mode": "high_quality" }`
-
-Examples that do not enable SAM 3:
-
-- `fast`
-- `low_latency`
-- `{ "use_sam3": true, "quality_mode": "low_latency" }`
-
 ## Next wiring PRs
 
 Recommended follow-up work:
 
-1. Add config fields under `pcfg.module` for SAM 3 refinement:
-   - `sam3_refine_enabled`
-   - `sam3_refine_prompt`
-   - `sam3_refine_fallback_prompt`
-   - `sam3_refine_merge_mode`
-   - `sam3_refine_min_iou`
-2. Add an optional post-detector hook in the pipeline after CTD/YOLO/Paddle detection.
-3. Add UI controls under detection/cleanup settings.
-4. Attach `result.safe_areas` metadata to text blocks or page metadata for auto-layout.
-5. Add a cleanup-only command/menu action using `cleanup_only_mode_plan(...)`.
-6. Add realtime profile wiring so SAM 3 is only used for high-quality/slower live translation.
+1. Expose raw SAM pixel masks from `sam_text_det` so `sam3_refiner` can refine with true SAM contours instead of block rectangles.
+2. Add auto-layout consumption of `region_inpaint_dict["sam3_refinement"]`.
+3. Add a dedicated cleanup-only menu/API action using `cleanup_only_mode_plan(...)`.
+4. Add realtime profile wiring so SAM 3 is only used for high-quality/slower live translation.
+5. Add a setup-health warning when `sam3_refiner` is selected but SAM 3 dependencies/model access are unavailable.
 
 ## Tests
 

--- a/docs/SAM3_REFINEMENT_HOOKS.md
+++ b/docs/SAM3_REFINEMENT_HOOKS.md
@@ -1,0 +1,119 @@
+# SAM 3 refinement hooks
+
+This document describes the first SAM 3 integration layer for BallonsTranslator-Pro.
+
+The goal is **not** to replace CTD, YOLO, Paddle, EasyOCR, or other production detectors. The intended pipeline is:
+
+1. Run an existing detector first, such as `ctd`, `hf_object_det`, `ysgyolo`, or `paddle_det`.
+2. Optionally run SAM 3 with prompts such as `speech bubble` or `text`.
+3. Filter SAM 3 candidates against the original detector mask.
+4. Merge the selected SAM 3 candidates with the detector mask.
+5. Expose the refined mask and safe-area metadata to inpainting, auto-layout, cleanup-only mode, and live translation high-quality mode.
+
+## Added utility module
+
+`utils/sam3_refinement.py` is dependency-safe. It does not import `transformers`, `torch`, or SAM 3 directly. Instead, callers provide a `mask_runner(image, prompt)` or `box_runner(image, prompt)` callback.
+
+This keeps normal installs working even when:
+
+- SAM 3 dependencies are missing.
+- the user has not accepted the SAM 3 Hugging Face gated model terms.
+- the user is offline.
+- the app is running in a lightweight/headless test environment.
+
+## Core helpers
+
+- `SAM3RefinementOptions`
+- `SAM3RefinementResult`
+- `refine_mask_with_sam3(...)`
+- `sam3_safe_areas_from_mask(...)`
+- `should_use_sam3_for_live_translation(...)`
+- `cleanup_only_mode_plan(...)`
+
+## Bubble mask refiner
+
+Use `refine_mask_with_sam3(...)` after an existing detector has produced an initial mask.
+
+Recommended settings:
+
+```python
+from utils.sam3_refinement import SAM3RefinementOptions, refine_mask_with_sam3
+
+opts = SAM3RefinementOptions(
+    enabled=True,
+    prompt="speech bubble",
+    fallback_prompt="text",
+    merge_mode="union",
+    min_iou_with_initial=0.02,
+    max_mask_area_ratio=0.75,
+)
+result = refine_mask_with_sam3(image, detector_mask, opts, mask_runner=sam3_mask_runner)
+refined_mask = result.mask
+```
+
+For strict cleanup, use `merge_mode="intersect"` to avoid expanding the mask too far. For whole-bubble cleanup, use `merge_mode="replace_if_nonempty"` or `union`.
+
+## Auto-layout safe-area detector
+
+`sam3_safe_areas_from_mask(...)` turns a refined SAM/bubble mask into conservative safe-area metadata. The current implementation returns a stable merged safe rectangle for the contour. Future UI/API wiring can attach these safe areas per text block.
+
+This is meant to feed the auto-layout engine so text can fit inside a real bubble contour instead of a rectangular detector box.
+
+## Cleanup-only mode
+
+`cleanup_only_mode_plan(...)` returns a serializable plan for a future UI/API preset:
+
+- run detection
+- skip OCR
+- skip translation
+- run inpainting
+- skip render/typesetting
+- export clean raws
+
+Default preset:
+
+```python
+cleanup_only_mode_plan(
+    detector="sam_text_det",
+    sam_prompt="speech bubble",
+    inpainter="lama_manga_onnx",
+)
+```
+
+## Live translation helper
+
+SAM 3 is too heavy for every live frame. Use `should_use_sam3_for_live_translation(...)` to gate SAM 3 so it only runs in high-quality/slower live profiles.
+
+Examples that enable SAM 3:
+
+- `high_quality_slower`
+- `hq_slow`
+- `{ "use_sam3": true, "quality_mode": "high_quality" }`
+
+Examples that do not enable SAM 3:
+
+- `fast`
+- `low_latency`
+- `{ "use_sam3": true, "quality_mode": "low_latency" }`
+
+## Next wiring PRs
+
+Recommended follow-up work:
+
+1. Add config fields under `pcfg.module` for SAM 3 refinement:
+   - `sam3_refine_enabled`
+   - `sam3_refine_prompt`
+   - `sam3_refine_fallback_prompt`
+   - `sam3_refine_merge_mode`
+   - `sam3_refine_min_iou`
+2. Add an optional post-detector hook in the pipeline after CTD/YOLO/Paddle detection.
+3. Add UI controls under detection/cleanup settings.
+4. Attach `result.safe_areas` metadata to text blocks or page metadata for auto-layout.
+5. Add a cleanup-only command/menu action using `cleanup_only_mode_plan(...)`.
+6. Add realtime profile wiring so SAM 3 is only used for high-quality/slower live translation.
+
+## Tests
+
+See `tests/test_sam3_refinement.py`.
+
+The tests use synthetic masks and fake runners. They do not require SAM 3, Hugging Face, PyTorch, OpenCV, or GPU access.

--- a/modules/textdetector/detector_sam3_refiner.py
+++ b/modules/textdetector/detector_sam3_refiner.py
@@ -1,0 +1,236 @@
+"""
+SAM 3 mask refinement detector.
+
+This module behaves like a normal BallonsTranslator text detector in the UI:
+users pick `sam3_refiner`, choose a curated SAM refinement model, choose a base
+text detector, and the normal config persistence path stores the parameters.
+
+Flow:
+1. Run a curated base detector (CTD/YOLO/Paddle/etc.).
+2. Run SAM 3 with a prompt such as "speech bubble".
+3. Filter SAM candidates against the base detector mask.
+4. Merge the refined mask and attach safe-area metadata for auto-layout.
+
+It is disabled-by-default at the app level because users must explicitly select
+this detector. No global detector behavior changes.
+"""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import numpy as np
+
+from .base import TEXTDETECTORS, register_textdetectors, TextDetectorBase, TextBlock, DEVICE_SELECTOR
+from utils.sam3_refinement import (
+    SAM3_REFINEMENT_BASE_DETECTOR_OPTIONS,
+    SAM3_REFINEMENT_MODEL_CUSTOM,
+    curated_sam3_refinement_models,
+    resolve_refinement_model_id,
+    SAM3RefinementOptions,
+    refine_mask_with_sam3,
+)
+
+
+@register_textdetectors("sam3_refiner")
+class SAM3RefinerDetector(TextDetectorBase):
+    """Base-detector + SAM 3 refinement wrapper.
+
+    This is intentionally a wrapper detector instead of a global hidden hook so
+    the feature has the same selection/config persistence behavior as other
+    detectors.
+    """
+
+    params = {
+        "base_detector": {
+            "type": "selector",
+            "options": list(SAM3_REFINEMENT_BASE_DETECTOR_OPTIONS),
+            "value": "ctd",
+            "description": "Detector to run first. Use CTD for default manga, hf_object_det/ysgyolo for comic bubble models, or Paddle for Chinese/general text.",
+        },
+        "refinement_model": {
+            "type": "selector",
+            "options": list(curated_sam3_refinement_models()),
+            "value": "facebook/sam3",
+            "description": "Curated models that actually help mask refinement. Use Custom only for SAM 3-compatible models.",
+        },
+        "custom_model_id": {
+            "type": "line_editor",
+            "value": "",
+            "description": "Used only when refinement_model is Custom SAM 3 model id. Must be SAM 3-compatible.",
+        },
+        "prompt": {
+            "type": "selector",
+            "options": ["speech bubble", "text", "caption", "sound effect", "panel"],
+            "value": "speech bubble",
+            "description": "SAM 3 text prompt. speech bubble is best for bubble safe areas; text can refine text masks.",
+        },
+        "fallback_prompt": {
+            "type": "selector",
+            "options": ["text", "speech bubble", "caption", "sound effect", ""],
+            "value": "text",
+            "description": "Prompt used if the primary prompt returns no usable mask.",
+        },
+        "merge_mode": {
+            "type": "selector",
+            "options": ["union", "intersect", "replace_if_nonempty"],
+            "value": "union",
+            "description": "How to combine base detector mask and SAM mask. union = safer coverage; intersect = strict cleanup; replace_if_nonempty = whole SAM bubble.",
+        },
+        "min_iou_with_initial": {
+            "type": "line_editor",
+            "value": 0.02,
+            "description": "Reject SAM candidates with IoU below this against the base detector mask. Lower catches more, higher is safer.",
+        },
+        "min_mask_area": {
+            "type": "line_editor",
+            "value": 64,
+            "description": "Reject SAM candidates smaller than this area in pixels.",
+        },
+        "max_mask_area_ratio": {
+            "type": "line_editor",
+            "value": 0.75,
+            "description": "Reject candidates larger than this fraction of the page.",
+        },
+        "expand_px": {
+            "type": "line_editor",
+            "value": 0,
+            "description": "Optional final mask dilation in pixels after merging.",
+        },
+        "safe_rect_min_coverage": {
+            "type": "line_editor",
+            "value": 0.88,
+            "description": "Minimum bubble-mask coverage used when deriving auto-layout safe rectangles.",
+        },
+        "attach_safe_areas": {
+            "type": "checkbox",
+            "value": True,
+            "description": "Attach SAM-derived safe-area metadata to detected blocks for future auto-layout/bubble fitting.",
+        },
+        "device": DEVICE_SELECTOR(),
+        "description": "Run CTD/YOLO/Paddle first, then refine the mask with a curated SAM 3 model. Normal detector settings are persisted like other modules.",
+    }
+    _load_model_keys = {"_sam_detector"}
+
+    def __init__(self, **params) -> None:
+        super().__init__(**params)
+        self._base_detector = None
+        self._base_detector_key = None
+        self._sam_detector = None
+        self._sam_detector_key = None
+        self._sam_model_id = None
+        self._sam_device = None
+
+    def _param(self, key: str, default=None):
+        try:
+            return self.get_param_value(key)
+        except Exception:
+            return default
+
+    def _base_params(self, detector_key: str) -> dict:
+        try:
+            from utils.config import pcfg
+            return (getattr(pcfg.module, "textdetector_params", {}) or {}).get(detector_key, {}) or {}
+        except Exception:
+            return {}
+
+    def _make_detector(self, detector_key: str, params: dict | None = None):
+        if detector_key not in TEXTDETECTORS.module_dict:
+            raise KeyError(detector_key)
+        cls = TEXTDETECTORS.module_dict[detector_key]
+        return cls(**(params or {}))
+
+    def _load_base_detector(self):
+        detector_key = str(self._param("base_detector", "ctd") or "ctd").strip()
+        if detector_key == "sam3_refiner":
+            detector_key = "ctd"
+        if detector_key not in SAM3_REFINEMENT_BASE_DETECTOR_OPTIONS:
+            self.logger.warning("SAM3 refiner rejected unsupported base detector %s; using ctd", detector_key)
+            detector_key = "ctd"
+        if self._base_detector is not None and self._base_detector_key == detector_key:
+            return
+        self._base_detector_key = detector_key
+        self._base_detector = self._make_detector(detector_key, self._base_params(detector_key))
+        self._base_detector.load_model()
+
+    def _load_sam_detector(self):
+        choice = str(self._param("refinement_model", "facebook/sam3") or "facebook/sam3")
+        custom = str(self._param("custom_model_id", "") or "")
+        model_id = resolve_refinement_model_id(choice, custom)
+        device = str(self._param("device", "cpu") or "cpu")
+        if device == "Default":
+            device = ""
+        if self._sam_detector is not None and self._sam_model_id == model_id and self._sam_device == device:
+            return
+        if "sam_text_det" not in TEXTDETECTORS.module_dict:
+            raise RuntimeError("sam_text_det is unavailable. Install transformers/torch with SAM 3 support and accept the model access terms if required.")
+        sam_cls = TEXTDETECTORS.module_dict["sam_text_det"]
+        self._sam_model_id = model_id
+        self._sam_device = device
+        self._sam_detector_key = "sam_text_det"
+        self._sam_detector = sam_cls(
+            model_id=model_id,
+            text_prompt=str(self._param("prompt", "speech bubble") or "speech bubble"),
+            device=device or "cpu",
+            box_padding=0,
+            min_area_px=int(float(self._param("min_mask_area", 64) or 64)),
+            max_area_ratio=float(self._param("max_mask_area_ratio", 0.75) or 0.75),
+        )
+        self._sam_detector.load_model()
+
+    def _load_model(self):
+        self._load_base_detector()
+        self._load_sam_detector()
+
+    def _sam_box_runner(self, image: np.ndarray, prompt: str):
+        self._load_sam_detector()
+        if self._sam_detector is None:
+            return []
+        if hasattr(self._sam_detector, "set_param_value"):
+            self._sam_detector.set_param_value("text_prompt", prompt)
+        _mask, blocks = self._sam_detector.detect(image, None)
+        return [getattr(blk, "xyxy", []) for blk in (blocks or [])]
+
+    def _opts(self) -> SAM3RefinementOptions:
+        return SAM3RefinementOptions(
+            enabled=True,
+            prompt=str(self._param("prompt", "speech bubble") or "speech bubble"),
+            fallback_prompt=str(self._param("fallback_prompt", "text") or "text"),
+            merge_mode=str(self._param("merge_mode", "union") or "union"),
+            min_mask_area=int(float(self._param("min_mask_area", 64) or 64)),
+            max_mask_area_ratio=float(self._param("max_mask_area_ratio", 0.75) or 0.75),
+            min_iou_with_initial=float(self._param("min_iou_with_initial", 0.02) or 0.02),
+            expand_px=int(float(self._param("expand_px", 0) or 0)),
+            safe_rect_min_coverage=float(self._param("safe_rect_min_coverage", 0.88) or 0.88),
+        )
+
+    def _detect(self, img: np.ndarray, proj=None) -> Tuple[np.ndarray, List[TextBlock]]:
+        self._load_base_detector()
+        mask, blocks = self._base_detector.detect(img, proj)
+        opts = self._opts()
+        result = refine_mask_with_sam3(img, mask, opts, box_runner=self._sam_box_runner)
+        attach = bool(self._param("attach_safe_areas", True))
+        if attach and blocks and result.safe_areas:
+            meta = result.to_dict()
+            for blk in blocks:
+                try:
+                    rid = getattr(blk, "region_inpaint_dict", None) or {}
+                    rid["sam3_refinement"] = meta
+                    blk.region_inpaint_dict = rid
+                except Exception:
+                    pass
+        for blk in blocks or []:
+            try:
+                blk.det_model = f"{self.name}:{self._base_detector_key}+sam3"
+            except Exception:
+                pass
+        return result.mask, blocks or []
+
+    def updateParam(self, param_key: str, param_content):
+        super().updateParam(param_key, param_content)
+        if param_key == "base_detector":
+            self._base_detector = None
+            self._base_detector_key = None
+        if param_key in {"refinement_model", "custom_model_id", "device"}:
+            self._sam_detector = None
+            self._sam_model_id = None
+            self._sam_device = None

--- a/tests/test_sam3_refinement.py
+++ b/tests/test_sam3_refinement.py
@@ -1,0 +1,99 @@
+import numpy as np
+
+from utils.sam3_refinement import (
+    SAM3RefinementOptions,
+    cleanup_only_mode_plan,
+    combine_refined_mask,
+    mask_area,
+    mask_iou,
+    refine_mask_with_sam3,
+    sam3_safe_areas_from_mask,
+    should_use_sam3_for_live_translation,
+)
+
+
+def test_refine_mask_with_sam3_unions_prompt_mask_and_reports_safe_area():
+    img = np.zeros((80, 100, 3), dtype=np.uint8)
+    initial = np.zeros((80, 100), dtype=np.uint8)
+    initial[30:50, 35:65] = 255
+    candidate = np.zeros((80, 100), dtype=np.uint8)
+    candidate[22:58, 24:76] = 255
+
+    def runner(_image, prompt):
+        assert prompt == "speech bubble"
+        return [candidate]
+
+    result = refine_mask_with_sam3(
+        img,
+        initial,
+        SAM3RefinementOptions(enabled=True, min_iou_with_initial=0.01),
+        mask_runner=runner,
+    )
+
+    assert result.used_sam3 is True
+    assert result.candidate_count == 1
+    assert result.selected_candidate_count == 1
+    assert mask_area(result.mask) > mask_area(initial)
+    assert result.safe_areas
+    assert result.safe_areas[0]["kind"] == "sam3_bubble_safe_area"
+
+
+def test_refine_mask_with_sam3_rejects_unrelated_candidate():
+    img = np.zeros((80, 100, 3), dtype=np.uint8)
+    initial = np.zeros((80, 100), dtype=np.uint8)
+    initial[30:50, 35:65] = 255
+    unrelated = np.zeros((80, 100), dtype=np.uint8)
+    unrelated[0:10, 0:10] = 255
+
+    result = refine_mask_with_sam3(
+        img,
+        initial,
+        SAM3RefinementOptions(enabled=True, min_iou_with_initial=0.10),
+        mask_runner=lambda _img, _prompt: [unrelated],
+    )
+
+    assert result.used_sam3 is False
+    assert result.selected_candidate_count == 0
+    assert mask_iou(result.mask, initial) == 1.0
+
+
+def test_combine_refined_mask_intersect_and_replace_modes():
+    initial = np.zeros((20, 20), dtype=np.uint8)
+    initial[5:15, 5:15] = 255
+    refined = np.zeros((20, 20), dtype=np.uint8)
+    refined[10:19, 10:19] = 255
+
+    inter = combine_refined_mask(initial, [refined], SAM3RefinementOptions(merge_mode="intersect"))
+    repl = combine_refined_mask(initial, [refined], SAM3RefinementOptions(merge_mode="replace_if_nonempty"))
+
+    assert mask_area(inter) == 25
+    assert mask_area(repl) == mask_area(refined)
+
+
+def test_sam3_safe_area_uses_mask_for_round_bubble():
+    yy, xx = np.ogrid[:100, :160]
+    mask = ((((xx - 80) / 78) ** 2 + ((yy - 50) / 48) ** 2) <= 1.0).astype(np.uint8) * 255
+    safe = sam3_safe_areas_from_mask(mask, SAM3RefinementOptions())
+
+    assert len(safe) == 1
+    rect = safe[0]["safe_rect"]
+    assert rect[2] < 160
+    assert rect[3] < 100
+    assert safe[0]["used_mask"] is True
+
+
+def test_live_translation_sam3_gate_only_allows_slow_quality_profiles():
+    assert should_use_sam3_for_live_translation("high_quality_slower") is True
+    assert should_use_sam3_for_live_translation({"use_sam3": True, "quality_mode": "high_quality"}) is True
+    assert should_use_sam3_for_live_translation("fast") is False
+    assert should_use_sam3_for_live_translation({"use_sam3": True, "quality_mode": "low_latency"}) is False
+
+
+def test_cleanup_only_mode_plan_disables_ocr_translation_and_render():
+    plan = cleanup_only_mode_plan()
+    assert plan["mode"] == "cleanup_only"
+    assert plan["run_detection"] is True
+    assert plan["run_inpaint"] is True
+    assert plan["run_ocr"] is False
+    assert plan["run_translation"] is False
+    assert plan["run_render"] is False

--- a/tests/test_sam3_refinement.py
+++ b/tests/test_sam3_refinement.py
@@ -2,11 +2,17 @@ import numpy as np
 
 from utils.sam3_refinement import (
     SAM3RefinementOptions,
+    SAM3_REFINEMENT_MODEL_CUSTOM,
+    SAM3_REFINEMENT_MODEL_DEFAULT,
+    curated_sam3_refinement_models,
     cleanup_only_mode_plan,
     combine_refined_mask,
+    default_refinement_settings,
+    get_persistent_refinement_settings,
     mask_area,
     mask_iou,
     refine_mask_with_sam3,
+    resolve_refinement_model_id,
     sam3_safe_areas_from_mask,
     should_use_sam3_for_live_translation,
 )
@@ -92,8 +98,45 @@ def test_live_translation_sam3_gate_only_allows_slow_quality_profiles():
 def test_cleanup_only_mode_plan_disables_ocr_translation_and_render():
     plan = cleanup_only_mode_plan()
     assert plan["mode"] == "cleanup_only"
+    assert plan["detector"] == "sam3_refiner"
     assert plan["run_detection"] is True
     assert plan["run_inpaint"] is True
     assert plan["run_ocr"] is False
     assert plan["run_translation"] is False
     assert plan["run_render"] is False
+
+
+def test_curated_model_choices_only_include_sam_refinement_options():
+    models = curated_sam3_refinement_models()
+    assert SAM3_REFINEMENT_MODEL_DEFAULT in models
+    assert SAM3_REFINEMENT_MODEL_CUSTOM in models
+    assert all("gpt" not in m.lower() for m in models)
+    assert all("ocr" not in m.lower() for m in models)
+    assert all("lama" not in m.lower() for m in models)
+
+
+def test_resolve_refinement_model_id_handles_custom_and_invalid_values():
+    assert resolve_refinement_model_id(SAM3_REFINEMENT_MODEL_DEFAULT) == SAM3_REFINEMENT_MODEL_DEFAULT
+    assert resolve_refinement_model_id(SAM3_REFINEMENT_MODEL_CUSTOM, "org/custom-sam3") == "org/custom-sam3"
+    assert resolve_refinement_model_id(SAM3_REFINEMENT_MODEL_CUSTOM, "") == SAM3_REFINEMENT_MODEL_DEFAULT
+    assert resolve_refinement_model_id("not-a-refiner") == SAM3_REFINEMENT_MODEL_DEFAULT
+
+
+def test_persistent_settings_round_trip_from_textdetector_params():
+    class ModuleCfg:
+        textdetector_params = {
+            "sam3_refinement": {
+                "enabled": {"value": True},
+                "base_detector": {"value": "paddle_det"},
+                "refinement_model": {"value": SAM3_REFINEMENT_MODEL_CUSTOM},
+                "custom_model_id": {"value": "org/custom-sam3"},
+                "prompt": {"value": "speech bubble"},
+            }
+        }
+
+    settings = get_persistent_refinement_settings(ModuleCfg())
+    assert settings["enabled"] is True
+    assert settings["base_detector"] == "paddle_det"
+    assert settings["refinement_model"] == SAM3_REFINEMENT_MODEL_CUSTOM
+    assert settings["custom_model_id"] == "org/custom-sam3"
+    assert set(default_refinement_settings()) <= set(settings)

--- a/utils/sam3_refinement.py
+++ b/utils/sam3_refinement.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+try:
+    from utils.text_masking import bubble_safe_text_rect
+except Exception:  # pragma: no cover
+    bubble_safe_text_rect = None
+
+MaskRunner = Callable[[np.ndarray, str], Sequence[np.ndarray]]
+BoxRunner = Callable[[np.ndarray, str], Sequence[Sequence[float]]]
+
+
+@dataclass(frozen=True)
+class SAM3RefinementOptions:
+    enabled: bool = False
+    prompt: str = "speech bubble"
+    fallback_prompt: str = "text"
+    merge_mode: str = "union"  # union | intersect | replace_if_nonempty
+    min_mask_area: int = 64
+    max_mask_area_ratio: float = 0.75
+    min_iou_with_initial: float = 0.02
+    expand_px: int = 0
+    safe_rect_min_coverage: float = 0.88
+
+
+@dataclass(frozen=True)
+class SAM3RefinementResult:
+    mask: np.ndarray
+    used_sam3: bool
+    prompt: str
+    merge_mode: str
+    warnings: Tuple[str, ...] = tuple()
+    candidate_count: int = 0
+    selected_candidate_count: int = 0
+    safe_areas: Tuple[Dict[str, Any], ...] = tuple()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "used_sam3": self.used_sam3,
+            "prompt": self.prompt,
+            "merge_mode": self.merge_mode,
+            "warnings": list(self.warnings),
+            "candidate_count": self.candidate_count,
+            "selected_candidate_count": self.selected_candidate_count,
+            "safe_areas": list(self.safe_areas),
+        }
+
+
+def as_binary_mask(mask: np.ndarray | None, shape: Tuple[int, int] | None = None) -> np.ndarray:
+    if mask is None:
+        return np.zeros(shape[:2], dtype=np.uint8) if shape else np.zeros((0, 0), dtype=np.uint8)
+    arr = np.asarray(mask)
+    if arr.ndim == 3:
+        arr = arr[..., 0]
+    arr = (arr > 0).astype(np.uint8) * 255
+    if shape is None or arr.shape[:2] == tuple(shape[:2]):
+        return np.ascontiguousarray(arr)
+    out = np.zeros(tuple(shape[:2]), dtype=np.uint8)
+    h = min(out.shape[0], arr.shape[0])
+    w = min(out.shape[1], arr.shape[1])
+    if h > 0 and w > 0:
+        out[:h, :w] = arr[:h, :w]
+    return out
+
+
+def mask_area(mask: np.ndarray | None) -> int:
+    return int(np.count_nonzero(as_binary_mask(mask) > 0))
+
+
+def mask_iou(a: np.ndarray | None, b: np.ndarray | None) -> float:
+    aa = as_binary_mask(a)
+    bb = as_binary_mask(b, aa.shape if aa.size else None)
+    if aa.size == 0 or bb.size == 0:
+        return 0.0
+    inter = np.logical_and(aa > 0, bb > 0).sum()
+    union = np.logical_or(aa > 0, bb > 0).sum()
+    return float(inter) / float(union) if union else 0.0
+
+
+def dilate_mask_numpy(mask: np.ndarray, radius: int) -> np.ndarray:
+    arr = as_binary_mask(mask)
+    r = max(0, int(radius or 0))
+    if r <= 0 or arr.size == 0:
+        return arr
+    padded = np.pad(arr > 0, ((r, r), (r, r)), mode="constant", constant_values=False)
+    out = np.zeros(arr.shape, dtype=bool)
+    for dy in range(0, 2 * r + 1):
+        for dx in range(0, 2 * r + 1):
+            out |= padded[dy:dy + arr.shape[0], dx:dx + arr.shape[1]]
+    return out.astype(np.uint8) * 255
+
+
+def _masks_from_boxes(boxes: Sequence[Sequence[float]], shape: Tuple[int, int]) -> List[np.ndarray]:
+    out: List[np.ndarray] = []
+    h, w = shape[:2]
+    for box in boxes or []:
+        if len(box) < 4:
+            continue
+        x1, y1, x2, y2 = [int(round(float(v))) for v in box[:4]]
+        x1, x2 = max(0, min(x1, w)), max(0, min(x2, w))
+        y1, y2 = max(0, min(y1, h)), max(0, min(y2, h))
+        if x2 <= x1 or y2 <= y1:
+            continue
+        m = np.zeros((h, w), dtype=np.uint8)
+        m[y1:y2, x1:x2] = 255
+        out.append(m)
+    return out
+
+
+def filter_sam3_candidates(initial_mask: np.ndarray, candidates: Sequence[np.ndarray], opts: SAM3RefinementOptions) -> Tuple[List[np.ndarray], List[str]]:
+    base = as_binary_mask(initial_mask)
+    page_area = max(1, base.shape[0] * base.shape[1]) if base.size else 1
+    selected: List[np.ndarray] = []
+    warnings: List[str] = []
+    for cand in candidates or []:
+        cm = as_binary_mask(cand, base.shape if base.size else None)
+        area = mask_area(cm)
+        if area < int(opts.min_mask_area):
+            continue
+        if opts.max_mask_area_ratio > 0 and area > float(opts.max_mask_area_ratio) * page_area:
+            warnings.append("ignored oversized SAM3 candidate")
+            continue
+        if mask_area(base) > 0 and mask_iou(base, cm) < float(opts.min_iou_with_initial):
+            continue
+        selected.append(cm)
+    return selected, warnings
+
+
+def combine_refined_mask(initial_mask: np.ndarray, refined: Sequence[np.ndarray], opts: SAM3RefinementOptions) -> np.ndarray:
+    base = as_binary_mask(initial_mask)
+    if not refined:
+        return base
+    stack = np.zeros_like(base)
+    for cm in refined:
+        stack = np.maximum(stack, as_binary_mask(cm, base.shape))
+    mode = (opts.merge_mode or "union").strip().lower()
+    if mode == "intersect":
+        merged = np.where(np.logical_and(base > 0, stack > 0), 255, 0).astype(np.uint8)
+    elif mode == "replace_if_nonempty":
+        merged = stack if mask_area(stack) > 0 else base
+    else:
+        merged = np.maximum(base, stack)
+    return dilate_mask_numpy(merged, opts.expand_px) if int(opts.expand_px or 0) > 0 else merged
+
+
+def refine_mask_with_sam3(image: np.ndarray, initial_mask: np.ndarray, opts: SAM3RefinementOptions, *, mask_runner: Optional[MaskRunner] = None, box_runner: Optional[BoxRunner] = None) -> SAM3RefinementResult:
+    base = as_binary_mask(initial_mask, np.asarray(image).shape[:2])
+    if not opts.enabled:
+        return SAM3RefinementResult(base, False, opts.prompt, opts.merge_mode)
+    if mask_runner is None and box_runner is None:
+        return SAM3RefinementResult(base, False, opts.prompt, opts.merge_mode, ("SAM3 enabled but no runner was provided",))
+    prompt = opts.prompt or "speech bubble"
+    raw: List[np.ndarray] = []
+    warnings: List[str] = []
+    try:
+        if mask_runner is not None:
+            raw.extend(as_binary_mask(m, base.shape) for m in (mask_runner(image, prompt) or []))
+        if box_runner is not None:
+            raw.extend(_masks_from_boxes(box_runner(image, prompt) or [], base.shape))
+    except Exception as exc:
+        warnings.append(f"SAM3 refinement failed: {exc}")
+    if not raw and opts.fallback_prompt and opts.fallback_prompt != prompt:
+        prompt = opts.fallback_prompt
+        try:
+            if mask_runner is not None:
+                raw.extend(as_binary_mask(m, base.shape) for m in (mask_runner(image, prompt) or []))
+            if box_runner is not None:
+                raw.extend(_masks_from_boxes(box_runner(image, prompt) or [], base.shape))
+        except Exception as exc:
+            warnings.append(f"SAM3 fallback failed: {exc}")
+    selected, filter_warnings = filter_sam3_candidates(base, raw, opts)
+    warnings.extend(filter_warnings)
+    merged = combine_refined_mask(base, selected, opts)
+    safe_areas = tuple(sam3_safe_areas_from_mask(merged, opts)) if selected else tuple()
+    return SAM3RefinementResult(merged, bool(selected), prompt, opts.merge_mode, tuple(warnings), len(raw), len(selected), safe_areas)
+
+
+def sam3_safe_areas_from_mask(mask: np.ndarray, opts: SAM3RefinementOptions | None = None) -> List[Dict[str, Any]]:
+    arr = as_binary_mask(mask)
+    if arr.size == 0 or not np.any(arr > 0):
+        return []
+    ys, xs = np.where(arr > 0)
+    rect = [float(xs.min()), float(ys.min()), float(xs.max() + 1 - xs.min()), float(ys.max() + 1 - ys.min())]
+    if bubble_safe_text_rect is not None:
+        safe = bubble_safe_text_rect(arr, rect, min_coverage=float((opts.safe_rect_min_coverage if opts else 0.88) or 0.88))
+    else:
+        safe = {"rect": rect, "coverage": 1.0, "edge_coverage": 1.0, "used_mask": False}
+    return [{"kind": "sam3_bubble_safe_area", "bbox": rect, "safe_rect": list(safe.get("rect", rect)), "coverage": float(safe.get("coverage", 0.0)), "edge_coverage": float(safe.get("edge_coverage", 0.0)), "used_mask": bool(safe.get("used_mask", False))}]
+
+
+def should_use_sam3_for_live_translation(profile: str | Mapping[str, Any] | None) -> bool:
+    if profile is None:
+        return False
+    if isinstance(profile, Mapping):
+        if bool(profile.get("use_sam3")):
+            quality = str(profile.get("quality_mode", profile.get("mode", ""))).lower()
+            return quality in {"high_quality", "quality", "slower", "slow", "hq"}
+        profile = str(profile.get("name", profile.get("preset", profile.get("mode", ""))))
+    text = str(profile or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return any(t in text for t in ("high_quality", "hq", "slower", "slow")) and "fast" not in text
+
+
+def cleanup_only_mode_plan(detector: str = "sam_text_det", sam_prompt: str = "speech bubble", inpainter: str = "lama_manga_onnx", export_clean_raws: bool = True) -> Dict[str, Any]:
+    return {"mode": "cleanup_only", "run_detection": True, "run_ocr": False, "run_translation": False, "run_inpaint": True, "run_render": False, "detector": detector, "sam_prompt": sam_prompt, "inpainter": inpainter, "export_clean_raws": bool(export_clean_raws)}

--- a/utils/sam3_refinement.py
+++ b/utils/sam3_refinement.py
@@ -13,6 +13,77 @@ except Exception:  # pragma: no cover
 MaskRunner = Callable[[np.ndarray, str], Sequence[np.ndarray]]
 BoxRunner = Callable[[np.ndarray, str], Sequence[Sequence[float]]]
 
+SAM3_REFINEMENT_SETTINGS_KEY = "sam3_refinement"
+SAM3_REFINEMENT_MODEL_DEFAULT = "facebook/sam3"
+SAM3_REFINEMENT_MODEL_CUSTOM = "Custom SAM 3 model id"
+SAM3_REFINEMENT_MODEL_OPTIONS: Tuple[str, ...] = (
+    SAM3_REFINEMENT_MODEL_DEFAULT,
+    SAM3_REFINEMENT_MODEL_CUSTOM,
+)
+SAM3_REFINEMENT_BASE_DETECTOR_OPTIONS: Tuple[str, ...] = (
+    "ctd",
+    "hf_object_det",
+    "ysgyolo",
+    "paddle_det",
+    "paddle_det_v5",
+    "easyocr_det",
+    "craft_det",
+)
+
+
+def curated_sam3_refinement_models() -> Tuple[str, ...]:
+    """Model choices shown in UI for SAM-based refinement.
+
+    Keep this intentionally short: these are only models that should help mask
+    refinement.  General OCR/detector/LLM models are deliberately excluded.
+    """
+    return SAM3_REFINEMENT_MODEL_OPTIONS
+
+
+def resolve_refinement_model_id(choice: str, custom_model_id: str = "") -> str:
+    choice = (choice or SAM3_REFINEMENT_MODEL_DEFAULT).strip()
+    if choice == SAM3_REFINEMENT_MODEL_CUSTOM:
+        return (custom_model_id or "").strip() or SAM3_REFINEMENT_MODEL_DEFAULT
+    if choice not in SAM3_REFINEMENT_MODEL_OPTIONS:
+        return SAM3_REFINEMENT_MODEL_DEFAULT
+    return choice
+
+
+def default_refinement_settings() -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "base_detector": "ctd",
+        "refinement_model": SAM3_REFINEMENT_MODEL_DEFAULT,
+        "custom_model_id": "",
+        "prompt": "speech bubble",
+        "fallback_prompt": "text",
+        "merge_mode": "union",
+        "min_mask_area": 64,
+        "max_mask_area_ratio": 0.75,
+        "min_iou_with_initial": 0.02,
+        "expand_px": 0,
+        "safe_rect_min_coverage": 0.88,
+        "attach_safe_areas": True,
+    }
+
+
+def get_persistent_refinement_settings(module_cfg: Any) -> Dict[str, Any]:
+    """Read persistent settings from pcfg.module.textdetector_params.
+
+    This avoids adding another custom config save path: settings live beside the
+    normal detector params and round-trip through existing config serialization.
+    """
+    params = getattr(module_cfg, "textdetector_params", None) or {}
+    stored = params.get(SAM3_REFINEMENT_SETTINGS_KEY, {}) or {}
+    out = default_refinement_settings()
+    if isinstance(stored, dict):
+        for key in out:
+            val = stored.get(key, out[key])
+            if isinstance(val, dict) and "value" in val:
+                val = val["value"]
+            out[key] = val
+    return out
+
 
 @dataclass(frozen=True)
 class SAM3RefinementOptions:
@@ -25,6 +96,20 @@ class SAM3RefinementOptions:
     min_iou_with_initial: float = 0.02
     expand_px: int = 0
     safe_rect_min_coverage: float = 0.88
+
+    @classmethod
+    def from_settings(cls, settings: Mapping[str, Any]) -> "SAM3RefinementOptions":
+        return cls(
+            enabled=bool(settings.get("enabled", False)),
+            prompt=str(settings.get("prompt", "speech bubble") or "speech bubble"),
+            fallback_prompt=str(settings.get("fallback_prompt", "text") or "text"),
+            merge_mode=str(settings.get("merge_mode", "union") or "union"),
+            min_mask_area=int(settings.get("min_mask_area", 64) or 64),
+            max_mask_area_ratio=float(settings.get("max_mask_area_ratio", 0.75) or 0.75),
+            min_iou_with_initial=float(settings.get("min_iou_with_initial", 0.02) or 0.02),
+            expand_px=int(settings.get("expand_px", 0) or 0),
+            safe_rect_min_coverage=float(settings.get("safe_rect_min_coverage", 0.88) or 0.88),
+        )
 
 
 @dataclass(frozen=True)
@@ -204,5 +289,5 @@ def should_use_sam3_for_live_translation(profile: str | Mapping[str, Any] | None
     return any(t in text for t in ("high_quality", "hq", "slower", "slow")) and "fast" not in text
 
 
-def cleanup_only_mode_plan(detector: str = "sam_text_det", sam_prompt: str = "speech bubble", inpainter: str = "lama_manga_onnx", export_clean_raws: bool = True) -> Dict[str, Any]:
+def cleanup_only_mode_plan(detector: str = "sam3_refiner", sam_prompt: str = "speech bubble", inpainter: str = "lama_manga_onnx", export_clean_raws: bool = True) -> Dict[str, Any]:
     return {"mode": "cleanup_only", "run_detection": True, "run_ocr": False, "run_translation": False, "run_inpaint": True, "run_render": False, "detector": detector, "sam_prompt": sam_prompt, "inpainter": inpainter, "export_clean_raws": bool(export_clean_raws)}


### PR DESCRIPTION
## Summary

Extends the SAM 3 refinement work into a normal selectable detector module.

### What changed

- Adds `sam3_refiner` as a standard text detector module.
- Lets users pick the SAM refinement model from a curated list:
  - `facebook/sam3`
  - `Custom SAM 3 model id`
- Keeps the refinement model list intentionally narrow so OCR models, LLMs, inpainters, translators, YOLO detectors, LaMa/MAT/Flux, etc. do not appear as invalid refinement choices.
- Lets users choose a curated first-pass/base detector:
  - `ctd`
  - `hf_object_det`
  - `ysgyolo`
  - `paddle_det`
  - `paddle_det_v5`
  - `easyocr_det`
  - `craft_det`
- Runs the base detector first, then runs SAM 3 with prompts such as `speech bubble` or `text`, filters candidates against the base detector mask, and merges masks using `union`, `intersect`, or `replace_if_nonempty`.
- Stores SAM-derived safe-area metadata on detected blocks under `blk.region_inpaint_dict["sam3_refinement"]` when enabled.
- Keeps all normal detector settings and persistence behavior by using the existing detector module/parameter UI:
  - `pcfg.module.textdetector = "sam3_refiner"`
  - `pcfg.module.textdetector_params["sam3_refiner"]`
  - base detector settings remain in their own normal `textdetector_params` entries.

### Files

- `modules/textdetector/detector_sam3_refiner.py`
- `utils/sam3_refinement.py`
- `tests/test_sam3_refinement.py`
- `docs/SAM3_REFINEMENT_HOOKS.md`

## Testing

Added synthetic-mask tests that do not require SAM 3, Hugging Face, PyTorch, OpenCV, or GPU access.

Suggested local command:

```bash
python -m pytest tests/test_sam3_refinement.py
```

## Safety / compatibility

- No default detector behavior changes.
- No new hard dependency for users who do not select `sam3_refiner`.
- Normal installs without SAM 3 should remain unaffected unless the user selects the SAM 3 refiner detector.
- Base detector settings remain configurable through the existing settings UI.

## Known limitation / follow-up

The first UI-wired implementation uses the existing `sam_text_det` detector output, which currently exposes SAM detections as boxes/blocks. `sam3_refiner` converts those boxes into masks for refinement. A follow-up PR should expose raw SAM pixel masks from `sam_text_det` so the refiner can use true SAM contours for even better bubble-safe areas.