### PR TITLE
Feat/UI ux settings restructure

### DIFF
--- a/modules/textdetector/detector_animetext_yolo.py
+++ b/modules/textdetector/detector_animetext_yolo.py
@@ -1,0 +1,207 @@
+"""
+AnimeText_yolo detector — deepghs/AnimeText_yolo (YOLO12) for robust anime/manga scene text detection.
+Requires:  pip install ultralytics huggingface-hub
+Model:    https://huggingface.co/deepghs/AnimeText_yolo
+"""
+import os
+import os.path as osp
+from typing import Tuple, List
+
+import numpy as np
+import cv2
+
+from .base import register_textdetectors, TextDetectorBase, TextBlock, DEVICE_SELECTOR
+from .box_utils import expand_blocks
+from utils.textblock import mit_merge_textlines, sort_regions, examine_textblk, sort_pnts
+from utils.imgproc_utils import xywh2xyxypoly
+
+
+_ANIME_TEXT_YOLO_AVAILABLE = False
+try:
+    from ultralytics import YOLO
+    from huggingface_hub import hf_hub_download, list_repo_files
+    _ANIME_TEXT_YOLO_AVAILABLE = True
+except Exception:
+    pass
+
+
+HF_REPO_ID = "deepghs/AnimeText_yolo"
+
+
+def _find_yolo_model_file() -> str:
+    """Return path to the best YOLO model file from the HF repo, downloading if needed."""
+    try:
+        files = list_repo_files(HF_REPO_ID, repo_type="model")
+        # Prefer .pt, then .safetensors
+        candidates = [f for f in files if f.endswith(".pt") or f.endswith(".safetensors")]
+        if not candidates:
+            return None
+        # Heuristic: pick the largest / most specific name (often best)
+        candidates.sort(key=lambda x: ("best" in x.lower(), "last" not in x.lower(), len(x)), reverse=True)
+        chosen = candidates[0]
+        return hf_hub_download(repo_id=HF_REPO_ID, filename=chosen, repo_type="model")
+    except Exception:
+        return None
+
+
+@register_textdetectors("animetext_yolo")
+class AnimeTextYoloDetector(TextDetectorBase):
+    """
+    AnimeText YOLO12 — trained on the AnimeText dataset for robust complex anime scene text detection.
+    Auto-downloads model weights from Hugging Face (deepghs/AnimeText_yolo) on first use.
+    """
+    params = {
+        "model path": {
+            "type": "line_editor",
+            "value": "",
+            "description": "Path to a local .pt/.safetensors YOLO model. Leave empty to auto-download from HF.",
+        },
+        "confidence threshold": {
+            "display_name": "Confidence threshold",
+            "type": "line_editor",
+            "value": 0.25,
+        },
+        "IoU threshold": {
+            "display_name": "IoU threshold",
+            "type": "line_editor",
+            "value": 0.5,
+        },
+        "device": {**DEVICE_SELECTOR(), "display_name": "Device"},
+        "font size multiplier": {
+            "display_name": "Font size multiplier",
+            "type": "line_editor",
+            "value": 1.0,
+        },
+        "font size max": {
+            "display_name": "Max font size",
+            "type": "line_editor",
+            "value": -1,
+        },
+        "font size min": {
+            "display_name": "Min font size",
+            "type": "line_editor",
+            "value": -1,
+        },
+        "merge text lines": {
+            "display_name": "Merge text lines", "type": "checkbox", "value": True
+        },
+        "box_padding": {
+            "type": "line_editor",
+            "value": 5,
+            "display_name": "Box padding",
+            "description": "Pixels to add around each detected box (all sides). Reduces clipped punctuation.",
+        },
+        "description": "AnimeText YOLO12 (deepghs/AnimeText_yolo). Auto-downloads from Hugging Face. Best for anime/manga scenes with complex text.",
+    }
+
+    _load_model_keys = {"model"}
+
+    def __init__(self, **params) -> None:
+        super().__init__(**params)
+        self._model_path = None
+
+    def _load_model(self):
+        if not _ANIME_TEXT_YOLO_AVAILABLE:
+            raise RuntimeError(
+                "AnimeText YOLO requires ultralytics and huggingface-hub. "
+                "Install: pip install ultralytics huggingface-hub"
+            )
+        model_path = self.get_param_value("model path")
+        if model_path and osp.exists(model_path):
+            self._model_path = model_path
+        else:
+            cached = _find_yolo_model_file()
+            if not cached:
+                raise RuntimeError(
+                    "Could not download AnimeText YOLO model from Hugging Face. "
+                    "Check internet connection or set 'model path' to a local .pt file."
+                )
+            self._model_path = cached
+        self.model = YOLO(self._model_path)
+        device = self.get_param_value("device")
+        if device:
+            self.model.to(device)
+
+    def _detect(self, img: np.ndarray, proj=None) -> Tuple[np.ndarray, List[TextBlock]]:
+        if not _ANIME_TEXT_YOLO_AVAILABLE:
+            raise RuntimeError("ultralytics / huggingface-hub not installed.")
+
+        conf = float(self.get_param_value("confidence threshold"))
+        iou = float(self.get_param_value("IoU threshold"))
+
+        result = self.model.predict(
+            source=img,
+            save=False,
+            show=False,
+            verbose=False,
+            conf=conf,
+            iou=iou,
+            agnostic_nms=True,
+        )[0]
+
+        im_h, im_w = img.shape[:2]
+        mask = np.zeros_like(img[..., 0])
+        detected_items = []
+
+        # Standard boxes
+        dets = result.boxes
+        if dets is not None and len(dets.cls) > 0:
+            for i in range(len(dets.cls)):
+                xyxy = dets.xyxy[i].cpu().numpy()
+                x1, y1, x2, y2 = xyxy.astype(int)
+                cv2.rectangle(mask, (x1, y1), (x2, y2), 255, -1)
+                pts = xywh2xyxypoly(np.array([[x1, y1, x2 - x1, y2 - y1]])).reshape(4, 2).tolist()
+                detected_items.append({"pts": pts, "label": "text"})
+
+        # Oriented boxes
+        dets = result.obb
+        if dets is not None and len(dets.cls) > 0:
+            for i in range(len(dets.cls)):
+                pts = dets.xyxyxyxy[i].cpu().numpy().astype(int)
+                cv2.fillPoly(mask, [pts], 255)
+                detected_items.append({"pts": pts.tolist(), "label": "text"})
+
+        blk_list = []
+        if self.get_param_value("merge text lines"):
+            pts_only_list = [item["pts"] for item in detected_items]
+            blk_list = mit_merge_textlines(pts_only_list, width=im_w, height=im_h)
+        else:
+            for item in detected_items:
+                pts_sorted, is_vertical = sort_pnts(item["pts"])
+                blk = TextBlock(lines=[pts_sorted], src_is_vertical=is_vertical, label=item["label"])
+                blk.vertical = is_vertical
+                blk.adjust_bbox()
+                examine_textblk(blk, im_w, im_h)
+                blk_list.append(blk)
+
+        blk_list = sort_regions(blk_list)
+
+        fnt_rsz = self.get_param_value("font size multiplier")
+        fnt_max = self.get_param_value("font size max")
+        fnt_min = self.get_param_value("font size min")
+        for blk in blk_list:
+            sz = blk._detected_font_size * fnt_rsz
+            if fnt_max > 0:
+                sz = min(fnt_max, sz)
+            if fnt_min > 0:
+                sz = max(fnt_min, sz)
+            blk.font_size = sz
+            blk._detected_font_size = sz
+
+        pad_val = 0
+        bp = self.params.get("box_padding", {})
+        if isinstance(bp, dict):
+            v = bp.get("value", 5)
+            try:
+                pad_val = max(0, min(24, int(v) if v not in (None, "") else 5))
+            except (TypeError, ValueError):
+                pad_val = 5
+        if pad_val > 0:
+            blk_list = expand_blocks(blk_list, pad_val, im_w, im_h)
+
+        return mask, blk_list
+
+    def updateParam(self, param_key: str, param_content):
+        super().updateParam(param_key, param_content)
+        if param_key == "model path" and hasattr(self, "model"):
+            del self.model

