### PR TITLE
fix(#137,#138): hyphen fragments, rectangular preset defaults, select…

### DIFF
--- a/modules/translators/base.py
+++ b/modules/translators/base.py
@@ -12,6 +12,7 @@ from utils.io_utils import text_is_empty, normalize_line_breaks
 from utils.logger import logger as LOGGER
 from utils.translation_cache import TranslationCache
 from utils.config import pcfg
+from utils.line_breaking import normalize_artificial_hyphenation
 
 TRANSLATORS = Registry('translators')
 register_translator = TRANSLATORS.register_module
@@ -20,12 +21,16 @@ PROXY = urllib.request.getproxies()
 
 
 def sanitize_translation_text(text: str) -> str:
-    """Normalize HTML line breaks and trim excessive trailing repetition from LLM/API output."""
+    """Normalize translator output before assigning it to text blocks."""
     if not text or not isinstance(text, str):
         return text
     # Unescape literal \n and \r\n from API (e.g. "Mortal\nworld" as two chars -> real newline)
     text = text.replace("\\n", "\n").replace("\\r\\n", "\n").replace("\\r", "\n")
     text = normalize_line_breaks(text)
+    # Some web translators/layout passes can return artificial visible word
+    # fragments such as "NE\u2010 VER" / "MI\u2010 ND\u2010...".  Clean those here so every
+    # translator and cache path benefits before rendering.
+    text = normalize_artificial_hyphenation(text)
     # Trim excessive trailing repetition (e.g. "one one one one one" or "一个一个..." from stuck generation)
     text = text.rstrip()
     if len(text) < 4:

--- a/tests/test_line_breaking_hyphenation.py
+++ b/tests/test_line_breaking_hyphenation.py
@@ -1,0 +1,34 @@
+from utils.line_breaking import normalize_artificial_hyphenation, split_long_token_with_hyphenation
+
+
+def measure(text: str) -> int:
+    return len(text) * 10
+
+
+def test_normalize_artificial_hyphenation_issue_137_google_translate_fragments():
+    text = "AH\u2010... NE\u2010 VER MI\u2010 ND\u2010..."
+
+    assert normalize_artificial_hyphenation(text) == "AH... NEVER MIND..."
+
+
+def test_normalize_artificial_hyphenation_handles_newline_splits():
+    text = "NE-\nVER\nMI-\nND"
+
+    assert normalize_artificial_hyphenation(text) == "NEVER\nMIND"
+
+
+def test_normalize_artificial_hyphenation_preserves_real_hyphenated_words():
+    text = "well-being and twenty-one should remain hyphenated"
+
+    assert normalize_artificial_hyphenation(text) == text
+
+
+def test_short_translated_words_are_not_hyphenated_even_when_enabled():
+    assert split_long_token_with_hyphenation("NEVER", measure, 10, hyphenate=True) == [("NEVER", 50)]
+    assert split_long_token_with_hyphenation("MIND", measure, 10, hyphenate=True) == [("MIND", 40)]
+
+
+def test_hyphenation_is_opt_in_by_default():
+    token = "extraordinarilylongword"
+
+    assert split_long_token_with_hyphenation(token, measure, 30) == [(token, measure(token))]

--- a/tests/test_text_layout_auto_formatting.py
+++ b/tests/test_text_layout_auto_formatting.py
@@ -103,6 +103,76 @@ def test_auto_layout_profile_defaults_cover_advanced_knobs():
     assert "Balanced" in auto_layout_profile_summary("balanced")
 
 
+def test_auto_layout_presets_default_to_square_balloon_shape():
+    balanced = auto_layout_profile_defaults("balanced")
+    fit = auto_layout_profile_defaults("fit")
+    readable = auto_layout_profile_defaults("readable")
+
+    assert balanced["layout_balloon_shape"] == "square"
+    assert fit["layout_balloon_shape"] == "square"
+    assert readable["layout_balloon_shape"] == "square"
+
+
+def test_apply_auto_layout_profile_resets_balloon_shape_to_square():
+    class Cfg:
+        layout_auto_preset = "balanced"
+        layout_font_size_min = 1.0
+        layout_balloon_shape = "auto"
+        layout_balloon_shape_model_id = "old/model"
+
+    cfg = Cfg()
+    apply_auto_layout_profile(cfg, "fit inside")
+    assert cfg.layout_balloon_shape == "square"
+    assert cfg.layout_balloon_shape_model_id == ""
+
+
+def test_rectangle_alias_uses_same_candidates_as_square():
+    square = candidate_layout_widths(
+        max_width=240,
+        min_width=60,
+        words_width=520,
+        delimiter_total_width=40,
+        line_height=24,
+        target_box_height=120,
+        balloon_shape="square",
+    )
+    rectangle = candidate_layout_widths(
+        max_width=240,
+        min_width=60,
+        words_width=520,
+        delimiter_total_width=40,
+        line_height=24,
+        target_box_height=120,
+        balloon_shape="rectangle",
+    )
+    assert rectangle == square
+
+
+def test_auto_layout_setting_hints_identifies_simple_rectangle_for_square():
+    hints = auto_layout_setting_hints({
+        "layout_balloon_shape": "square",
+        "layout_balloon_shape_auto_method": "model_contour",
+        "layout_balloon_shape_model_id": "shape/model",
+    })
+    assert hints["shape_detection"] == "simple rectangle"
+
+
+def test_auto_layout_setting_hints_identifies_simple_rectangle_for_rect_aliases():
+    for alias in ("rectangle", "rect"):
+        hints = auto_layout_setting_hints({
+            "layout_balloon_shape": alias,
+            "layout_balloon_shape_auto_method": "contour_ratio",
+            "layout_balloon_shape_model_id": "",
+        })
+        assert hints["shape_detection"] == "simple rectangle", f"alias {alias!r} not recognised"
+
+
+def test_auto_layout_profile_summaries_mention_rectangular_text_boxes():
+    for preset in ("balanced", "fit", "readable"):
+        summary = auto_layout_profile_summary(preset)
+        assert "rectangular text boxes" in summary, f"preset {preset!r} summary missing 'rectangular text boxes'"
+
+
 def test_apply_auto_layout_profile_updates_config_like_object():
     class Cfg:
         layout_auto_preset = "balanced"
@@ -128,6 +198,7 @@ def test_auto_layout_setting_hints_explain_numeric_values():
         "layout_max_line_width_frac_no_bubble": 0.9,
         "layout_center_in_bubble_min_gap_px": 0,
         "layout_box_size_check_model_id": "builtin",
+        "layout_balloon_shape": "auto",
         "layout_balloon_shape_auto_method": "model_contour",
         "layout_balloon_shape_model_id": "shape/model",
     })

