### PR TITLE
chore: port low-risk upstream PR fixes (#1163, #1130, #1152, #1027)

### DIFF
--- a/modules/textdetector/yolov5/yolo.py
+++ b/modules/textdetector/yolov5/yolo.py
@@ -73,13 +73,22 @@ class Detect(nn.Module):
 
     def _make_grid(self, nx=20, ny=20, i=0):
         d = self.anchors[i].device
-        if package_version_parse(torch.__version__) >= package_version_parse('1.10.0'):  # torch>=1.10.0 meshgrid workaround for torch>=0.7 compatibility
-            yv, xv = torch.meshgrid([torch.arange(ny, device=d), torch.arange(nx, device=d)], indexing='ij')
-        else:
-            yv, xv = torch.meshgrid([torch.arange(ny, device=d), torch.arange(nx, device=d)])
-        grid = torch.stack((xv, yv), 2).expand((1, self.na, ny, nx, 2)).float()
-        anchor_grid = (self.anchors[i].clone() * self.stride[i]) \
-            .view((1, self.na, 1, 1, 2)).expand((1, self.na, ny, nx, 2)).float()
+        if d.type == 'xpu':  # XPU: compute on CPU then move to device
+            if package_version_parse(torch.__version__) >= package_version_parse('1.10.0'):
+                yv, xv = torch.meshgrid([torch.arange(ny), torch.arange(nx)], indexing='ij')
+            else:
+                yv, xv = torch.meshgrid([torch.arange(ny), torch.arange(nx)])
+            grid = torch.stack((xv, yv), 2).expand((1, self.na, ny, nx, 2)).float().to(d)
+            anchor_grid = (self.anchors[i].clone().to('cpu') * self.stride[i].to('cpu')) \
+                .view((1, self.na, 1, 1, 2)).expand((1, self.na, ny, nx, 2)).float().to(d)
+        else:  # CUDA/CPU: compute directly on device
+            if package_version_parse(torch.__version__) >= package_version_parse('1.10.0'):
+                yv, xv = torch.meshgrid([torch.arange(ny, device=d), torch.arange(nx, device=d)], indexing='ij')
+            else:
+                yv, xv = torch.meshgrid([torch.arange(ny, device=d), torch.arange(nx, device=d)])
+            grid = torch.stack((xv, yv), 2).expand((1, self.na, ny, nx, 2)).float()
+            anchor_grid = (self.anchors[i].clone() * self.stride[i]) \
+                .view((1, self.na, 1, 1, 2)).expand((1, self.na, ny, nx, 2)).float()
         return grid, anchor_grid
 
 class Model(nn.Module):

--- a/modules/textdetector/yolov5/yolov5_utils.py
+++ b/modules/textdetector/yolov5/yolov5_utils.py
@@ -167,10 +167,12 @@ def non_max_suppression(prediction, conf_thres=0.25, iou_thres=0.45, classes=Non
         # Detections matrix nx6 (xyxy, conf, cls)
         if multi_label:
             i, j = (x[:, 5:] > conf_thres).nonzero(as_tuple=False).T
-            x = torch.cat((box[i], x[i, j + 5, None], j[:, None].float()), 1)
+            j_float = j.to('cpu').float().to(x.device) if x.device.type == 'xpu' else j.float()
+            x = torch.cat((box[i], x[i, j + 5, None], j_float[:, None]), 1)
         else:  # best class only
             conf, j = x[:, 5:].max(1, keepdim=True)
-            x = torch.cat((box, conf, j.float()), 1)[conf.view(-1) > conf_thres]
+            j_float = j.to('cpu').float().to(x.device) if x.device.type == 'xpu' else j.float()
+            x = torch.cat((box, conf, j_float), 1)[conf.view(-1) > conf_thres]
 
         # Filter by class
         if classes is not None:

--- a/tests/test_upstream_pr_port.py
+++ b/tests/test_upstream_pr_port.py
@@ -1,0 +1,55 @@
+"""Regression tests for upstream PR ports (source-level assertions)."""
+
+# --- Test #1163: bare except fix ---
+def test_shared_bare_except():
+    with open("utils/shared.py", "r", encoding="utf8") as f:
+        source = f.read()
+    # The specific cache-loading block should use 'except Exception:'
+    assert "except Exception:\n                print(f'cached file" in source
+
+
+# --- Test #1130: blk.xyxy updated in setRect ---
+def test_textitem_setRect_updates_xyxy():
+    with open("ui/textitem.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "def _xywh_to_xyxy(r):" in source
+    assert "self.blk.xyxy = _xywh_to_xyxy(rect)" in source
+
+
+# --- Test #1152: MergeBlkItemsCommand exists ---
+def test_merge_blk_items_command_exists():
+    with open("ui/textedit_commands.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "class MergeBlkItemsCommand(QUndoCommand):" in source
+    assert "self.ctrl.deleteTextblkItemList(self.secondary_list" in source
+    assert "self.ctrl.recoverTextblkItemList(self.secondary_list" in source
+
+
+# --- Test #1027: XPU patches structure ---
+def test_yolo_make_grid_xpu_guard():
+    with open("modules/textdetector/yolov5/yolo.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "d.type == 'xpu'" in source
+    assert "torch.meshgrid([torch.arange(ny), torch.arange(nx)]" in source
+
+
+def test_yolov5_utils_nms_xpu_guard():
+    with open("modules/textdetector/yolov5/yolov5_utils.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "x.device.type == 'xpu'" in source
+    assert "j.to('cpu').float().to(x.device)" in source
+
+
+# --- Test label color dialog initial value ---
+def test_label_color_dialog_initial():
+    with open("ui/custom_widget/label.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "QColorDialog.getColor(initial_color)" in source
+    assert "initial_color = self.color if self.color is not None else QColor(255, 255, 255)" in source
+
+
+# --- Test mainwindow uses undo command for merge ---
+def test_mainwindow_merge_uses_command():
+    with open("ui/mainwindow.py", "r", encoding="utf8") as f:
+        source = f.read()
+    assert "MergeBlkItemsCommand(blks, self.st_manager)" in source

--- a/ui/custom_widget/label.py
+++ b/ui/custom_widget/label.py
@@ -54,7 +54,8 @@ class ColorPickerLabel(QLabel):
         btn = event.button()
         if btn == Qt.MouseButton.LeftButton:
             self.changingColor.emit()
-            color = QColorDialog.getColor()
+            initial_color = self.color if self.color is not None else QColor(255, 255, 255)
+            color = QColorDialog.getColor(initial_color)
             is_valid = color.isValid()
             if is_valid:
                 self.setPickerColor(color)

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -52,7 +52,7 @@ from .mainwindowbars import TitleBar, LeftBar, BottomBar
 from .io_thread import ImgSaveThread, ImportDocThread, ExportDocThread, GitUpdateThread, ModelDownloadThread
 from .custom_widget import Widget, ViewWidget
 from .global_search_widget import GlobalSearchWidget
-from .textedit_commands import GlobalRepalceAllCommand, ApplyTranslationCandidateCommand
+from .textedit_commands import GlobalRepalceAllCommand, ApplyTranslationCandidateCommand, MergeBlkItemsCommand
 from .framelesswindow import FramelessWindow, FramelessMoveResize
 from .drawing_commands import RunBlkTransCommand
 from .keywordsubwidget import KeywordSubWidget
@@ -8570,25 +8570,7 @@ class MainWindow(mainwindow_cls):
         blks = self.canvas.selected_text_items()
         if len(blks) < 2:
             return
-        blks = sorted(blks, key=lambda b: b.idx)
-        first = blks[0]
-        page_name = self.imgtrans_proj.current_img
-        if not page_name:
-            return
-        src_parts = [self.st_manager.pairwidget_list[b.idx].e_source.toPlainText() for b in blks]
-        trans_parts = [self.st_manager.pairwidget_list[b.idx].e_trans.toPlainText() for b in blks]
-        first.blk.text = ['\n'.join(src_parts)]
-        first.blk.translation = '\n'.join(trans_parts)
-        self.st_manager.pairwidget_list[first.idx].e_source.setPlainText('\n'.join(src_parts))
-        self.st_manager.pairwidget_list[first.idx].e_trans.setPlainText('\n'.join(trans_parts))
-        indices_to_remove = sorted([b.idx for b in blks[1:]], reverse=True)
-        for i in indices_to_remove:
-            self.imgtrans_proj.pages[page_name].pop(i)
-        to_remove_items = blks[1:]
-        to_remove_widgets = [self.st_manager.pairwidget_list[b.idx] for b in blks[1:]]
-        self.st_manager.deleteTextblkItemList(to_remove_items, to_remove_widgets)
-        self.canvas.setProjSaveState(False)
-        self.global_search_widget.set_document_edited()
+        self.canvas.push_undo_command(MergeBlkItemsCommand(blks, self.st_manager))
 
     def on_split_selected_regions(self):
         """Try to split each selected region into multiple regions using image gaps (e.g. two bubbles in one box)."""

--- a/ui/textedit_commands.py
+++ b/ui/textedit_commands.py
@@ -1,14 +1,14 @@
 from typing import List, Union, Tuple, Optional, Callable
 
 from qtpy.QtGui import QTextCursor
-from qtpy.QtCore import QPointF
+from qtpy.QtCore import QPointF, QRectF
 try:
     from qtpy.QtWidgets import QUndoCommand
 except:
     from qtpy.QtGui import QUndoCommand
 
 from .textitem import TextBlkItem, TextBlock
-from .textedit_area import TransTextEdit, SourceTextEdit
+from .textedit_area import TransTextEdit, SourceTextEdit, TransPairWidget
 from utils.fontformat import FontFormat
 import utils.config as C
 from .misc import doc_replace, doc_replace_no_shift
@@ -584,3 +584,55 @@ class MultiPasteCommand(QUndoCommand):
         for blkitem, etran in zip(self.blkitems, self.etrans):
             blkitem.undo()
             etran.undo()
+
+
+class MergeBlkItemsCommand(QUndoCommand):
+    """Merge multiple selected TextBlkItems into one, combining their bounding rects and text."""
+    def __init__(self, blk_list: List[TextBlkItem], ctrl, parent=None):
+        super().__init__(parent)
+        self.ctrl = ctrl
+        blk_list = sorted(blk_list, key=lambda b: b.idx)
+        self.blk_list = blk_list
+        self.pwidget_list: List[TransPairWidget] = [ctrl.pairwidget_list[b.idx] for b in blk_list]
+
+        self.old_rects = [b.absBoundingRect(qrect=True) for b in blk_list]
+        self.old_trans_texts = [pw.e_trans.toPlainText() for pw in self.pwidget_list]
+        self.old_src_texts = [pw.e_source.toPlainText() for pw in self.pwidget_list]
+        self.old_html_list = [b.toHtml() for b in blk_list]
+
+        union = QRectF()
+        for b in blk_list:
+            union = union.united(b.absBoundingRect(qrect=True))
+        self.merged_rect = union
+
+        self.merged_src = '\n'.join(t for t in self.old_src_texts if t.strip())
+        self.merged_trans = '\n'.join(t for t in self.old_trans_texts if t.strip())
+
+        self.primary = blk_list[0]
+        self.primary_pwidget = self.pwidget_list[0]
+        self.secondary_list = blk_list[1:]
+        self.secondary_pwidget_list = self.pwidget_list[1:]
+
+        self.op_counter = 0
+
+    def redo(self):
+        if self.op_counter == 0:
+            self.op_counter += 1
+        self.primary.setRect(self.merged_rect)
+        self.primary_pwidget.e_source.setPlainText(self.merged_src)
+        self.primary_pwidget.e_trans.setPlainText(self.merged_trans)
+        self.primary.setPlainText(self.merged_trans)
+        if self.secondary_list:
+            self.ctrl.deleteTextblkItemList(self.secondary_list, self.secondary_pwidget_list)
+
+    def undo(self):
+        if self.secondary_list:
+            self.ctrl.recoverTextblkItemList(self.secondary_list, self.secondary_pwidget_list)
+        for b, pw, rect, html, src_text, trans_text in zip(
+                self.blk_list, self.pwidget_list,
+                self.old_rects, self.old_html_list,
+                self.old_src_texts, self.old_trans_texts):
+            b.setRect(rect)
+            b.setHtml(html)
+            pw.e_source.setPlainText(src_text)
+            pw.e_trans.setPlainText(trans_text)

--- a/ui/textitem.py
+++ b/ui/textitem.py
@@ -586,7 +586,14 @@ class TextBlkItem(QGraphicsTextItem):
         return path
 
     def setRect(self, rect: Union[List, QRectF], padding=True, repaint=True) -> None:
-        
+
+        def _xywh_to_xyxy(r):
+            if isinstance(r, QRectF):
+                x, y, w, h = r.x(), r.y(), r.width(), r.height()
+            else:
+                x, y, w, h = r[0], r[1], r[2], r[3]
+            return [x, y, x + w, y + h]
+
         if isinstance(rect, List):
             rect = QRectF(*rect)
         if padding:
@@ -596,6 +603,7 @@ class TextBlkItem(QGraphicsTextItem):
         self._display_rect = rect
         self.layout.setMaxSize(rect.width(), rect.height())
         self.setCenterTransform()
+        self.blk.xyxy = _xywh_to_xyxy(rect)
         if repaint:
             self.repaint_background()
 

--- a/utils/shared.py
+++ b/utils/shared.py
@@ -185,7 +185,7 @@ def load_cache():
             try:
                 with open(cache_path, "r", encoding="utf8") as file:
                     cache_data = json.load(file)
-            except:
+            except Exception:
                 print(f'cached file {cache_path} is invalid')
                 cache_data = {}
         else:


### PR DESCRIPTION
- #1163: Replace bare except: with except Exception: in utils/shared.py to avoid catching SystemExit/KeyboardInterrupt.

- #1130: Update lk.xyxy in ui/textitem.py setRect() after manual bounding-box edits so OCR uses correct coordinates.

- #1152: Add MergeBlkItemsCommand to ui/textedit_commands.py for undoable merge of multiple selected text blocks. Replaced direct mutation in mainwindow with push_undo_command().

- #1027: Intel XPU (IPEX-LLM) compatibility patches in YOLOv5:
  * _make_grid computes meshgrid/anchors on CPU then moves to XPU. * on_max_suppression bypasses .float() via CPU for XPU device.
  Also port the label color-dialog initial-color fix.

Includes regression tests in tests/test_upstream_pr_port.py.

## Summary
- What changed?
- Why is this needed?

## Required Checks

### README parity (EN + ZH)
- [ ] I reviewed [`README.md`](../README.md) and [`README_zh_CN.md`](../README_zh_CN.md) and confirmed they are in parity for any user-facing changes in this PR.
- [ ] If one README was updated without the other, I explained why.

### Startup script verification
- [ ] Verified startup behavior and entry points as applicable:
  - [ ] [`launch.py`](../launch.py)
  - [ ] [`launch_win.bat`](../launch_win.bat)
  - [ ] [`launch_win_with_autoupdate.bat`](../launch_win_with_autoupdate.bat)
  - [ ] [`launch_win_amd_nightly.bat`](../launch_win_amd_nightly.bat)
- [ ] Included a brief verification result for each script touched by this PR.

### First-run model-picker verification
- [ ] Verified first-run model package selection flow end-to-end where applicable:
  - [ ] [`utils/model_packages.py`](../utils/model_packages.py)
  - [ ] [`ui/model_package_selector_dialog.py`](../ui/model_package_selector_dialog.py)
- [ ] Confirmed behavior for first launch, model package listing, selection, and persistence.
- [ ] Included before/after screenshots for any UI change to the first-run model dialog.

## UX / Behavior Validation
- [ ] For UX-facing changes, I documented a clear **manual verification path** (steps + expected result).
- [ ] If defaults changed, I explained the **migration impact** for existing users/configurations.

## Risks / Compatibility
- Potential regressions:
- Rollback notes (if needed):

## Additional Notes
- Environment limitations (if any):