--- a/modules/textdetector/detector_pp_doclayout_v3.py
+++ b/modules/textdetector/detector_pp_doclayout_v3.py
@@ -1,0 +1,260 @@
+"""
+PP-DocLayoutV3 detector — PaddlePaddle document-layout text detector.
+Identifies text regions (title, text, paragraph, etc.) in complex document/comic layouts.
+Requires:  pip install transformers pillow  (or paddleocr / paddlepaddle)
+Model:    https://huggingface.co/PaddlePaddle/PP-DocLayoutV3
+"""
+import os
+from typing import Tuple, List
+
+import numpy as np
+import cv2
+
+from .base import register_textdetectors, TextDetectorBase, TextBlock, DEVICE_SELECTOR
+from .box_utils import expand_blocks
+from utils.textblock import sort_regions, examine_textblk, sort_pnts
+from utils.imgproc_utils import xywh2xyxypoly
+
+
+_PP_DOCLAYOUT_AVAILABLE = False
+_Backend = None  # 'transformers' or 'paddle'
+
+# Try transformers first (easier to install, no Paddle C++ libs)
+try:
+    from transformers import AutoModelForVisualDocumentUnderstanding, AutoProcessor
+    _PP_DOCLAYOUT_AVAILABLE = True
+    _Backend = "transformers"
+except Exception:
+    pass
+
+# Fallback to PaddleOCR LayoutDetection
+try:
+    if not _PP_DOCLAYOUT_AVAILABLE:
+        from paddleocr import LayoutDetection
+        _PP_DOCLAYOUT_AVAILABLE = True
+        _Backend = "paddle"
+except Exception:
+    pass
+
+
+HF_REPO_ID = "PaddlePaddle/PP-DocLayoutV3"
+
+# Classes considered "text" regions we want to keep.
+# V3 label names vary by backend; we include common synonyms.
+_TEXT_LABELS = {
+    "text", "paragraph", "title", "header", "footer", "caption",
+    "list", "table", "equation", "chart",
+    # Chinese labels (Paddle often emits Chinese class names)
+    "文字", "文本", "段落", "标题", "页眉", "页脚", "题注", "列表",
+}
+
+
+def _is_text_label(label: str) -> bool:
+    if not label:
+        return False
+    lo = label.strip().lower()
+    # Direct match
+    if lo in _TEXT_LABELS:
+        return True
+    # Partial match (e.g. "text_block")
+    for tl in _TEXT_LABELS:
+        if tl in lo or lo in tl:
+            return True
+    return False
+
+
+@register_textdetectors("pp_doclayout_v3")
+class PPDocLayoutV3Detector(TextDetectorBase):
+    """
+    PP-DocLayoutV3 — document layout detector that finds text regions in complex layouts
+    (curved pages, mixed columns, manga with complex paneling, etc.).
+
+    Uses transformers (preferred) or paddleocr as backend.
+    Auto-downloads model weights from Hugging Face on first use.
+    """
+    params = {
+        "confidence threshold": {
+            "display_name": "Confidence threshold",
+            "type": "line_editor",
+            "value": 0.3,
+        },
+        "device": {**DEVICE_SELECTOR(), "display_name": "Device"},
+        "font size multiplier": {
+            "display_name": "Font size multiplier",
+            "type": "line_editor",
+            "value": 1.0,
+        },
+        "font size max": {
+            "display_name": "Max font size",
+            "type": "line_editor",
+            "value": -1,
+        },
+        "font size min": {
+            "display_name": "Min font size",
+            "type": "line_editor",
+            "value": -1,
+        },
+        "box_padding": {
+            "type": "line_editor",
+            "value": 4,
+            "display_name": "Box padding",
+            "description": "Pixels to add around each detected box.",
+        },
+        "description": "PP-DocLayoutV3 (PaddlePaddle). Document layout-aware text detection for complex page layouts and curved surfaces. Auto-downloads from HF.",
+    }
+
+    _load_model_keys = {"model", "processor"}
+
+    def __init__(self, **params) -> None:
+        super().__init__(**params)
+
+    def _load_model(self):
+        if not _PP_DOCLAYOUT_AVAILABLE:
+            raise RuntimeError(
+                "PP-DocLayoutV3 requires transformers (pip install transformers pillow) "
+                "or paddleocr (pip install paddleocr)."
+            )
+        if _Backend == "transformers":
+            self.processor = AutoProcessor.from_pretrained(HF_REPO_ID, trust_remote_code=True)
+            self.model = AutoModelForVisualDocumentUnderstanding.from_pretrained(
+                HF_REPO_ID, trust_remote_code=True
+            )
+            device = self.get_param_value("device")
+            if device and device != "cpu":
+                self.model = self.model.to(device)
+        elif _Backend == "paddle":
+            self.model = LayoutDetection(model_name="PP-DocLayout-L")
+            self.processor = None
+
+    def _detect(self, img: np.ndarray, proj=None) -> Tuple[np.ndarray, List[TextBlock]]:
+        if not _PP_DOCLAYOUT_AVAILABLE:
+            raise RuntimeError("PP-DocLayoutV3 backend not installed.")
+
+        im_h, im_w = img.shape[:2]
+        mask = np.zeros((im_h, im_w), dtype=np.uint8)
+        detected_items = []
+        conf_thresh = float(self.get_param_value("confidence threshold"))
+
+        if _Backend == "transformers":
+            # transformers pipeline
+            from PIL import Image
+            pil_img = Image.fromarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+            inputs = self.processor(images=pil_img, return_tensors="pt")
+            device = self.get_param_value("device")
+            if device and device != "cpu":
+                inputs = {k: v.to(device) if hasattr(v, "to") else v for k, v in inputs.items()}
+
+            with np.errstate(all="ignore"):
+                outputs = self.model(**inputs)
+
+            # The output structure varies; try common patterns
+            pred_boxes = None
+            pred_labels = None
+            pred_scores = None
+
+            if hasattr(outputs, "pred_boxes") and outputs.pred_boxes is not None:
+                pred_boxes = outputs.pred_boxes.cpu().numpy() if hasattr(outputs.pred_boxes, "cpu") else outputs.pred_boxes
+            if hasattr(outputs, "pred_logits") and outputs.pred_logits is not None:
+                logits = outputs.pred_logits
+                if hasattr(logits, "cpu"):
+                    logits = logits.cpu().numpy()
+                pred_scores = np.max(logits, axis=-1)
+                pred_labels = np.argmax(logits, axis=-1)
+
+            # Some models return decoded dicts directly
+            if pred_boxes is None and isinstance(outputs, dict):
+                pred_boxes = outputs.get("boxes") or outputs.get("pred_boxes")
+                pred_labels = outputs.get("labels") or outputs.get("pred_labels")
+                pred_scores = outputs.get("scores") or outputs.get("pred_scores")
+
+            if pred_boxes is not None and pred_labels is not None:
+                id2label = getattr(self.model.config, "id2label", {}) if hasattr(self.model, "config") else {}
+                for i in range(len(pred_boxes)):
+                    box = pred_boxes[i]
+                    score = float(pred_scores[i]) if pred_scores is not None and i < len(pred_scores) else 1.0
+                    if score < conf_thresh:
+                        continue
+                    label_id = int(pred_labels[i]) if pred_labels is not None else -1
+                    label_str = id2label.get(label_id, str(label_id)) if isinstance(id2label, dict) else str(label_id)
+                    if not _is_text_label(label_str):
+                        continue
+
+                    # Box may be normalized [0,1] or pixel coords
+                    if np.max(box) <= 1.0:
+                        x1, y1, x2, y2 = (
+                            int(box[0] * im_w),
+                            int(box[1] * im_h),
+                            int(box[2] * im_w),
+                            int(box[3] * im_h),
+                        )
+                    else:
+                        x1, y1, x2, y2 = map(int, box[:4])
+
+                    x1, y1 = max(0, x1), max(0, y1)
+                    x2, y2 = min(im_w, x2), min(im_h, y2)
+                    if x2 <= x1 or y2 <= y1:
+                        continue
+                    cv2.rectangle(mask, (x1, y1), (x2, y2), 255, -1)
+                    pts = xywh2xyxypoly(np.array([[x1, y1, x2 - x1, y2 - y1]])).reshape(4, 2).tolist()
+                    detected_items.append({"pts": pts, "label": "text"})
+
+        elif _Backend == "paddle":
+            # paddleocr LayoutDetection returns a list of dicts
+            result = self.model.predict(img)
+            if isinstance(result, list):
+                for item in result:
+                    if not isinstance(item, dict):
+                        continue
+                    score = float(item.get("score", 0))
+                    if score < conf_thresh:
+                        continue
+                    label = item.get("label", "")
+                    if not _is_text_label(label):
+                        continue
+                    bbox = item.get("bbox")
+                    if bbox is None:
+                        continue
+                    x1, y1, x2, y2 = map(int, bbox[:4])
+                    x1, y1 = max(0, x1), max(0, y1)
+                    x2, y2 = min(im_w, x2), min(im_h, y2)
+                    if x2 <= x1 or y2 <= y1:
+                        continue
+                    cv2.rectangle(mask, (x1, y1), (x2, y2), 255, -1)
+                    pts = xywh2xyxypoly(np.array([[x1, y1, x2 - x1, y2 - y1]])).reshape(4, 2).tolist()
+                    detected_items.append({"pts": pts, "label": "text"})
+
+        blk_list = []
+        for item in detected_items:
+            pts_sorted, is_vertical = sort_pnts(item["pts"])
+            blk = TextBlock(lines=[pts_sorted], src_is_vertical=is_vertical, label=item["label"])
+            blk.vertical = is_vertical
+            blk.adjust_bbox()
+            examine_textblk(blk, im_w, im_h)
+            blk_list.append(blk)
+
+        blk_list = sort_regions(blk_list)
+
+        fnt_rsz = self.get_param_value("font size multiplier")
+        fnt_max = self.get_param_value("font size max")
+        fnt_min = self.get_param_value("font size min")
+        for blk in blk_list:
+            sz = blk._detected_font_size * fnt_rsz
+            if fnt_max > 0:
+                sz = min(fnt_max, sz)
+            if fnt_min > 0:
+                sz = max(fnt_min, sz)
+            blk.font_size = sz
+            blk._detected_font_size = sz
+
+        pad_val = 0
+        bp = self.params.get("box_padding", {})
+        if isinstance(bp, dict):
+            v = bp.get("value", 4)
+            try:
+                pad_val = max(0, min(24, int(v) if v not in (None, "") else 4))
+            except (TypeError, ValueError):
+                pad_val = 4
+        if pad_val > 0:
+            blk_list = expand_blocks(blk_list, pad_val, im_w, im_h)
+
+        return mask, blk_list