--- a/tests/test_translation_sanitize_hyphenation.py
+++ b/tests/test_translation_sanitize_hyphenation.py
@@ -1,0 +1,18 @@
+from modules.translators.base import sanitize_translation_text
+
+
+UNICODE_HYPHEN = chr(0x2010)
+
+
+def test_sanitize_translation_text_removes_issue_137_artificial_hyphen_fragments():
+    text = f"AH{UNICODE_HYPHEN}... NE{UNICODE_HYPHEN} VER MI{UNICODE_HYPHEN} ND{UNICODE_HYPHEN}..."
+    assert sanitize_translation_text(text) == "AH... NEVER MIND..."
+
+
+def test_sanitize_translation_text_handles_newline_word_fragments():
+    assert sanitize_translation_text("NE-\nVER\nMI-\nND") == "NEVER\nMIND"
+
+
+def test_sanitize_translation_text_preserves_real_hyphenated_words():
+    text = "well-being and twenty-one should remain hyphenated"
+    assert sanitize_translation_text(text) == text

--- a/ui/configpanel.py
+++ b/ui/configpanel.py
@@ -1485,6 +1485,28 @@ class ConfigPanel(Widget):
             self.tr('Optional balloon shape model ID'),
             discription=self.tr('Recommended: leave empty. If you choose a model-based auto shape method, set a Hugging Face image-classification model here. Example heavy model: prithivMLmods/Geometric-Shapes-Classification; lighter: 0-ma/vit-geometric-shapes-tiny.')
         ))
