### PR TITLE
Update translations in zh_CN.ts for consistency

### DIFF
--- a/translate/zh_CN.ts
+++ b/translate/zh_CN.ts
@@ -5161,7 +5161,7 @@ Continue with advanced-only packages?</source>
     <message>
         <location filename="../ui/shortcuts_dialog.py" line="103" />
         <source>Apply</source>
-        <translation>申请</translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../ui/shortcuts_dialog.py" line="107" />
@@ -5992,7 +5992,7 @@ Continue with advanced-only packages?</source>
     <message>
         <location filename="../ui/theme_customizer_dialog.py" line="118" />
         <source>Apply</source>
-        <translation>申请</translation>
+        <translation>应用</translation>
     </message>
     <message>
         <location filename="../ui/theme_customizer_dialog.py" line="120" />
@@ -6580,7 +6580,7 @@ Continue with advanced-only packages?</source>
     <message>
         <location filename="../ui/mainwindowbars.py" line="827" />
         <source>BallonsTranslatorPro</source>
-        <translation>气球翻译器Pro</translation>
+        <translation>BallonsTranslator Pro</translation>
     </message>
     <message>
         <location filename="../ui/mainwindowbars.py" line="834" />
@@ -8731,12 +8731,12 @@ At 30 fps: use 1 to never miss text (every frame); 2–3 to catch quickly with l
     <message>
         <location filename="../ui/welcome_widget.py" line="155" />
         <source>BallonsTranslator Pro</source>
-        <translation>气球翻译专业版</translation>
+        <translation>BallonsTranslator Pro</translation>
     </message>
     <message>
         <location filename="../ui/welcome_widget.py" line="160" />
         <source>Open a project folder or choose a recent one to start.</source>
-        <translation>打开项目文件夹或选择最近的一个来启动。</translation>
+        <translation>打开项目文件夹或选择最近的一个来启动</translation>
     </message>
     <message>
         <location filename="../ui/welcome_widget.py" line="168" />


### PR DESCRIPTION
This PR improves the Simplified Chinese (zh_CN) localization by fixing some confusing machine translations: Fixed "Apply" button: Changed from 申请 (Apply for a job/document) to 应用 (Apply settings), which is the standard UI terminology. Fixed Brand Name: Restored "BallonsTranslator Pro" to its original English name. Previous machine translations like 气球翻译器Pro or 气球翻译专业版 were literal and unnatural for software branding.

## Summary
- What changed?
- Why is this needed?

## Required Checks

### README parity (EN + ZH)
- [ ] I reviewed [`README.md`](../README.md) and [`README_zh_CN.md`](../README_zh_CN.md) and confirmed they are in parity for any user-facing changes in this PR.
- [ ] If one README was updated without the other, I explained why.

### Startup script verification
- [ ] Verified startup behavior and entry points as applicable:
  - [ ] [`launch.py`](../launch.py)
  - [ ] [`launch_win.bat`](../launch_win.bat)
  - [ ] [`launch_win_with_autoupdate.bat`](../launch_win_with_autoupdate.bat)
  - [ ] [`launch_win_amd_nightly.bat`](../launch_win_amd_nightly.bat)
- [ ] Included a brief verification result for each script touched by this PR.

### First-run model-picker verification
- [ ] Verified first-run model package selection flow end-to-end where applicable:
  - [ ] [`utils/model_packages.py`](../utils/model_packages.py)
  - [ ] [`ui/model_package_selector_dialog.py`](../ui/model_package_selector_dialog.py)
- [ ] Confirmed behavior for first launch, model package listing, selection, and persistence.
- [ ] Included before/after screenshots for any UI change to the first-run model dialog.

## UX / Behavior Validation
- [ ] For UX-facing changes, I documented a clear **manual verification path** (steps + expected result).
- [ ] If defaults changed, I explained the **migration impact** for existing users/configurations.

## Risks / Compatibility
- Potential regressions:
- Rollback notes (if needed):

## Additional Notes
- Environment limitations (if any):