--- a/tests/test_canvas_mask_overlay.py
+++ b/tests/test_canvas_mask_overlay.py
@@ -1,0 +1,45 @@
+"""Tests for Canvas._build_mask_overlay fix (#1117)."""
+import sys
+import os.path as osp
+import numpy as np
+
+sys.path.insert(0, osp.dirname(osp.dirname(osp.abspath(__file__))))
+
+from ui.canvas import Canvas
+
+
+def test_build_mask_overlay_zero_mask():
+    """A zero mask should produce a fully transparent RGBA image."""
+    mask = np.zeros((10, 10), dtype=np.uint8)
+    rgba = Canvas._build_mask_overlay(mask, 0.5)
+    assert rgba.shape == (10, 10, 4)
+    assert rgba.dtype == np.uint8
+    # Alpha channel should be all zeros
+    assert np.all(rgba[:, :, 3] == 0)
+
+
+def test_build_mask_overlay_full_mask():
+    """A fully white mask at transparency=1 should produce alpha=255."""
+    mask = np.full((10, 10), 255, dtype=np.uint8)
+    rgba = Canvas._build_mask_overlay(mask, 1.0)
+    assert np.all(rgba[:, :, 3] == 255)
+    # Check magenta tint
+    assert np.all(rgba[:, :, 0] == 200)
+    assert np.all(rgba[:, :, 1] == 0)
+    assert np.all(rgba[:, :, 2] == 200)
+
+
+def test_build_mask_overlay_partial_transparency():
+    """Partial transparency should scale alpha proportionally."""
+    mask = np.full((10, 10), 128, dtype=np.uint8)
+    rgba = Canvas._build_mask_overlay(mask, 0.5)
+    expected_alpha = int(128 * 0.5)
+    assert np.all(rgba[:, :, 3] == expected_alpha)
+
+
+def test_build_mask_overlay_gradient_mask():
+    """A gradient mask should preserve per-pixel alpha values."""
+    mask = np.arange(0, 256, dtype=np.uint8).reshape(16, 16)
+    rgba = Canvas._build_mask_overlay(mask, 0.5)
+    expected_alpha = np.clip(mask * 0.5, 0, 255).astype(np.uint8)
+    np.testing.assert_array_equal(rgba[:, :, 3], expected_alpha)

--- a/tests/test_delete_recover_sync.py
+++ b/tests/test_delete_recover_sync.py
@@ -15,6 +15,8 @@ def _install_scenetext_stubs():
     qtwidgets.QApplication = object
     qtwidgets.QWidget = object
     qtwidgets.QGraphicsItem = object
+    qtwidgets.QScrollArea = object
+    qtwidgets.QSizePolicy = object
     qtwidgets.QUndoCommand = DummyUndoCommand
 
     qtcore = types.ModuleType("qtpy.QtCore")
@@ -98,6 +100,7 @@ def _install_scenetext_stubs():
     sys.modules["utils.config"] = cfg
 
     shared = types.ModuleType("utils.shared")
+    shared.PROGRAM_PATH = "."
     sys.modules["utils.shared"] = shared
 
     imgproc = types.ModuleType("utils.imgproc_utils")

--- a/tests/test_detector_animetext_yolo.py
+++ b/tests/test_detector_animetext_yolo.py
@@ -1,0 +1,51 @@
+"""Tests for AnimeText_yolo detector module structure and registration."""
+import sys
+import os.path as osp
+import types
+import numpy as np
+
+sys.path.insert(0, osp.dirname(osp.dirname(osp.abspath(__file__))))
+
+# Stub ultralytics and huggingface_hub so we never hit heavy deps or network
+ult = types.ModuleType("ultralytics")
+ult.YOLO = type("YOLO", (), {"predict": lambda *a, **k: [type("R", (), {"boxes": None, "obb": None})()]})()
+sys.modules["ultralytics"] = ult
+
+hf = types.ModuleType("huggingface_hub")
+hf.hf_hub_download = lambda **k: "/fake/model.pt"
+hf.list_repo_files = lambda *a, **k: ["animetext_yolo_n.pt", "README.md"]
+sys.modules["huggingface_hub"] = hf
+
+from modules.textdetector.detector_animetext_yolo import (
+    AnimeTextYoloDetector,
+    _ANIME_TEXT_YOLO_AVAILABLE,
+)
+from modules.textdetector.base import TEXTDETECTORS
+
+
+def test_module_available():
+    assert _ANIME_TEXT_YOLO_AVAILABLE is True  # because we stubbed it
+
+
+def test_detector_registered():
+    assert "animetext_yolo" in TEXTDETECTORS.module_dict
+    cls = TEXTDETECTORS.module_dict["animetext_yolo"]
+    assert cls is AnimeTextYoloDetector
+
+
+def test_params_structure():
+    params = AnimeTextYoloDetector.params
+    assert "confidence threshold" in params
+    assert "IoU threshold" in params
+    assert "device" in params
+    assert "model path" in params
+    assert params["confidence threshold"]["type"] == "line_editor"
+
+
+def test_detector_can_instantiate():
+    det = AnimeTextYoloDetector()
+    assert det.name == "animetext_yolo"
+
+
+def test_detector_class_importable():
+    assert AnimeTextYoloDetector is not None