+        # Allowed shapes for Auto mode (issue #138): multi-checkbox filter
+        _allowed_shapes_container = QWidget()
+        _allowed_shapes_layout = QHBoxLayout(_allowed_shapes_container)
+        _allowed_shapes_layout.setContentsMargins(0, 0, 0, 0)
+        _allowed_shapes_layout.setSpacing(8)
+        _shape_keys = ['round', 'elongated', 'narrow', 'diamond', 'square', 'bevel', 'pentagon', 'point']
+        _shape_labels = [self.tr('Round'), self.tr('Elongated'), self.tr('Narrow'), self.tr('Diamond'), self.tr('Square'), self.tr('Bevel'), self.tr('Pentagon'), self.tr('Point')]
+        allowed_raw = (getattr(pcfg.module, 'layout_balloon_shape_auto_allowed', '') or '')
+        allowed_set = {s.strip().lower() for s in allowed_raw.split(',') if s.strip()}
+        self._balloon_shape_allowed_checkboxes = {}
+        for key, label in zip(_shape_keys, _shape_labels):
+            cb = QCheckBox(label)
+            cb.setChecked(not allowed_set or key in allowed_set)
+            cb.stateChanged.connect(self._on_balloon_shape_allowed_changed)
+            _allowed_shapes_layout.addWidget(cb)
+            self._balloon_shape_allowed_checkboxes[key] = cb
+        _allowed_shapes_layout.addStretch(1)
+        generalConfigPanel.addSublock(ConfigSubBlock(
+            _allowed_shapes_container,
+            self.tr('Allowed shapes for Auto detection'),
+            discription=self.tr('When Balloon shape is Auto, restrict which shapes the auto-detector may assign. Uncheck shapes you never want (e.g. uncheck Diamond to avoid diamond-shaped text layout). All checked = no restriction.')
+        ))
         # Minimum line width so short text (e.g. "pluck!") is not broken into 2–3 char lines
         self.layout_min_line_width_spin = QSpinBox()
         self.layout_min_line_width_spin.setRange(40, 400)
@@ -1929,6 +1951,13 @@ class ConfigPanel(Widget):
             self.layout_balloon_shape_auto_method_combo.blockSignals(True)
             self.layout_balloon_shape_auto_method_combo.setCurrentIndex(idx)
             self.layout_balloon_shape_auto_method_combo.blockSignals(False)
+        if hasattr(self, '_balloon_shape_allowed_checkboxes'):
+            allowed_raw = (getattr(pcfg.module, 'layout_balloon_shape_auto_allowed', '') or '')
+            allowed_set = {s.strip().lower() for s in allowed_raw.split(',') if s.strip()}
+            for key, cb in self._balloon_shape_allowed_checkboxes.items():
+                cb.blockSignals(True)
+                cb.setChecked(not allowed_set or key in allowed_set)
+                cb.blockSignals(False)
         self._update_auto_layout_interpretation()
 
     def _update_auto_layout_interpretation(self):
@@ -2075,6 +2104,17 @@ class ConfigPanel(Widget):
     def _on_layout_balloon_shape_model_id_changed(self, text: str):
         pcfg.module.layout_balloon_shape_model_id = (text or "").strip()
         self._update_auto_layout_interpretation()
+        self.save_config.emit()
+
+    def _on_balloon_shape_allowed_changed(self, _state=None):
+        if not hasattr(self, '_balloon_shape_allowed_checkboxes'):
+            return
+        checked = [k for k, cb in self._balloon_shape_allowed_checkboxes.items() if cb.isChecked()]
+        all_keys = list(self._balloon_shape_allowed_checkboxes.keys())
+        if set(checked) == set(all_keys):
+            pcfg.module.layout_balloon_shape_auto_allowed = ""
+        else:
+            pcfg.module.layout_balloon_shape_auto_allowed = ",".join(checked)
         self.save_config.emit()
 
     def _on_layout_min_line_width_changed(self, value: int):