--- a/tests/test_detector_pp_doclayout_v3.py
+++ b/tests/test_detector_pp_doclayout_v3.py
@@ -1,0 +1,77 @@
+"""Tests for PP-DocLayoutV3 detector module structure and registration."""
+import sys
+import os.path as osp
+import types
+import numpy as np
+
+sys.path.insert(0, osp.dirname(osp.dirname(osp.abspath(__file__))))
+
+# Stub transformers so we never pull heavy deps
+trans = types.ModuleType("transformers")
+trans.AutoModelForVisualDocumentUnderstanding = type(
+    "AutoModelForVisualDocumentUnderstanding",
+    (),
+    {
+        "from_pretrained": classmethod(
+            lambda cls, *a, **k: type(
+                "M", (), {"config": type("C", (), {"id2label": {0: "text"}})()}
+            )()
+        )
+    },
+)
+trans.AutoProcessor = type(
+    "AutoProcessor",
+    (),
+    {
+        "from_pretrained": classmethod(
+            lambda cls, *a, **k: type("P", (), {"__call__": lambda self, **kw: {"pixel_values": np.zeros((1, 3, 224, 224))}})()
+        )
+    },
+)
+sys.modules["transformers"] = trans
+
+# Also stub PIL
+pil_mod = types.ModuleType("PIL")
+pil_mod.Image = type("Image", (), {"fromarray": classmethod(lambda cls, arr: object())})
+sys.modules["PIL"] = pil_mod
+pil_image = types.ModuleType("PIL.Image")
+pil_image.Image = pil_mod.Image
+sys.modules["PIL.Image"] = pil_image
+
+from modules.textdetector.detector_pp_doclayout_v3 import (
+    PPDocLayoutV3Detector,
+    _PP_DOCLAYOUT_AVAILABLE,
+    _is_text_label,
+)
+from modules.textdetector.base import TEXTDETECTORS
+
+
+def test_module_available():
+    assert _PP_DOCLAYOUT_AVAILABLE is True
+
+
+def test_detector_registered():
+    assert "pp_doclayout_v3" in TEXTDETECTORS.module_dict
+    cls = TEXTDETECTORS.module_dict["pp_doclayout_v3"]
+    assert cls is PPDocLayoutV3Detector
+
+
+def test_params_structure():
+    params = PPDocLayoutV3Detector.params
+    assert "confidence threshold" in params
+    assert "device" in params
+    assert params["confidence threshold"]["type"] == "line_editor"
+
+
+def test_detector_can_instantiate():
+    det = PPDocLayoutV3Detector()
+    assert det.name == "pp_doclayout_v3"
+
+
+def test_is_text_label():
+    assert _is_text_label("text") is True
+    assert _is_text_label("paragraph") is True
+    assert _is_text_label("title") is True
+    assert _is_text_label("figure") is False
+    assert _is_text_label("image") is False
+    assert _is_text_label("") is False