--- a/ui/context_menu_config_dialog.py
+++ b/ui/context_menu_config_dialog.py
@@ -94,7 +94,7 @@ CONTEXT_MENU_ITEMS: List[Tuple[str, List[Tuple[str, str]]]] = [
         ("format_re_auto_fit_selected", "Re-auto-fit selected text box(es)"),
         ("format_re_auto_fit_page", "Re-auto-fit current page"),
         ("format_re_auto_fit_all", "Re-auto-fit all pages"),
-        ("format_balloon_shape", "Balloon shape (submenu)"),
+        ("format_balloon_shape", "Text box shape: Rectangle / Auto (submenu)"),
         ("format_resize_to_fit_content", "Resize to fit content"),
         ("format_fit_to_mask_safe_box", "Fit box to visible mask area"),
         ("format_center_in_bubble", "Center in bubble"),

--- a/ui/scenetext_manager.py
+++ b/ui/scenetext_manager.py
@@ -264,6 +264,15 @@ def _resolve_auto_balloon_shape(
     else:
         steps = ["model", "contour", "ratio"]
 
+    def _apply_allowed_filter(shape: str) -> str:
+        allowed_str = (getattr(pcfg.module, "layout_balloon_shape_auto_allowed", None) or "").strip()
+        if not allowed_str:
+            return shape
+        allowed = {s.strip().lower() for s in allowed_str.split(",") if s.strip()}
+        if not allowed:
+            return shape
+        return shape if shape in allowed else "square"
+
     for step in steps:
         if step == "model":
             s = try_model()
@@ -272,8 +281,8 @@ def _resolve_auto_balloon_shape(
         else:
             s = try_ratio()
         if s:
-            return s
-    return try_ratio()
+            return _apply_allowed_filter(s)
+    return _apply_allowed_filter(try_ratio())
 
 
 def _word_count(line: str) -> int:

--- a/utils/auto_text_layout.py
+++ b/utils/auto_text_layout.py
@@ -33,7 +33,9 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        # Default to a simple rectangular textbox shape. Users can still opt
+        # into Auto/Round/Diamond/etc. from advanced settings or the context menu.
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 80.0,
@@ -57,7 +59,7 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 70.0,
@@ -81,7 +83,7 @@ AUTO_LAYOUT_PROFILE_DEFAULTS = {
         "layout_font_fit_bubble": True,
         "layout_font_binary_search": True,
         "layout_auto_final_fit_pass": True,
-        "layout_balloon_shape": "auto",
+        "layout_balloon_shape": "square",
         "layout_balloon_shape_auto_method": "contour_ratio",
         "layout_balloon_shape_model_id": "",
         "layout_min_line_width_px": 92.0,
@@ -118,10 +120,10 @@ def apply_auto_layout_profile(config_obj, value: str | None) -> dict:
 def auto_layout_profile_summary(value: str | None) -> str:
     preset = normalize_auto_layout_preset(value)
     if preset == AUTO_LAYOUT_PRESET_FIT:
-        return "Strict fit: smaller min font, strong overflow penalties, compact line widths, mask-safe area, no model checks by default."
+        return "Strict fit: smaller min font, strong overflow penalties, compact line widths, mask-safe area, and simple rectangular text boxes by default."
     if preset == AUTO_LAYOUT_PRESET_READABLE:
-        return "Readable: allows roomier boxes/fewer lines and larger font while keeping final overflow checks and bubble centering on."
-    return "Balanced: mask-safe geometry, centered bubbles, optimal line breaks, binary font fitting, and model-free shape detection by default."
+        return "Readable: allows roomier boxes/fewer lines and larger font while keeping final overflow checks and simple rectangular text boxes by default."
+    return "Balanced: mask-safe geometry, centered bubbles, optimal line breaks, binary font fitting, and simple rectangular text boxes by default."
 
 
 def _band(value: float, bands: tuple[tuple[float, str], ...], fallback: str) -> str:
@@ -160,6 +162,7 @@ def auto_layout_setting_hints(values: dict | object | None = None) -> dict:
     box_model = str(get("layout_box_size_check_model_id", "") or "").strip()
     shape_model = str(get("layout_balloon_shape_model_id", "") or "").strip()
     shape_method = str(get("layout_balloon_shape_auto_method", "contour_ratio") or "contour_ratio")
+    shape_value = str(get("layout_balloon_shape", "square") or "square").strip().lower()
 
     return {
         "font_range": f"{min_pt:g}–{max_pt:g} pt (" + _band(min_pt, ((6.5, "tiny text allowed"), (9.5, "normal manga range")), "large/readable minimum") + ")",
@@ -170,7 +173,7 @@ def auto_layout_setting_hints(values: dict | object | None = None) -> dict:
         "no_bubble_width": _band(no_bubble, ((0.70, "compact"), (0.82, "balanced"), (0.92, "wide/readable")), "very wide"),
         "center_gap": "never skip centering" if center_gap <= 0 else f"skip combined bubbles within {center_gap:g}px",
         "box_model": "geometry only" if not box_model else ("built-in CLIP" if box_model == "builtin" else "custom model"),
-        "shape_detection": ("model-assisted" if shape_model or shape_method.startswith("model") else "model-free contour/aspect"),
+        "shape_detection": "simple rectangle" if shape_value in ("square", "rectangle", "rect") else ("model-assisted" if shape_model or shape_method.startswith("model") else "model-free contour/aspect"),
     }
 
 
@@ -330,7 +333,7 @@ def estimate_target_line_count(
         target = by_width + 1
     else:
         target = by_width
-    if (balloon_shape or "auto") in ("round", "diamond", "square", "bevel", "pentagon") and target > 1:
+    if (balloon_shape or "auto") in ("round", "diamond", "square", "rectangle", "rect", "bevel", "pentagon") and target > 1:
         target += 1
     return int(max(1, min(max(1, by_height + 1), target)))
 
@@ -372,6 +375,8 @@ def candidate_layout_widths(
         "narrow": (0.50, 0.60, 0.72, 0.84),
         "point": (0.52, 0.64, 0.76, 0.88),
         "square": (0.66, 0.76, 0.86, 0.96),
+        "rectangle": (0.66, 0.76, 0.86, 0.96),
+        "rect": (0.66, 0.76, 0.86, 0.96),
         "bevel": (0.64, 0.74, 0.86, 0.96),
         "pentagon": (0.62, 0.74, 0.84, 0.94),
         "elongated": (0.74, 0.84, 0.92, 1.0),

--- a/utils/config.py
+++ b/utils/config.py
@@ -190,6 +190,8 @@ class ModuleConfig(Config):
     # When "auto": which method(s) to use and in what order. Default is model-free contour/aspect-ratio detection; set a model ID to opt into model-based shape classification.
     layout_balloon_shape_auto_method: str = "contour_ratio"
     layout_balloon_shape_model_id: str = ""  # Optional. Heavier: prithivMLmods/Geometric-Shapes-Classification. Lighter: 0-ma/vit-geometric-shapes-tiny.
+    # When "auto": comma-separated list of shape names the auto-detector is allowed to assign. Empty = all shapes. E.g. "round,elongated,square,bevel,point"
+    layout_balloon_shape_auto_allowed: str = ""
     # Minimum line width (px) so short text (e.g. "pluck!") is not forced into 2–3 char lines; layout never uses a narrower width.
     layout_min_line_width_px: float = 80.0
     # Max line width as fraction of box width for free-standing text (no bubble). Lower = more lines, shorter lines. Only used when region_rect is None.

--- a/utils/line_breaking.py
+++ b/utils/line_breaking.py
@@ -1,4 +1,39 @@
 from typing import Callable, List, Optional, Tuple
+import re
+
+
+_HYPHEN_CHARS = "\u002d\u2010\u2011\u2012\u2013\u2014\u2212"
+_HYPHEN_CLASS = re.escape(_HYPHEN_CHARS)
+_ARTIFICIAL_ALPHA_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]+([a-z]{{1,18}})")
+_ARTIFICIAL_PUNCT_HYPHEN_RE = re.compile(rf"(?i)([a-z]{{1,12}})[{_HYPHEN_CLASS}][ \t\r\n]*(?=(?:\.{{2,}}|\u2026|[!?\uff01\uff1f]))")
+# Short all-caps/translated manga words look terrible when split (NE- VER,
+# MI- ND).  Hyphenation remains available only for genuinely long tokens.
+_MIN_HYPHENATE_ALPHA_LEN = 12
+
+
+
+def normalize_artificial_hyphenation(text: str) -> str:
+    """Remove hyphens that were inserted only to split a word across lines.
+
+    Comic auto-lettering used to enable Pyphen by default.  That can turn short
+    translated words into awkward fragments such as ``NE-\nVER`` or
+    ``MI\u2010 ND``.  This helper only removes hyphens followed by whitespace/newline
+    or punctuation ellipses, so normal typed hyphenated words like
+    ``well-being`` are preserved.
+    """
+    if not text:
+        return text or ""
+    out = str(text)
+    previous = None
+    while previous != out:
+        previous = out
+        out = _ARTIFICIAL_ALPHA_HYPHEN_RE.sub(lambda m: m.group(1) + m.group(2), out)
+    out = _ARTIFICIAL_PUNCT_HYPHEN_RE.sub(lambda m: m.group(1), out)
+    return out
+
+
+def _alpha_len(token: str) -> int:
+    return sum(1 for ch in str(token or "") if ch.isalpha())
 
 
 def _badness(slack: float) -> float:
@@ -91,18 +126,24 @@ def split_long_token_with_hyphenation(
     token: str,
     measure: Callable[[str], int],
     max_width: int,
-    hyphenate: bool = True,
+    hyphenate: bool = False,
     hyphen_lang: str = "en_US",
 ) -> List[Tuple[str, int]]:
     """
-    If token is wider than max_width, try to split it into smaller pieces with hyphens.
-    Returns list of (piece, piece_width) where pieces may include trailing hyphen.
+    If token is wider than max_width, optionally split it into smaller pieces.
+
+    Hyphenation is now opt-in.  It can look very poor in manga/manhua bubbles
+    (e.g. ``NE- VER``), so default auto-layout should shrink/fit/reflow before
+    inserting visible hyphens.  Even when explicitly enabled, short translated
+    words are not hyphenated.
     """
     tok = token or ""
     w = int(measure(tok))
     if w <= max_width or max_width <= 0:
         return [(tok, w)]
     if not hyphenate:
+        return [(tok, w)]
+    if _alpha_len(tok) < _MIN_HYPHENATE_ALPHA_LEN:
         return [(tok, w)]
 
     parts = hyphenate_word_pyphen(tok, lang=hyphen_lang)


### PR DESCRIPTION
…able auto balloon shapes

Issue #137 - Artificial visible hyphen fragments (NE- VER, MI- ND):
- utils/line_breaking.py: add normalize_artificial_hyphenation() to strip split-word hyphens (NE-\nVER -> NEVER) while preserving real hyphens (well-being). Make split_long_token_with_hyphenation opt-in (hyphenate=False default). Add short-word guard (_MIN_HYPHENATE_ALPHA_LEN = 12).
- modules/translators/base.py: call normalize_artificial_hyphenation() in sanitize_translation_text() so all translator/cache paths are cleaned.

Issue #137 follow-up - Non-rectangular default text boxes:
- utils/auto_text_layout.py: all three auto-layout presets (balanced, fit, readable) now default layout_balloon_shape='square' instead of 'auto'. Profile summaries updated. shape_detection hint reports 'simple rectangle' for square/rectangle/rect. Add rectangle/rect aliases throughout shape logic.

Issue #138 - Selectable balloon shapes for Auto detection:
- utils/config.py: add layout_balloon_shape_auto_allowed field (comma-separated allowlist; empty = all shapes allowed).
- ui/scenetext_manager.py: _resolve_auto_balloon_shape() applies allowed-shape filter; detected shapes outside the allowlist fall back to 'square'.
- ui/configpanel.py: new 'Allowed shapes for Auto detection' multi-checkbox row (Round/Elongated/Narrow/Diamond/Square/Bevel/Pentagon/Point) with handler and config-sync.
- ui/context_menu_config_dialog.py: rename 'Balloon shape (submenu)' to 'Text box shape: Rectangle / Auto (submenu)' for clarity.

Tests (24 passing):
- tests/test_line_breaking_hyphenation.py (new, 5 tests)
- tests/test_translation_sanitize_hyphenation.py (new, 3 tests)
- tests/test_text_layout_auto_formatting.py (7 new tests added)

## Summary
- What changed?
- Why is this needed?

## Required Checks

### README parity (EN + ZH)
- [ ] I reviewed [`README.md`](../README.md) and [`README_zh_CN.md`](../README_zh_CN.md) and confirmed they are in parity for any user-facing changes in this PR.
- [ ] If one README was updated without the other, I explained why.

### Startup script verification
- [ ] Verified startup behavior and entry points as applicable:
  - [ ] [`launch.py`](../launch.py)
  - [ ] [`launch_win.bat`](../launch_win.bat)
  - [ ] [`launch_win_with_autoupdate.bat`](../launch_win_with_autoupdate.bat)
  - [ ] [`launch_win_amd_nightly.bat`](../launch_win_amd_nightly.bat)
- [ ] Included a brief verification result for each script touched by this PR.

### First-run model-picker verification
- [ ] Verified first-run model package selection flow end-to-end where applicable:
  - [ ] [`utils/model_packages.py`](../utils/model_packages.py)
  - [ ] [`ui/model_package_selector_dialog.py`](../ui/model_package_selector_dialog.py)
- [ ] Confirmed behavior for first launch, model package listing, selection, and persistence.
- [ ] Included before/after screenshots for any UI change to the first-run model dialog.

## UX / Behavior Validation
- [ ] For UX-facing changes, I documented a clear **manual verification path** (steps + expected result).
- [ ] If defaults changed, I explained the **migration impact** for existing users/configurations.

## Risks / Compatibility
- Potential regressions:
- Rollback notes (if needed):

## Additional Notes
- Environment limitations (if any):