--- a/tests/test_module_parse_widgets_fallback.py
+++ b/tests/test_module_parse_widgets_fallback.py
@@ -1,0 +1,456 @@
+"""Tests for module_parse_widgets fallback fix (#904)."""
+import sys
+import types
+import os.path as osp
+
+sys.path.insert(0, osp.dirname(osp.dirname(osp.abspath(__file__))))
+
+class _MockSignal:
+    def connect(self, *a, **k): pass
+    def emit(self, *a, **k): pass
+
+class _MockWidget:
+    def __init__(self, *a, **k): pass
+    def addWidget(self, *a, **k): pass
+    def addLayout(self, *a, **k): pass
+    def addStretch(self, *a, **k): pass
+    def setSpacing(self, *a, **k): pass
+    def setContentsMargins(self, *a, **k): pass
+    def setColumnStretch(self, *a, **k): pass
+    def setRowStretch(self, *a, **k): pass
+    def setToolTip(self, *a, **k): pass
+    def setText(self, *a, **k): pass
+    def setChecked(self, *a, **k): pass
+    def setCurrentText(self, *a, **k): pass
+    def setEditable(self, *a, **k): pass
+    def setValidator(self, *a, **k): pass
+    def setFixedWidth(self, *a, **k): pass
+    def setFixedHeight(self, *a, **k): pass
+    def setMaximumWidth(self, *a, **k): pass
+    def setMinimumWidth(self, *a, **k): pass
+    def setMinimumHeight(self, *a, **k): pass
+    def setFont(self, *a, **k): pass
+    def hide(self, *a, **k): pass
+    def show(self, *a, **k): pass
+    def blockSignals(self, *a, **k): pass
+    def setEnabled(self, *a, **k): pass
+    def setStyleSheet(self, *a, **k): pass
+    def setPlaceholderText(self, *a, **k): pass
+    def setReadOnly(self, *a, **k): pass
+    def setFocus(self, *a, **k): pass
+    def setPlainText(self, *a, **k): pass
+    def setAlignment(self, *a, **k): pass
+    def setWordWrap(self, *a, **k): pass
+    def text(self, *a, **k): return ""
+    def isChecked(self, *a, **k): return False
+    def value(self, *a, **k): return 0
+    def currentText(self, *a, **k): return ""
+    def count(self, *a, **k): return 0
+    def isVisible(self, *a, **k): return False
+    def mapToGlobal(self, *a, **k): pass
+    def view(self, *a, **k): return self
+    def setItemDelegate(self, *a, **k): pass
+    def setMouseTracking(self, *a, **k): pass
+    def setCursor(self, *a, **k): pass
+    def viewport(self, *a, **k): return self
+    def update(self, *a, **k): pass
+    def parent(self, *a, **k): return None
+    def setParent(self, *a, **k): pass
+    def size(self, *a, **k): return self
+    def width(self, *a, **k): return 100
+    def height(self, *a, **k): return 30
+    def pos(self, *a, **k): return self
+    def x(self, *a, **k): return 0
+    def y(self, *a, **k): return 0
+    def rect(self, *a, **k): return self
+    def geometry(self, *a, **k): return self
+    def frameGeometry(self, *a, **k): return self
+    def setGeometry(self, *a, **k): pass
+    def move(self, *a, **k): pass
+    def resize(self, *a, **k): pass
+    def close(self, *a, **k): pass
+    def deleteLater(self, *a, **k): pass
+    def raise_(self, *a, **k): pass
+    def lower(self, *a, **k): pass
+    def stackUnder(self, *a, **k): pass
+    def activateWindow(self, *a, **k): pass
+    def setWindowTitle(self, *a, **k): pass
+    def setWindowIcon(self, *a, **k): pass
+    def setWindowFlags(self, *a, **k): pass
+    def windowFlags(self, *a, **k): return 0
+    def isActiveWindow(self, *a, **k): return False
+    def hasFocus(self, *a, **k): return False
+    def setFocusPolicy(self, *a, **k): pass
+    def setAttribute(self, *a, **k): pass
+    def testAttribute(self, *a, **k): return False
+    def findChild(self, *a, **k): return None
+    def findChildren(self, *a, **k): return []
+    def children(self, *a, **k): return []
+    def actions(self, *a, **k): return []
+    def addAction(self, *a, **k): pass
+    def removeAction(self, *a, **k): pass
+    def clear(self, *a, **k): pass
+    def setSizePolicy(self, *a, **k): pass
+    def sizePolicy(self, *a, **k): return self
+    def setAcceptDrops(self, *a, **k): pass
+    def acceptDrops(self, *a, **k): return False
+    def setDragEnabled(self, *a, **k): pass
+    def setDropIndicatorShown(self, *a, **k): pass
+    def setDefaultDropAction(self, *a, **k): pass
+    def setDragDropMode(self, *a, **k): pass
+    def setDragDropOverwriteMode(self, *a, **k): pass
+    def setSelectionMode(self, *a, **k): pass
+    def setSelectionBehavior(self, *a, **k): pass
+    def setAlternatingRowColors(self, *a, **k): pass
+    def setUniformRowHeights(self, *a, **k): pass
+    def setAnimated(self, *a, **k): pass
+    def setAllColumnsShowFocus(self, *a, **k): pass
+    def setAutoExpandDelay(self, *a, **k): pass
+    def setIndentation(self, *a, **k): pass
+    def setRootIsDecorated(self, *a, **k): pass
+    def setSortingEnabled(self, *a, **k): pass
+    def sortByColumn(self, *a, **k): pass
+    def header(self, *a, **k): return self
+    def setHeaderHidden(self, *a, **k): pass
+    def setColumnWidth(self, *a, **k): pass
+    def columnWidth(self, *a, **k): return 100
+    def setColumnCount(self, *a, **k): pass
+    def columnCount(self, *a, **k): return 1
+    def setRowCount(self, *a, **k): pass
+    def rowCount(self, *a, **k): return 0
+    def setCellWidget(self, *a, **k): pass
+    def cellWidget(self, *a, **k): return None
+    def item(self, *a, **k): return None
+    def setItem(self, *a, **k): pass
+    def takeItem(self, *a, **k): return None
+    def addItem(self, *a, **k): pass
+    def insertItem(self, *a, **k): pass
+    def removeItem(self, *a, **k): pass
+    def itemText(self, *a, **k): return ""
+    def itemData(self, *a, **k): return None
+    def setItemData(self, *a, **k): pass
+    def setItemText(self, *a, **k): pass
+    def setIconSize(self, *a, **k): pass
+    def iconSize(self, *a, **k): return self
+    def setUniformItemSizes(self, *a, **k): pass
+    def setResizeMode(self, *a, **k): pass
+    def setViewMode(self, *a, **k): pass
+    def setFlow(self, *a, **k): pass
+    def setWrapping(self, *a, **k): pass
+    def setSpacing(self, *a, **k): pass
+    def setGridSize(self, *a, **k): pass
+    def setBatchSize(self, *a, **k): pass
+    def setLayoutMode(self, *a, **k): pass
+    def setMovement(self, *a, **k): pass
+    def setWordWrap(self, *a, **k): pass
+    def setTextElideMode(self, *a, **k): pass
+    def setHorizontalScrollMode(self, *a, **k): pass
+    def setVerticalScrollMode(self, *a, **k): pass
+    def setTabPosition(self, *a, **k): pass
+    def setTabShape(self, *a, **k): pass
+    def setDocumentMode(self, *a, **k): pass
+    def setMovable(self, *a, **k): pass
+    def setTabsClosable(self, *a, **k): pass
+    def setTabBarAutoHide(self, *a, **k): pass
+    def setUsesScrollButtons(self, *a, **k): pass
+    def setCornerWidget(self, *a, **k): pass
+    def setOrientation(self, *a, **k): pass
+    def setOpaqueResize(self, *a, **k): pass
+    def setHandleWidth(self, *a, **k): pass
+    def setStretchFactor(self, *a, **k): pass
+    def setSizes(self, *a, **k): pass
+    def sizes(self, *a, **k): return []
+    def addWidget(self, *a, **k): pass
+    def insertWidget(self, *a, **k): pass
+    def widget(self, *a, **k): return None
+    def indexOf(self, *a, **k): return -1
+    def setCurrentIndex(self, *a, **k): pass
+    def currentIndex(self, *a, **k): return 0
+    def setCurrentWidget(self, *a, **k): pass
+    def removeWidget(self, *a, **k): pass
+    def setLineWidth(self, *a, **k): pass
+    def setMidLineWidth(self, *a, **k): pass
+    def setFrameStyle(self, *a, **k): pass
+    def setFrameShape(self, *a, **k): pass
+    def setFrameShadow(self, *a, **k): pass
+    def setAutoFillBackground(self, *a, **k): pass
+    def setBackgroundRole(self, *a, **k): pass
+    def setForegroundRole(self, *a, **k): pass
+    def setContentsMargins(self, *a, **k): pass
+    def getContentsMargins(self, *a, **k): return (0, 0, 0, 0)
+    def contentsMargins(self, *a, **k): return self
+    def contentsRect(self, *a, **k): return self
+    def setSpacing(self, *a, **k): pass
+    def spacing(self, *a, **k): return 0
+    def setStretch(self, *a, **k): pass
+    def stretch(self, *a, **k): return 0
+    def setAlignment(self, *a, **k): pass
+    def alignment(self, *a, **k): return 0
+    def setMenu(self, *a, **k): pass
+    def menu(self, *a, **k): return None
+    def setPopupMode(self, *a, **k): pass
+    def setToolButtonStyle(self, *a, **k): pass
+    def setArrowType(self, *a, **k): pass
+    def setDefaultAction(self, *a, **k): pass
+    def setCheckable(self, *a, **k): pass
+    def setChecked(self, *a, **k): pass
+    def isChecked(self, *a, **k): return False
+    def setAutoRaise(self, *a, **k): pass
+    def setDown(self, *a, **k): pass
+    def isDown(self, *a, **k): return False
+    def animateClick(self, *a, **k): pass
+    def click(self, *a, **k): pass
+    def toggle(self, *a, **k): pass
+    def setShortcut(self, *a, **k): pass
+    def setShortcuts(self, *a, **k): pass
+    def setAutoRepeat(self, *a, **k): pass
+    def setAutoRepeatDelay(self, *a, **k): pass
+    def setAutoRepeatInterval(self, *a, **k): pass
+    def setText(self, *a, **k): pass
+    def text(self, *a, **k): return ""
+    def setIcon(self, *a, **k): pass
+    def icon(self, *a, **k): return None
+    def setWhatsThis(self, *a, **k): pass
+    def setStatusTip(self, *a, **k): pass
+    def setShortcutContext(self, *a, **k): pass
+    def setData(self, *a, **k): pass
+    def data(self, *a, **k): return None
+    def setFlags(self, *a, **k): pass
+    def flags(self, *a, **k): return 0
+    def setCheckState(self, *a, **k): pass
+    def checkState(self, *a, **k): return 0
+    def setTristate(self, *a, **k): pass
+    def isTristate(self, *a, **k): return False
+    def setExclusive(self, *a, **k): pass
+    def setId(self, *a, **k): pass
+    def id(self, *a, **k): return -1
+    def setSingleStep(self, *a, **k): pass
+    def setPageStep(self, *a, **k): pass
+    def setRange(self, *a, **k): pass
+    def setSliderPosition(self, *a, **k): pass
+    def sliderPosition(self, *a, **k): return 0
+    def setInvertedAppearance(self, *a, **k): pass
+    def setInvertedControls(self, *a, **k): pass
+    def setTracking(self, *a, **k): pass
+    def setTickPosition(self, *a, **k): pass
+    def setTickInterval(self, *a, **k): pass
+    def setWrapping(self, *a, **k): pass
+    def setSpecialValueText(self, *a, **k): pass
+    def setPrefix(self, *a, **k): pass
+    def setSuffix(self, *a, **k): pass
+    def setDecimals(self, *a, **k): pass
+    def setMaximum(self, *a, **k): pass
+    def setMinimum(self, *a, **k): pass
+    def maximum(self, *a, **k): return 9999
+    def minimum(self, *a, **k): return 0
+    def setSingleStep(self, *a, **k): pass
+    def setDisplayIntegerBase(self, *a, **k): pass
+    def setDisplayAlignment(self, *a, **k): pass
+    def setButtonSymbols(self, *a, **k): pass
+    def setCorrectionMode(self, *a, **k): pass
+    def setKeyboardTracking(self, *a, **k): pass
+    def setAccelerated(self, *a, **k): pass
+    def selectAll(self, *a, **k): pass
+    def deselect(self, *a, **k): pass
+    def insert(self, *a, **k): pass
+    def undo(self, *a, **k): pass
+    def redo(self, *a, **k): pass
+    def cut(self, *a, **k): pass
+    def copy(self, *a, **k): pass
+    def paste(self, *a, **k): pass
+    def clear(self, *a, **k): pass
+    def selectAll(self, *a, **k): pass
+    def home(self, *a, **k): pass
+    def end(self, *a, **k): pass
+    def setEchoMode(self, *a, **k): pass
+    def setInputMask(self, *a, **k): pass
+    def setMaxLength(self, *a, **k): pass
+    def maxLength(self, *a, **k): return 32767
+    def setCursorPosition(self, *a, **k): pass
+    def cursorPosition(self, *a, **k): return 0
+    def setTabChangesFocus(self, *a, **k): pass
+    def setAcceptRichText(self, *a, **k): pass
+    def setOverwriteMode(self, *a, **k): pass
+    def setTextInteractionFlags(self, *a, **k): pass
+    def setVisible(self, *a, **k): pass
+    def isVisible(self, *a, **k): return False
+    def setEnabled(self, *a, **k): pass
+    def isEnabled(self, *a, **k): return True
+    def setHidden(self, *a, **k): pass
+    def setLayout(self, *a, **k): pass
+    def layout(self, *a, **k): return None
+    def font(self, *a, **k): return _MockFont()
+    def __getattr__(self, name):
+        if name.startswith('__') and name.endswith('__'):
+            raise AttributeError(name)
+        if 'changed' in name.lower() or 'clicked' in name.lower() or 'pressed' in name.lower() or 'triggered' in name.lower() or 'editingFinished' in name or 'activated' in name or 'textChanged' in name or 'stateChanged' in name or 'currentIndexChanged' in name or 'focus_out' in name or 'focus_in' in name or name == 'entered' or name == 'leaved' or name == 'hoverEnter' or name == 'hoverLeave':
+            return _MockSignal()
+        return _MockWidget() if name[0].isupper() else lambda *a, **k: None
+
+class _MockVariantAnimation(_MockWidget):
+    def setDuration(self, v): pass
+    def setStartValue(self, v): pass
+    def setEndValue(self, v): pass
+    valueChanged = _MockSignal()
+
+class _MockMsgBox(object):
+    class StandardButton:
+        Ok = 1; Yes = 2; No = 4; Cancel = 8
+
+# Minimal Qt stubs for module_parse_widgets
+qtcore = types.ModuleType("qtpy.QtCore")
+class _MockQt:
+    class Orientation:
+        Horizontal = 1
+        Vertical = 2
+    class AlignmentFlag:
+        AlignCenter = 1; AlignLeft = 2; AlignRight = 4; AlignTop = 8; AlignBottom = 16; AlignVCenter = 32; AlignHCenter = 64
+    class PenStyle:
+        SolidLine = 1
+    class GlobalColor:
+        transparent = 1; black = 2; white = 3
+    class CompositionMode:
+        CompositionMode_SourceOver = 1
+    class RenderHint:
+        SmoothPixmapTransform = 1
+    class WidgetAttribute:
+        WA_TransparentForMouseEvents = 1
+        WA_MouseTracking = 2
+        WA_TranslucentBackground = 3
+        WA_NoSystemBackground = 4
+        WA_OpaquePaintEvent = 5
+qtcore.Qt = _MockQt
+def _make_signal(*a, **k):
+    return _MockSignal()
+qtcore.Signal = _make_signal
+class _MockQObject:
+    def __init__(self, *a, **k): pass
+    def installEventFilter(self, *a, **k): pass
+qtcore.QObject = _MockQObject
+qtcore.QEvent = object
+qtcore.QPoint = object
+qtcore.QPointF = object
+qtcore.QSize = object
+qtcore.QSizeF = object
+qtcore.QRect = object
+qtcore.QRectF = object
+qtcore.QMimeData = object
+qtcore.QTimer = object
+qtcore.QPropertyAnimation = object
+qtcore.QAbstractAnimation = object
+qtcore.QParallelAnimationGroup = object
+qtcore.QModelIndex = object
+qtcore.QVariantAnimation = _MockVariantAnimation
+qtcore.QAbstractItemModel = object
+qtcore.QItemSelection = object
+qtcore.QThread = object
+class _MockEasingCurve:
+    Linear = 0; InOutCubic = 1
+qtcore.QEasingCurve = _MockEasingCurve
+class _MockProperty:
+    def __init__(self, *a, **k): pass
+    def setter(self, fn): return fn
+    def __call__(self, fn): return self
+qtcore.Property = _MockProperty
+sys.modules["qtpy.QtCore"] = qtcore
+
+qtgui = types.ModuleType("qtpy.QtGui")
+class _MockDoubleValidator:
+    class Notation:
+        StandardNotation = 0
+    def setTop(self, v): pass
+    def setBottom(self, v): pass
+    def setNotation(self, n): pass
+qtgui.QDoubleValidator = _MockDoubleValidator
+class _MockFont:
+    def setPointSizeF(self, *a, **k): pass
+    def setPointSize(self, *a, **k): pass
+    def setWeight(self, *a, **k): pass
+    def setFamily(self, *a, **k): pass
+    def setBold(self, *a, **k): pass
+    def setItalic(self, *a, **k): pass
+    def setUnderline(self, *a, **k): pass
+    def setStrikeOut(self, *a, **k): pass
+    def setStyleStrategy(self, *a, **k): pass
+    def pointSizeF(self, *a, **k): return 12.0
+qtgui.QFont = _MockFont
+class _MockColor:
+    def __init__(self, *a, **k): pass
+qtgui.QColor = _MockColor
+qtgui.QPen = object
+qtgui.QBrush = object
+qtgui.QPalette = object
+qtgui.QPixmap = object
+qtgui.QImage = object
+qtgui.QKeyEvent = object
+qtgui.QMouseEvent = object
+qtgui.QCursor = object
+qtgui.QKeySequence = object
+qtgui.QTextCursor = object
+qtgui.QTextCharFormat = object
+qtgui.QTextDocument = object
+qtgui.QAbstractTextDocumentLayout = object
+qtgui.QTextFrameFormat = object
+qtgui.QGradient = object
+qtgui.QLinearGradient = object
+qtgui.QRadialGradient = object
+qtgui.QTransform = object
+qtgui.QPolygonF = object
+qtgui.QBitmap = object
+qtgui.QRegion = object
+qtgui.QPainterPath = object
+qtgui.QPainter = object
+qtgui.QInputMethodEvent = object
+qtgui.QDragEnterEvent = object
+qtgui.QDropEvent = object
+qtgui.QDrag = object
+qtgui.QIcon = object
+qtgui.QFontMetrics = object
+qtgui.QFontMetricsF = object
+qtgui.QCloseEvent = object
+qtgui.QShowEvent = object
+qtgui.QHideEvent = object
+qtgui.QFocusEvent = object
+qtgui.QMoveEvent = object
+qtgui.QResizeEvent = object
+qtgui.QWheelEvent = object
+qtgui.QContextMenuEvent = object
+sys.modules["qtpy.QtGui"] = qtgui
+
+qtwidgets = types.ModuleType("qtpy.QtWidgets")
+for _name in ['QWidget', 'QHBoxLayout', 'QVBoxLayout', 'QGridLayout', 'QLabel', 'QLineEdit', 'QPlainTextEdit', 'QCheckBox', 'QComboBox', 'QPushButton', 'QSizePolicy', 'QMessageBox', 'QFileDialog', 'QDialog', 'QScrollArea', 'QApplication', 'QAbstractScrollArea', 'QGraphicsItem', 'QGraphicsSceneHoverEvent', 'QGraphicsTextItem', 'QStyleOptionGraphicsItem', 'QStyle', 'QGraphicsSceneMouseEvent', 'QFrame', 'QSlider', 'QGroupBox', 'QSpinBox', 'QDoubleSpinBox', 'QTextEdit', 'QStackedWidget', 'QGraphicsDropShadowEffect', 'QInputDialog', 'QGraphicsItemGroup', 'QGraphicsProxyWidget', 'QGraphicsObject', 'QGraphicsOpacityEffect', 'QGraphicsBlurEffect', 'QGraphicsColorizeEffect', 'QSpacerItem', 'QToolButton', 'QMenu', 'QAction', 'QActionGroup', 'QTreeView', 'QSplitter', 'QKeySequenceEdit', 'QTabWidget', 'QTabBar', 'QProgressBar', 'QRadioButton', 'QButtonGroup', 'QListView', 'QTableView', 'QHeaderView', 'QAbstractItemView', 'QItemSelectionModel', 'QStyledItemDelegate', 'QStyleOptionViewItem', 'QStyleOptionComboBox', 'QStyleOptionProgressBar', 'QStyleOptionButton', 'QLayout', 'QWidgetItem', 'QLayoutItem', 'QColorDialog', 'QStyleOptionSlider', 'QShortcut', 'QCompleter', 'QSystemTrayIcon']:
+    if _name == 'QMessageBox':
+        setattr(qtwidgets, _name, _MockMsgBox)
+    else:
+        setattr(qtwidgets, _name, _MockWidget)
+sys.modules["qtpy.QtWidgets"] = qtwidgets
+
+from ui.module_parse_widgets import ParamWidget
+
+
+def test_unknown_param_type_falls_back_to_line_editor():
+    """A param dict with an unrecognised 'type' should not crash; it should fall back to a line editor."""
+    params = {
+        'weird_param': {
+            'type': 'unknown_future_type',
+            'value': 'fallback_test',
+            'description': 'A param with a type the UI does not yet know about.'
+        }
+    }
+    # Should not raise ValueError anymore (fix #904)
+    w = ParamWidget(params)
+    assert w is not None
+
+
+def test_selector_with_missing_options_falls_back():
+    """A selector param whose 'options' list is missing should not crash."""
+    params = {
+        'model path': {
+            'type': 'selector',
+            # Deliberately no 'options' key to simulate fresh install with empty CKPT_LIST
+            'value': 'data/models/default.pt',
+            'display_name': 'Model path'
+        }
+    }
+    w = ParamWidget(params)
+    assert w is not None

--- a/tests/test_size_combobox_cap.py
+++ b/tests/test_size_combobox_cap.py
@@ -1,0 +1,219 @@
+"""Tests for SizeComboBox.value() clamping fix (#920)."""
+import sys
+import types
+import os.path as osp
+
+# Add project root so ui.* imports resolve
+sys.path.insert(0, osp.dirname(osp.dirname(osp.abspath(__file__))))
+
+# Stub Qt before importing ui modules
+qtcore = types.ModuleType("qtpy.QtCore")
+class _MockQt:
+    class Orientation:
+        Horizontal = 1
+        Vertical = 2
+    class AlignmentFlag:
+        AlignCenter = 1
+    class PenStyle:
+        SolidLine = 1
+    class GlobalColor:
+        transparent = 1
+        black = 2
+        white = 3
+    class CompositionMode:
+        CompositionMode_SourceOver = 1
+    class RenderHint:
+        SmoothPixmapTransform = 1
+qtcore.Qt = _MockQt
+qtcore.Signal = lambda *a, **k: None
+class _MockQObject:
+    def __init__(self, *a, **k): pass
+qtcore.QObject = _MockQObject
+qtcore.QEvent = object
+qtcore.QPoint = object
+qtcore.QPointF = object
+qtcore.QSize = object
+qtcore.QSizeF = object
+qtcore.QRect = object
+qtcore.QRectF = object
+qtcore.QMimeData = object
+qtcore.QTimer = object
+qtcore.QPropertyAnimation = object
+qtcore.QAbstractAnimation = object
+class _MockEasingCurve:
+    Linear = 0
+    InOutCubic = 1
+qtcore.QEasingCurve = _MockEasingCurve
+qtcore.QParallelAnimationGroup = object
+qtcore.QModelIndex = object
+class _MockVariantAnimation:
+    def __init__(self, *a, **k): pass
+    def setDuration(self, v): pass
+    def setStartValue(self, v): pass
+    def setEndValue(self, v): pass
+qtcore.QVariantAnimation = _MockVariantAnimation
+qtcore.QAbstractItemModel = object
+qtcore.QItemSelection = object
+qtcore.QThread = object
+class _MockProperty:
+    def __init__(self, *a, **k):
+        pass
+    def setter(self, fn):
+        return fn
+    def __call__(self, fn):
+        return self
+qtcore.Property = _MockProperty
+sys.modules["qtpy.QtCore"] = qtcore
+
+class _MockNotation:
+    StandardNotation = 0
+class _MockDoubleValidator:
+    Notation = _MockNotation
+    def setTop(self, v): pass
+    def setBottom(self, v): pass
+    def setNotation(self, n): pass
+
+qtgui = types.ModuleType("qtpy.QtGui")
+qtgui.QDoubleValidator = _MockDoubleValidator
+qtgui.QFont = object
+qtgui.QColor = object
+qtgui.QPen = object
+qtgui.QBrush = object
+qtgui.QPalette = object
+qtgui.QPixmap = object
+qtgui.QImage = object
+qtgui.QKeyEvent = object
+qtgui.QMouseEvent = object
+qtgui.QCursor = object
+qtgui.QKeySequence = object
+qtgui.QTextCursor = object
+qtgui.QTextCharFormat = object
+qtgui.QTextDocument = object
+qtgui.QAbstractTextDocumentLayout = object
+qtgui.QTextFrameFormat = object
+qtgui.QGradient = object
+qtgui.QLinearGradient = object
+qtgui.QRadialGradient = object
+qtgui.QTransform = object
+qtgui.QPolygonF = object
+qtgui.QBitmap = object
+qtgui.QRegion = object
+qtgui.QPainterPath = object
+qtgui.QPainter = object
+qtgui.QInputMethodEvent = object
+qtgui.QDragEnterEvent = object
+qtgui.QDropEvent = object
+qtgui.QDrag = object
+qtgui.QIcon = object
+qtgui.QFontMetrics = object
+qtgui.QFontMetricsF = object
+qtgui.QCloseEvent = object
+qtgui.QShowEvent = object
+qtgui.QHideEvent = object
+qtgui.QFocusEvent = object
+qtgui.QMoveEvent = object
+qtgui.QResizeEvent = object
+qtgui.QWheelEvent = object
+qtgui.QContextMenuEvent = object
+sys.modules["qtpy.QtGui"] = qtgui
+
+qtwidgets = types.ModuleType("qtpy.QtWidgets")
+
+class MockLayout:
+    def __init__(self, *a, **k):
+        pass
+    def addWidget(self, *a, **k):
+        pass
+    def addLayout(self, *a, **k):
+        pass
+    def addStretch(self, *a, **k):
+        pass
+    def setSpacing(self, *a, **k):
+        pass
+    def setContentsMargins(self, *a, **k):
+        pass
+
+class MockSignal:
+    def connect(self, *a, **k):
+        pass
+    def emit(self, *a, **k):
+        pass
+    def disconnect(self, *a, **k):
+        pass
+
+class MockComboBox:
+    def __init__(self, *a, **k):
+        self._items = []
+        self._current_text = ""
+        self._validator = None
+        self._editable = False
+        self.editTextChanged = MockSignal()
+        self.activated = MockSignal()
+        self.currentTextChanged = MockSignal()
+    def addItems(self, items):
+        self._items.extend(items)
+    def setValidator(self, v):
+        self._validator = v
+    def setEditable(self, e):
+        self._editable = e
+    def currentText(self):
+        return self._current_text
+    def setCurrentText(self, t):
+        self._current_text = t
+    def hasFocus(self):
+        return False
+    def view(self):
+        return self
+    def isVisible(self):
+        return False
+    def setMinimumWidth(self, *a):
+        pass
+
+class _MockMsgBox(object):
+    class StandardButton:
+        Ok = 1
+        Yes = 2
+        No = 4
+        Cancel = 8
+_EXTRA_WIDGETS = ['QVBoxLayout', 'QHBoxLayout', 'QGridLayout', 'QFrame', 'QLabel', 'QPushButton', 'QLineEdit', 'QPlainTextEdit', 'QCheckBox', 'QSizePolicy', 'QApplication', 'QGraphicsItem', 'QGraphicsSceneHoverEvent', 'QGraphicsTextItem', 'QStyleOptionGraphicsItem', 'QStyle', 'QGraphicsSceneMouseEvent', 'QWidget', 'QMessageBox', 'QFileDialog', 'QDialog', 'QFontComboBox', 'QSlider', 'QGroupBox', 'QSpinBox', 'QDoubleSpinBox', 'QComboBox', 'QTextEdit', 'QScrollArea', 'QStackedWidget', 'QGraphicsDropShadowEffect', 'QInputDialog', 'QGraphicsItemGroup', 'QAbstractScrollArea', 'QGraphicsProxyWidget', 'QGraphicsObject', 'QGraphicsOpacityEffect', 'QGraphicsBlurEffect', 'QGraphicsColorizeEffect', 'QSpacerItem', 'QToolButton', 'QMenu', 'QAction', 'QActionGroup', 'QTreeView', 'QSplitter', 'QKeySequenceEdit', 'QTabWidget', 'QTabBar', 'QProgressBar', 'QRadioButton', 'QButtonGroup', 'QListView', 'QTableView', 'QHeaderView', 'QAbstractItemView', 'QItemSelectionModel', 'QStyledItemDelegate', 'QStyleOptionViewItem', 'QStyleOptionComboBox', 'QStyleOptionProgressBar', 'QStyleOptionButton', 'QLayout', 'QWidgetItem', 'QLayoutItem', 'QColorDialog', 'QStyleOptionSlider', 'QShortcut', 'QCompleter', 'QSystemTrayIcon']
+for _name in _EXTRA_WIDGETS:
+    if _name == 'QMessageBox':
+        setattr(qtwidgets, _name, _MockMsgBox)
+    else:
+        setattr(qtwidgets, _name, MockLayout if 'Layout' in _name else object)
+
+qtwidgets.QComboBox = MockComboBox
+sys.modules["qtpy.QtWidgets"] = qtwidgets
+
+from ui.custom_widget.combobox import SizeComboBox
+
+
+def test_value_clamps_to_max():
+    box = SizeComboBox([1, 300], 'font_size')
+    box.setCurrentText("99999")
+    assert box.value() == 300, f"Expected 300, got {box.value()}"
+
+
+def test_value_clamps_to_min():
+    box = SizeComboBox([10, 300], 'font_size')
+    box.setCurrentText("-50")
+    assert box.value() == 10, f"Expected 10, got {box.value()}"
+
+
+def test_value_within_range_passes_through():
+    box = SizeComboBox([1, 300], 'font_size')
+    box.setCurrentText("42")
+    assert box.value() == 42, f"Expected 42, got {box.value()}"
+
+
+def test_setvalue_clamps():
+    box = SizeComboBox([1, 300], 'font_size')
+    box.setValue(500)
+    assert box.value() == 300, f"Expected 300 after setValue(500), got {box.value()}"
+
+
+def test_change_by_delta_respects_max():
+    box = SizeComboBox([1, 300], 'font_size')
+    box.setValue(250)
+    box.changeByDelta(100, multiplier=1.0)
+    assert box.value() == 300, f"Expected 300, got {box.value()}"

--- a/ui/canvas.py
+++ b/ui/canvas.py
@@ -562,8 +562,8 @@ class Canvas(QGraphicsScene):
         if view_mode == "debug":
             # Debug: show base image + mask overlay (boxes/masks) for QA
             if self.imgtrans_proj.mask_valid:
-                painter.setOpacity(0.5)
-                painter.drawPixmap(origin, ndarray2pixmap(self.imgtrans_proj.mask_array))
+                mask_rgba = self._build_mask_overlay(self.imgtrans_proj.mask_array, 0.5)
+                painter.drawPixmap(origin, ndarray2pixmap(mask_rgba))
             painter.end()
             self.inpaintLayer.setPixmap(pixmap)
             return
@@ -577,11 +577,31 @@ class Canvas(QGraphicsScene):
                 painter.drawPixmap(origin, pixmap)
 
         if self.imgtrans_proj.mask_valid and pcfg.mask_transparency > 0 and not self.textEditMode():
-            painter.setOpacity(pcfg.mask_transparency)
-            painter.drawPixmap(origin, ndarray2pixmap(self.imgtrans_proj.mask_array))
+            # Build RGBA overlay so per-pixel alpha is preserved (#1117).
+            # Gray mask values become alpha; magenta tint makes it visible on any bg.
+            mask_rgba = self._build_mask_overlay(self.imgtrans_proj.mask_array, pcfg.mask_transparency)
+            painter.drawPixmap(origin, ndarray2pixmap(mask_rgba))
 
         painter.end()
         self.inpaintLayer.setPixmap(pixmap)
+
+    @staticmethod
+    def _build_mask_overlay(mask: np.ndarray, transparency: float) -> np.ndarray:
+        """Convert grayscale mask to RGBA with per-pixel alpha (#1117).
+
+        Each mask pixel value (0-255) is multiplied by *transparency* to become the
+        alpha channel.  A magenta tint makes the mask visible against any background.
+        """
+        h, w = mask.shape[:2]
+        rgba = np.zeros((h, w, 4), dtype=np.uint8)
+        # Magenta tint for visibility: R=200, G=0, B=200
+        rgba[:, :, 0] = 200
+        rgba[:, :, 2] = 200
+        # Alpha = mask_intensity * transparency, clamped to 0-255
+        alpha = mask.astype(np.float32) * transparency
+        np.clip(alpha, 0, 255, out=alpha)
+        rgba[:, :, 3] = alpha.astype(np.uint8)
+        return rgba
 
     def setMaskTransparency(self, transparency: float):
         pcfg.mask_transparency = transparency

--- a/ui/custom_widget/combobox.py
+++ b/ui/custom_widget/combobox.py
@@ -118,10 +118,11 @@ class SizeComboBox(QComboBox):
         txt = self.currentText()
         try:
             val = float(txt)
+            val = min(self.max_val, max(self.min_val, val))
             self._value = val
             return val
         except:
-            return self._value
+            return min(self.max_val, max(self.min_val, self._value))
 
     def setValue(self, value: float):
         value = min(self.max_val, max(self.min_val, value))

--- a/ui/module_manager.py
+++ b/ui/module_manager.py
@@ -788,9 +788,11 @@ class ImgtransThread(QThread):
                     inpaint_mask_array, ballon_mask, bub_dict = maskseg_method(
                         im, mask=tgt_mask[y1: y2, x1: x2], **cleaning_kwargs
                     )
-                    # Dilate mask slightly so original text (e.g. Chinese) is fully covered and erased
+                    # Dilate mask slightly so original text (e.g. Chinese) is fully covered and erased.
+                    # Using a 7x7 kernel instead of 5x5 because tight detectors (e.g. YSGYOLO) can leave
+                    # anti-aliased text edges un-masked, which then remain visible after inpaint (#935).
                     if inpaint_mask_array is not None and inpaint_mask_array.size > 0:
-                        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (5, 5))
+                        kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (7, 7))
                         inpaint_mask_array = cv2.dilate(
                             (inpaint_mask_array > 127).astype(np.uint8) * 255, kernel, iterations=1
                         )

--- a/ui/module_parse_widgets.py
+++ b/ui/module_parse_widgets.py
@@ -188,7 +188,7 @@ class ParamWidget(QWidget):
                     else:
                         size = size2width(param_size)
 
-                    options_list = list(param_dict['options'])
+                    options_list = list(param_dict.get('options', []))
                     if param_key == 'device':
                         default_label = self.tr('Default')
                         if default_label not in options_list:
@@ -237,6 +237,13 @@ class ParamWidget(QWidget):
                     param_widget.paramwidget_edited.connect(self.on_paramwidget_edited)
                     if 'description' in param_dict:
                         param_widget.setToolTip(param_dict['description'])
+
+                # Fix #904: fallback for unknown/malformed param types so a missing option
+                # list or unrecognised param_type doesn't crash the module config UI.
+                if param_widget is None:
+                    param_widget = ParamLineEditor(param_key, force_digital=is_digital)
+                    param_widget.setText(str(value))
+                    param_widget.paramwidget_edited.connect(self.on_paramwidget_edited)
 
             widget_idx = 0
             if require_label:

--- a/ui/text_panel.py
+++ b/ui/text_panel.py
@@ -205,7 +205,7 @@ class FontSizeBox(QFrame):
         self.downBtn.setObjectName("FsizeIncrementDown")
         self.upBtn.clicked.connect(self.onUpBtnClicked)
         self.downBtn.clicked.connect(self.onDownBtnClicked)
-        self.fcombobox = SizeComboBox([1, 1000], 'font_size', self)
+        self.fcombobox = SizeComboBox([1, 300], 'font_size', self)
         self.fcombobox.addItems([
             "5", "5.5", "6", "6.5", "7", "7.5", "8", "9", "10", "10.5",
             "11", "12", "14", "16", "18", "20", "22", "24", "26", "28",
@@ -238,7 +238,7 @@ class FontSizeBox(QFrame):
         newsize = int(round(size * raito))
         if newsize == size:
             newsize += 1
-        newsize = min(1000, newsize)
+        newsize = min(300, newsize)
         if newsize != size:
             if not multi_size:
                 self.param_changed.emit('font_size', newsize)


### PR DESCRIPTION
## Summary
- What changed?
- Why is this needed?

## Required Checks

### README parity (EN + ZH)
- [ ] I reviewed [`README.md`](../README.md) and [`README_zh_CN.md`](../README_zh_CN.md) and confirmed they are in parity for any user-facing changes in this PR.
- [ ] If one README was updated without the other, I explained why.

### Startup script verification
- [ ] Verified startup behavior and entry points as applicable:
  - [ ] [`launch.py`](../launch.py)
  - [ ] [`launch_win.bat`](../launch_win.bat)
  - [ ] [`launch_win_with_autoupdate.bat`](../launch_win_with_autoupdate.bat)
  - [ ] [`launch_win_amd_nightly.bat`](../launch_win_amd_nightly.bat)
- [ ] Included a brief verification result for each script touched by this PR.

### First-run model-picker verification
- [ ] Verified first-run model package selection flow end-to-end where applicable:
  - [ ] [`utils/model_packages.py`](../utils/model_packages.py)
  - [ ] [`ui/model_package_selector_dialog.py`](../ui/model_package_selector_dialog.py)
- [ ] Confirmed behavior for first launch, model package listing, selection, and persistence.
- [ ] Included before/after screenshots for any UI change to the first-run model dialog.

## UX / Behavior Validation
- [ ] For UX-facing changes, I documented a clear **manual verification path** (steps + expected result).
- [ ] If defaults changed, I explained the **migration impact** for existing users/configurations.

## Risks / Compatibility
- Potential regressions:
- Rollback notes (if needed):

## Additional Notes
- Environment limitations (if any):
